### PR TITLE
feat: Battle Monsters 3-card booster pack claim on Base Sepolia

### DIFF
--- a/packages/app/src/constants/boosterpacks.ts
+++ b/packages/app/src/constants/boosterpacks.ts
@@ -1,0 +1,17 @@
+export interface OnchainBoosterpackConfig {
+  chainId: number;
+  faucetAddress: string;
+  packId: number;
+  cardIds: number[];
+}
+
+// Base Sepolia testnet deployment
+// Factory:  0xaE0B8933FcDA800e5C561B5585De7130Faff02d5
+// Booster:  0x0D10D51Aa601113eb5C0b5c52FA9E590CC43Cc80
+// Faucet:   0x353490205cBe9fB473443619C95779Bde640e76C
+export const BATTLE_MONSTERS_3_CARD_BASE_SEPOLIA: OnchainBoosterpackConfig = {
+  chainId: 84532,
+  faucetAddress: "0x353490205cBe9fB473443619C95779Bde640e76C",
+  packId: 2,
+  cardIds: [1, 2, 3],
+};

--- a/packages/app/src/constants/boosterpacks.ts
+++ b/packages/app/src/constants/boosterpacks.ts
@@ -1,6 +1,7 @@
 export interface OnchainBoosterpackConfig {
   chainId: number;
   faucetAddress: string;
+  factoryAddress: string;
   packId: number;
   cardIds: number[];
 }
@@ -12,6 +13,7 @@ export interface OnchainBoosterpackConfig {
 export const BATTLE_MONSTERS_3_CARD_BASE_SEPOLIA: OnchainBoosterpackConfig = {
   chainId: 84532,
   faucetAddress: "0x353490205cBe9fB473443619C95779Bde640e76C",
+  factoryAddress: "0xaE0B8933FcDA800e5C561B5585De7130Faff02d5",
   packId: 2,
   cardIds: [1, 2, 3],
 };

--- a/packages/app/src/constants/chains.ts
+++ b/packages/app/src/constants/chains.ts
@@ -126,6 +126,19 @@ const chains: ChainsProps[] = [
   // 	blockExplorerUrls: ['https://polygonscan.com/'],
   // 	blockExplorerTitle: 'Polygonscan'
   // }
+  {
+    chainId: "0x14a34", // = 84532
+    name: "BASE_SEPOLIA",
+    chainName: "Base Sepolia",
+    nativeCurrency: {
+      name: "Ether",
+      symbol: "ETH",
+      decimals: 18,
+    },
+    rpcUrls: ["https://sepolia.base.org"],
+    blockExplorerUrls: ["https://sepolia.basescan.org"],
+    blockExplorerTitle: "Basescan (Sepolia)",
+  },
 ];
 
 export default chains;

--- a/packages/app/src/constants/packs.ts
+++ b/packages/app/src/constants/packs.ts
@@ -1,10 +1,11 @@
 import { Boosterpack_3_cards_Battle_Monsters, Boosterpack_3_cards_Battle_Support, Boosterpack_3_cards_Gen_1, Boosterpack_6_cards_Battle_Monsters, Boosterpack_6_cards_Battle_Support, Boosterpack_6_cards_Gen_1, Boosterpack_9_cards_Battle_Monsters, Boosterpack_9_cards_Battle_Support, Boosterpack_9_cards_Gen_1 } from '../assets';
+import { BATTLE_MONSTERS_3_CARD_BASE_SEPOLIA } from './boosterpacks';
 
 const BATTLE_MONSTERS_EDITION = {
 	title: 'Battle Monsters edition',
 	title_formatted: 'BATTLE_MONSTERS_EDITION',
 	packs: [
-		{ name: "Battle Monsters edition - 3 cards", cardsPerPack: 3, url: Boosterpack_3_cards_Battle_Monsters, minted: "10/20", time: "20 hours", price: "75" },
+		{ name: "Battle Monsters edition - 3 cards", cardsPerPack: 3, url: Boosterpack_3_cards_Battle_Monsters, minted: "10/20", time: "20 hours", price: "75", onchainConfig: BATTLE_MONSTERS_3_CARD_BASE_SEPOLIA },
 		{ name: "Battle Monsters edition - 6 cards", cardsPerPack: 6, url: Boosterpack_6_cards_Battle_Monsters, minted: "10/20", time: "20 hours", price: "175" },
 		{ name: "Battle Monsters edition - 9 cards", cardsPerPack: 9, url: Boosterpack_9_cards_Battle_Monsters, minted: "10/20", time: "20 hours", price: "1000" },
 	]
@@ -35,7 +36,8 @@ const ALL_BOOSTERPACKS = new Map([
 	[1, [BATTLE_MONSTERS_EDITION, GEN_1_EDITION, BATTLE_SUPPORT_EDITION]],
 	[4, [BATTLE_MONSTERS_EDITION, GEN_1_EDITION, BATTLE_SUPPORT_EDITION]],
 	[56, [BATTLE_MONSTERS_EDITION, GEN_1_EDITION, BATTLE_SUPPORT_EDITION]],
-	[137, [BATTLE_MONSTERS_EDITION, GEN_1_EDITION, BATTLE_SUPPORT_EDITION]]
+	[137, [BATTLE_MONSTERS_EDITION, GEN_1_EDITION, BATTLE_SUPPORT_EDITION]],
+	[84532, [BATTLE_MONSTERS_EDITION]],
 ]);
 
 export default ALL_BOOSTERPACKS;

--- a/packages/app/src/contracts/src/abis/boosterPackFaucet.json
+++ b/packages/app/src/contracts/src/abis/boosterPackFaucet.json
@@ -1,0 +1,12 @@
+[
+  {
+    "type": "function",
+    "name": "claimAndReveal",
+    "inputs": [
+      { "name": "packId", "type": "uint256", "internalType": "uint256" },
+      { "name": "cardIds", "type": "uint256[]", "internalType": "uint256[]" }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  }
+]

--- a/packages/app/src/hooks/index.ts
+++ b/packages/app/src/hooks/index.ts
@@ -8,6 +8,7 @@ export { default as useCardsFactoryData, getCardFactoryData } from './useCardsFa
 export type { CardBalances } from './useCardsFactoryData';
 export { default as useCardsStorePrices, getCardStorePrices } from './useCardsStorePrices';
 export type { CardPrice } from './useCardsStorePrices';
+export { default as useClaimBoosterPack } from './useClaimBoosterPack';
 export { default as useClaimEvent } from './useClaimEvent';
 export { default as useClaimMerkle } from './useClaimMerkle';
 export type { Merkle } from './useClaimMerkle';

--- a/packages/app/src/hooks/useClaimBoosterPack.ts
+++ b/packages/app/src/hooks/useClaimBoosterPack.ts
@@ -9,7 +9,7 @@ export interface ReceivedCard {
   amount: number;
 }
 
-export type ClaimPhase = 'idle' | 'wallet-pending' | 'video-playing' | 'revealing' | 'done';
+export type ClaimPhase = 'idle' | 'wallet-pending' | 'video-playing' | 'revealing';
 
 const TRANSFER_SINGLE = '0xc3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7aacaa2d0f62';
 
@@ -25,11 +25,15 @@ function parseCards(receipt: any, userAddress: string, faucet: string, factory: 
     })
     .map((log: any) => {
       const hex = log.data.slice(2);
-      return {
-        id:     parseInt(hex.slice(0, 64), 16),
-        amount: parseInt(hex.slice(64, 128), 16),
-      };
+      return { id: parseInt(hex.slice(0, 64), 16), amount: parseInt(hex.slice(64, 128), 16) };
     });
+}
+
+// Merge duplicate card IDs by summing amounts
+function mergeCards(cards: ReceivedCard[]): ReceivedCard[] {
+  const map = new Map<number, number>();
+  cards.forEach(c => map.set(c.id, (map.get(c.id) ?? 0) + c.amount));
+  return Array.from(map.entries()).map(([id, amount]) => ({ id, amount }));
 }
 
 const useClaimBoosterPack = (config: OnchainBoosterpackConfig) => {
@@ -37,28 +41,39 @@ const useClaimBoosterPack = (config: OnchainBoosterpackConfig) => {
   const [phase, setPhase]                = useState<ClaimPhase>('idle');
   const [receivedCards, setReceivedCards] = useState<ReceivedCard[]>([]);
   const [claimError, setClaimError]      = useState<string | null>(null);
+  const [packCount, setPackCount]        = useState(0); // how many packs are being opened
 
-  const onClaim = useCallback(async () => {
+  const onClaim = useCallback(async (quantity: number = 1) => {
     if (!pepemon.provider) { setClaimError('No wallet connected'); return; }
     if (pepemon.chainId !== config.chainId) { setClaimError(`Switch to chainId ${config.chainId}`); return; }
 
     setClaimError(null);
     setReceivedCards([]);
+    setPackCount(quantity);
     setPhase('wallet-pending');
 
     try {
-      const signer = pepemon.provider.getSigner();
-      const faucet = new Contract(config.faucetAddress, FaucetAbi, signer);
-      const tx = await faucet.claimAndReveal(config.packId, config.cardIds);
-
-      // Wallet confirmed — start showing the reveal video
-      setPhase('video-playing');
-
-      const receipt = await tx.wait();
+      const signer  = pepemon.provider.getSigner();
+      const faucet  = new Contract(config.faucetAddress, FaucetAbi, signer);
       const userAddress = await signer.getAddress();
-      const cards = parseCards(receipt, userAddress, config.faucetAddress, config.factoryAddress);
-      setReceivedCards(cards);
-      // Signal: tx done, cards parsed — overlay transitions when video min-time is up
+
+      // Submit all N transactions (N wallet popups in sequence), collect tx objects
+      const txs: any[] = [];
+      for (let i = 0; i < quantity; i++) {
+        const tx = await faucet.claimAndReveal(config.packId, config.cardIds);
+        txs.push(tx);
+        // Start the video as soon as the first tx is submitted
+        if (i === 0) setPhase('video-playing');
+      }
+
+      // Wait for all to confirm concurrently (video plays during this)
+      const receipts = await Promise.all(txs.map((tx: any) => tx.wait()));
+
+      // Parse all cards from all receipts, merge amounts
+      const all = receipts.flatMap((receipt: any) =>
+        parseCards(receipt, userAddress, config.faucetAddress, config.factoryAddress)
+      );
+      setReceivedCards(mergeCards(all));
       setPhase('revealing');
     } catch (e: any) {
       setPhase('idle');
@@ -69,9 +84,10 @@ const useClaimBoosterPack = (config: OnchainBoosterpackConfig) => {
   const onDismiss = useCallback(() => {
     setPhase('idle');
     setReceivedCards([]);
+    setPackCount(0);
   }, []);
 
-  return { onClaim, phase, receivedCards, claimError, onDismiss };
+  return { onClaim, phase, packCount, receivedCards, claimError, onDismiss };
 };
 
 export default useClaimBoosterPack;

--- a/packages/app/src/hooks/useClaimBoosterPack.ts
+++ b/packages/app/src/hooks/useClaimBoosterPack.ts
@@ -67,7 +67,7 @@ const useClaimBoosterPack = (config: OnchainBoosterpackConfig) => {
   }, [pepemon.provider, pepemon.chainId, config]);
 
   const onDismiss = useCallback(() => {
-    setPhase('done');
+    setPhase('idle');
     setReceivedCards([]);
   }, []);
 

--- a/packages/app/src/hooks/useClaimBoosterPack.ts
+++ b/packages/app/src/hooks/useClaimBoosterPack.ts
@@ -4,49 +4,74 @@ import usePepemon from './usePepemon';
 import FaucetAbi from '../contracts/src/abis/boosterPackFaucet.json';
 import { OnchainBoosterpackConfig } from '../constants/boosterpacks';
 
+export interface ReceivedCard {
+  id: number;
+  amount: number;
+}
+
+export type ClaimPhase = 'idle' | 'wallet-pending' | 'video-playing' | 'revealing' | 'done';
+
+const TRANSFER_SINGLE = '0xc3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7aacaa2d0f62';
+
+function parseCards(receipt: any, userAddress: string, faucet: string, factory: string): ReceivedCard[] {
+  return receipt.logs
+    .filter((log: any) => {
+      if (log.address.toLowerCase() !== factory.toLowerCase()) return false;
+      if (log.topics[0] !== TRANSFER_SINGLE) return false;
+      const from = '0x' + log.topics[2].slice(-40);
+      const to   = '0x' + log.topics[3].slice(-40);
+      return from.toLowerCase() === faucet.toLowerCase()
+          && to.toLowerCase()   === userAddress.toLowerCase();
+    })
+    .map((log: any) => {
+      const hex = log.data.slice(2);
+      return {
+        id:     parseInt(hex.slice(0, 64), 16),
+        amount: parseInt(hex.slice(64, 128), 16),
+      };
+    });
+}
+
 const useClaimBoosterPack = (config: OnchainBoosterpackConfig) => {
   const pepemon = usePepemon();
-  const [isClaiming, setIsClaiming] = useState(false);
-  const [isSubmitted, setIsSubmitted] = useState(false);
-  const [claimError, setClaimError] = useState<string | null>(null);
-  const [claimSuccess, setClaimSuccess] = useState(false);
+  const [phase, setPhase]                = useState<ClaimPhase>('idle');
+  const [receivedCards, setReceivedCards] = useState<ReceivedCard[]>([]);
+  const [claimError, setClaimError]      = useState<string | null>(null);
 
   const onClaim = useCallback(async () => {
+    if (!pepemon.provider) { setClaimError('No wallet connected'); return; }
+    if (pepemon.chainId !== config.chainId) { setClaimError(`Switch to chainId ${config.chainId}`); return; }
+
     setClaimError(null);
-    setClaimSuccess(false);
-    setIsSubmitted(false);
+    setReceivedCards([]);
+    setPhase('wallet-pending');
 
-    if (!pepemon.provider) {
-      setClaimError('No wallet connected');
-      return false;
-    }
-    if (pepemon.chainId !== config.chainId) {
-      setClaimError(`Switch to chainId ${config.chainId}`);
-      return false;
-    }
-
-    setIsClaiming(true);
     try {
       const signer = pepemon.provider.getSigner();
       const faucet = new Contract(config.faucetAddress, FaucetAbi, signer);
       const tx = await faucet.claimAndReveal(config.packId, config.cardIds);
-      // Wallet confirmed — tx is now submitted to the chain
-      setIsSubmitted(true);
-      await tx.wait();
-      setIsSubmitted(false);
-      setClaimSuccess(true);
-      return true;
+
+      // Wallet confirmed — start showing the reveal video
+      setPhase('video-playing');
+
+      const receipt = await tx.wait();
+      const userAddress = await signer.getAddress();
+      const cards = parseCards(receipt, userAddress, config.faucetAddress, config.factoryAddress);
+      setReceivedCards(cards);
+      // Signal: tx done, cards parsed — overlay transitions when video min-time is up
+      setPhase('revealing');
     } catch (e: any) {
-      setIsSubmitted(false);
-      const msg = e?.reason || e?.message || 'Transaction failed';
-      setClaimError(msg);
-      return false;
-    } finally {
-      setIsClaiming(false);
+      setPhase('idle');
+      setClaimError(e?.reason || e?.message || 'Transaction failed');
     }
   }, [pepemon.provider, pepemon.chainId, config]);
 
-  return { onClaim, isClaiming, isSubmitted, claimError, claimSuccess };
+  const onDismiss = useCallback(() => {
+    setPhase('done');
+    setReceivedCards([]);
+  }, []);
+
+  return { onClaim, phase, receivedCards, claimError, onDismiss };
 };
 
 export default useClaimBoosterPack;

--- a/packages/app/src/hooks/useClaimBoosterPack.ts
+++ b/packages/app/src/hooks/useClaimBoosterPack.ts
@@ -1,0 +1,52 @@
+import { useState, useCallback } from 'react';
+import { Contract } from '@ethersproject/contracts';
+import usePepemon from './usePepemon';
+import FaucetAbi from '../contracts/src/abis/boosterPackFaucet.json';
+import { OnchainBoosterpackConfig } from '../constants/boosterpacks';
+
+const useClaimBoosterPack = (config: OnchainBoosterpackConfig) => {
+  const pepemon = usePepemon();
+  const [isClaiming, setIsClaiming] = useState(false);
+  const [isSubmitted, setIsSubmitted] = useState(false);
+  const [claimError, setClaimError] = useState<string | null>(null);
+  const [claimSuccess, setClaimSuccess] = useState(false);
+
+  const onClaim = useCallback(async () => {
+    setClaimError(null);
+    setClaimSuccess(false);
+    setIsSubmitted(false);
+
+    if (!pepemon.provider) {
+      setClaimError('No wallet connected');
+      return false;
+    }
+    if (pepemon.chainId !== config.chainId) {
+      setClaimError(`Switch to chainId ${config.chainId}`);
+      return false;
+    }
+
+    setIsClaiming(true);
+    try {
+      const signer = pepemon.provider.getSigner();
+      const faucet = new Contract(config.faucetAddress, FaucetAbi, signer);
+      const tx = await faucet.claimAndReveal(config.packId, config.cardIds);
+      // Wallet confirmed — tx is now submitted to the chain
+      setIsSubmitted(true);
+      await tx.wait();
+      setIsSubmitted(false);
+      setClaimSuccess(true);
+      return true;
+    } catch (e: any) {
+      setIsSubmitted(false);
+      const msg = e?.reason || e?.message || 'Transaction failed';
+      setClaimError(msg);
+      return false;
+    } finally {
+      setIsClaiming(false);
+    }
+  }, [pepemon.provider, pepemon.chainId, config]);
+
+  return { onClaim, isClaiming, isSubmitted, claimError, claimSuccess };
+};
+
+export default useClaimBoosterPack;

--- a/packages/app/src/utils/isSupportedChain.ts
+++ b/packages/app/src/utils/isSupportedChain.ts
@@ -7,7 +7,7 @@ const isSupportedChain = (chainId: number, pathname: string) => {
 	}
 
 	if (pathname.startsWith('/store') || pathname === '/') {
-		return (chainId === 1 || chainId === 4 || chainId === 56);
+		return (chainId === 1 || chainId === 4 || chainId === 56 || chainId === 84532);
 	}
 	return (chainId === 1 || chainId === 4);
 }

--- a/packages/app/src/views/Store/components/StoreAside.tsx
+++ b/packages/app/src/views/Store/components/StoreAside.tsx
@@ -35,10 +35,15 @@ const StyledStoreAsideInner = styled.div`
 	@media (min-width: ${theme.breakpoints.tabletL}) {
 		position: sticky;
 		top: calc(${theme.topBarSize}px + 1em);
+		display: flex;
+		flex-direction: column;
+		max-height: calc(100vh - ${theme.topBarSize}px - 2em);
+		overflow: hidden;
 	}
 
 	@media (min-width: ${theme.breakpoints.desktop}) {
 		top: 1em;
+		max-height: calc(100vh - 2em);
 	}
 `
 

--- a/packages/app/src/views/Store/components/StorePacksAside.tsx
+++ b/packages/app/src/views/Store/components/StorePacksAside.tsx
@@ -1,91 +1,168 @@
-import React, {
-	// useContext
-} from "react";
-// import styled from "styled-components";
-import { StyledStoreBody,
-	// StyledPepemonCardMeta, StyledPepemonCardPrice
-} from './index';
-import { Button, Title, Text, Spacer,
-	// StyledSpacer
-} from '../../../components';
-// import { PepemonProviderContext } from '../../../contexts';
+import React, { useContext, useRef, useEffect } from "react";
+import styled from "styled-components";
+import { StyledStoreBody } from './index';
+import { Button, Title, Text, Spacer } from '../../../components';
+import { PepemonProviderContext } from '../../../contexts';
 import { StoreAside } from '../components';
-// import { ProgressBar } from '../../../components';
-// import { coin } from '../../../assets';
-import { useModal } from '../../../hooks';
 import { theme } from '../../../theme';
+import { useClaimBoosterPack } from '../../../hooks';
+import chains from '../../../constants/chains';
 
-const StorePacksAside: React.FC<any> = ({setSelectedPack, selectedPack}) => {
-	// const [pepemon] = useContext(PepemonProviderContext);
-	// const { chainId } = pepemon;
+const BASE_SEPOLIA_CHAIN_ID = 84532;
 
-	const [handlePresent] = useModal({
-		title: 'Claim this deck',
-		modalActions: [
-			{
-				text: 'Not available (yet)',
-				buttonProps: {
-					disabled: true,
-					styling: 'purple',
-					width: '100%'
-				}
-			}
-		]
-	});
+const FullScreenOverlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  z-index: 9999;
+  background: #000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+`;
+
+const OverlayVideo = styled.video`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+`;
+
+const ClaimRevealOverlay: React.FC<{ visible: boolean }> = ({ visible }) => {
+	const videoRef = useRef<HTMLVideoElement>(null);
+
+	useEffect(() => {
+		if (visible && videoRef.current) {
+			videoRef.current.currentTime = 0;
+			videoRef.current.play().catch(() => {/* autoplay may be blocked */});
+		} else if (!visible && videoRef.current) {
+			videoRef.current.pause();
+		}
+	}, [visible]);
+
+	if (!visible) return null;
 
 	return (
-		<StoreAside close={() => setSelectedPack(null)} title="Selected Pack">
-			<StyledStoreBody>
-				<Title as="h2" font={theme.font.neometric} size='m'>{selectedPack.name}</Title>
-				<Spacer size="sm"/>
-				<Text as="p" font={theme.font.inter} size='s' lineHeight={1.3} color={theme.color.gray[600]}>When claiming this booster pack you will recieve {selectedPack.cardsPerPack} random cards.</Text>
-				<Spacer size="sm"/>
-				<img loading="lazy" src={selectedPack.url} alt={selectedPack.name} style={{width: "100%"}}/>
-				<Spacer size='md'/>
-				{/*
-					<StyledPepemonCardMeta>
-						<dt>Rarity:</dt>
-						<dd>Epic</dd>
-					</StyledPepemonCardMeta>
-					<Spacer size='sm'/>
-					<StyledSpacer bg={theme.color.gray[100]} size={2}/>
-					<StyledPepemonCardMeta>
-						<dt>Type:</dt>
-						<dd>Collectors edition</dd>
-					</StyledPepemonCardMeta>
-					<Spacer size='sm'/>
-					<StyledSpacer bg={theme.color.gray[100]} size={2}/>
-					<StyledPepemonCardMeta>
-						<dt>Set:</dt>
-						<dd>New beginning</dd>
-					</StyledPepemonCardMeta>
-					<Spacer size='sm'/>
-					<StyledSpacer bg={theme.color.gray[100]} size={2}/>
-					<StyledPepemonCardMeta>
-						<dt>Artist:</dt>
-						<dd>Azucena N.A.</dd>
-					</StyledPepemonCardMeta>
-					<Spacer size='sm'/>
-					<StyledSpacer bg={theme.color.gray[100]} size={2}/>
-					<StyledPepemonCardMeta>
-						<dt>Price:</dt>
-						<dd>
-							<StyledPepemonCardPrice styling="alt">
-								<img loading="lazy" src={coin} alt="coin"/>
-								{selectedPack.price} {chainId === 56 ? 'BNB' : 'PPDEX'}
-							</StyledPepemonCardPrice>
-						</dd>
-					</StyledPepemonCardMeta>
+		<FullScreenOverlay>
+			<OverlayVideo
+				ref={videoRef}
+				src="/videos/claim-reveal.mp4"
+				loop
+				playsInline
+			/>
+		</FullScreenOverlay>
+	);
+};
+
+const StorePacksAside: React.FC<any> = ({setSelectedPack, selectedPack}) => {
+	const [pepemon] = useContext(PepemonProviderContext);
+	const { chainId, account } = pepemon;
+
+	const onchainConfig = selectedPack?.onchainConfig ?? null;
+	const isLivePack = onchainConfig !== null;
+	const isOnRightChain = isLivePack && chainId === onchainConfig.chainId;
+
+	const { onClaim, isClaiming, isSubmitted, claimError, claimSuccess } = useClaimBoosterPack(
+		onchainConfig ?? { chainId: 0, faucetAddress: '', packId: 0, cardIds: [] }
+	);
+
+	const switchToBaseSepolia = async () => {
+		const chain = chains.find(c => parseInt(c.chainId, 16) === BASE_SEPOLIA_CHAIN_ID);
+		if (!chain || !window.ethereum) return;
+		try {
+			await (window.ethereum as any).request({
+				method: 'wallet_switchEthereumChain',
+				params: [{ chainId: chain.chainId }],
+			});
+		} catch (err: any) {
+			if (err.code === 4902) {
+				await (window.ethereum as any).request({
+					method: 'wallet_addEthereumChain',
+					params: [{
+						chainId: chain.chainId,
+						chainName: chain.chainName,
+						nativeCurrency: chain.nativeCurrency,
+						rpcUrls: chain.rpcUrls,
+						blockExplorerUrls: chain.blockExplorerUrls,
+					}],
+				});
+			}
+		}
+	};
+
+	const renderButton = () => {
+		if (!isLivePack) {
+			return (
+				<Button disabled styling="purple" width="100%">
+					Not available (yet)
+				</Button>
+			);
+		}
+
+		if (!account) {
+			return (
+				<Button disabled styling="purple" width="100%">
+					Connect wallet to claim
+				</Button>
+			);
+		}
+
+		if (!isOnRightChain) {
+			return (
+				<Button styling="purple" width="100%" onClick={switchToBaseSepolia}>
+					Switch to Base Sepolia
+				</Button>
+			);
+		}
+
+		if (claimSuccess) {
+			return (
+				<Button disabled styling="purple" width="100%">
+					✓ Cards sent to your wallet!
+				</Button>
+			);
+		}
+
+		return (
+			<Button
+				styling="purple"
+				width="100%"
+				disabled={isClaiming}
+				onClick={onClaim}
+			>
+				{isClaiming && !isSubmitted ? 'Confirm in wallet…' : isClaiming ? 'Confirming on chain…' : 'Claim 3 cards'}
+			</Button>
+		);
+	};
+
+	return (
+		<>
+			<ClaimRevealOverlay visible={isSubmitted} />
+			<StoreAside close={() => setSelectedPack(null)} title="Selected Pack">
+				<StyledStoreBody>
+					<Title as="h2" font={theme.font.neometric} size='m'>{selectedPack.name}</Title>
+					<Spacer size="sm"/>
+					<Text as="p" font={theme.font.inter} size='s' lineHeight={1.3} color={theme.color.gray[600]}>
+						When claiming this booster pack you will recieve {selectedPack.cardsPerPack} random cards.
+					</Text>
+					<Spacer size="sm"/>
+					<img loading="lazy" src={selectedPack.url} alt={selectedPack.name} style={{width: "100%"}}/>
 					<Spacer size='md'/>
-					<Text as="p" font={theme.font.inter} size='xs' color={theme.color.gray[300]} spacing={1.2} txtTransform="uppercase">Chances of getting this card:</Text>
-					<Spacer size='sm'/>
-					<ProgressBar percent={60}/>
-					<Spacer size='md'/>
-				*/}
-				<Button disabled styling="purple" onClick={() => handlePresent() } width="100%">Not available (yet)</Button>
-			</StyledStoreBody>
-		</StoreAside>
-	)
-}
+					{renderButton()}
+					{claimError && (
+						<>
+							<Spacer size="sm"/>
+							<Text as="p" font={theme.font.inter} size='xs' color="red">
+								{claimError}
+							</Text>
+						</>
+					)}
+				</StyledStoreBody>
+			</StoreAside>
+		</>
+	);
+};
 
 export default StorePacksAside;

--- a/packages/app/src/views/Store/components/StorePacksAside.tsx
+++ b/packages/app/src/views/Store/components/StorePacksAside.tsx
@@ -10,23 +10,21 @@ import type { ReceivedCard } from '../../../hooks/useClaimBoosterPack';
 import chains from '../../../constants/chains';
 
 const BASE_SEPOLIA_CHAIN_ID = 84532;
-// Video plays a minimum of this long before card reveal starts, even if the chain confirms faster
-const VIDEO_MIN_MS = 6000;
 
 // ─── Animations ──────────────────────────────────────────────────────────────
 
 const popIn = keyframes`
-  0%   { transform: scale(0.4) translateY(60px); opacity: 0; }
-  70%  { transform: scale(1.08) translateY(-6px); opacity: 1; }
+  0%   { transform: scale(0.3) translateY(40px); opacity: 0; }
+  65%  { transform: scale(1.1) translateY(-4px); opacity: 1; }
   100% { transform: scale(1) translateY(0); opacity: 1; }
 `;
 
 const glow = keyframes`
-  0%, 100% { box-shadow: 0 0 18px 4px rgba(168, 85, 247, 0.5); }
-  50%       { box-shadow: 0 0 38px 12px rgba(168, 85, 247, 0.9), 0 0 60px 20px rgba(99,102,241,0.4); }
+  0%, 100% { box-shadow: 0 0 14px 3px rgba(168, 85, 247, 0.55); }
+  50%       { box-shadow: 0 0 34px 10px rgba(168, 85, 247, 0.9), 0 0 54px 18px rgba(99,102,241,0.35); }
 `;
 
-// ─── Styled components ────────────────────────────────────────────────────────
+// ─── Overlay styled components ────────────────────────────────────────────────
 
 const Overlay = styled.div`
   position: fixed;
@@ -48,65 +46,112 @@ const FullVideo = styled.video`
   object-fit: cover;
 `;
 
-const RevealLayer = styled.div`
+const CardOverlayLayer = styled.div<{ visible: boolean }>`
   position: relative;
   z-index: 1;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 32px;
+  gap: 28px;
   padding: 24px;
   width: 100%;
-  max-width: 480px;
+  max-width: 560px;
+  background: rgba(0, 0, 0, 0.55);
+  border-radius: 20px;
+  backdrop-filter: blur(8px);
+  opacity: ${p => (p.visible ? 1 : 0)};
+  transform: ${p => (p.visible ? 'scale(1)' : 'scale(0.95)')};
+  transition: opacity 0.5s ease, transform 0.5s ease;
+  pointer-events: ${p => (p.visible ? 'auto' : 'none')};
 `;
 
 const CardRow = styled.div`
   display: flex;
   flex-wrap: wrap;
-  gap: 16px;
+  gap: 14px;
   justify-content: center;
 `;
 
-const CardSlot = styled.div<{ delay: number; visible: boolean }>`
-  width: 120px;
+const CardSlot = styled.div<{ visible: boolean }>`
+  width: 110px;
   opacity: ${p => (p.visible ? 1 : 0)};
-  animation: ${p => (p.visible ? popIn : 'none')} 0.6s cubic-bezier(0.34,1.56,0.64,1) ${p => p.delay}ms both;
+  animation: ${p => (p.visible ? popIn : 'none')} 0.55s cubic-bezier(0.34,1.56,0.64,1) both;
 `;
 
 const CardImg = styled.img`
   width: 100%;
-  border-radius: 12px;
-  animation: ${glow} 2s ease-in-out infinite;
-`;
-
-const CardBack = styled.div`
-  width: 100%;
-  aspect-ratio: 2/3;
-  border-radius: 12px;
-  background: linear-gradient(135deg, #4f46e5 0%, #7c3aed 100%);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 32px;
+  border-radius: 10px;
+  animation: ${glow} 2.4s ease-in-out infinite;
 `;
 
 const CardName = styled.p`
   color: #fff;
-  font-size: 11px;
+  font-size: 10px;
   text-align: center;
-  margin: 6px 0 0;
-  font-weight: 600;
+  margin: 5px 0 0;
+  font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.06em;
 `;
 
 const RevealTitle = styled.h2`
   color: #fff;
-  font-size: 22px;
+  font-size: 20px;
   font-weight: 800;
   text-align: center;
-  text-shadow: 0 0 20px rgba(168,85,247,0.8);
+  text-shadow: 0 0 18px rgba(168,85,247,0.9);
   margin: 0;
+`;
+
+// ─── Aside layout ─────────────────────────────────────────────────────────────
+
+const AsideContent = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  @media (min-width: ${theme.breakpoints.tabletL}) {
+    max-height: calc(100vh - 80px);
+    overflow: hidden;
+  }
+`;
+
+const ScrollableContent = styled.div`
+  @media (min-width: ${theme.breakpoints.tabletL}) {
+    overflow-y: auto;
+    flex: 1;
+    min-height: 0;
+  }
+`;
+
+const StickyBottom = styled.div`
+  @media (min-width: ${theme.breakpoints.tabletL}) {
+    position: sticky;
+    bottom: 0;
+    background: #fff;
+    padding-top: 12px;
+    border-top: 1px solid ${theme.color.gray[100]};
+    flex-shrink: 0;
+  }
+`;
+
+const QuantityRow = styled.div`
+  display: flex;
+  gap: 8px;
+  margin-bottom: 10px;
+`;
+
+const QtyBtn = styled.button<{ active: boolean }>`
+  flex: 1;
+  padding: 6px 0;
+  border-radius: 8px;
+  border: 2px solid ${p => (p.active ? theme.color.purple[600] : theme.color.gray[200])};
+  background: ${p => (p.active ? theme.color.purple[600] : 'transparent')};
+  color: ${p => (p.active ? '#fff' : theme.color.gray[600])};
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.15s;
+  &:hover { border-color: ${theme.color.purple[600]}; }
 `;
 
 // ─── Card metadata ────────────────────────────────────────────────────────────
@@ -115,6 +160,7 @@ interface CardMeta { image: string; name: string; }
 
 function useCardMeta(ids: number[]): Record<number, CardMeta> {
   const [meta, setMeta] = useState<Record<number, CardMeta>>({});
+  const key = ids.join(',');
   useEffect(() => {
     if (!ids.length) return;
     const unique = Array.from(new Set(ids));
@@ -134,127 +180,125 @@ function useCardMeta(ids: number[]): Record<number, CardMeta> {
       results.forEach(r => { m[r.id] = { image: r.image, name: r.name }; });
       setMeta(m);
     });
-  }, [ids.join(',')]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
   return meta;
 }
 
 // ─── Reveal overlay ───────────────────────────────────────────────────────────
 
 interface RevealOverlayProps {
-  phase: 'idle' | 'wallet-pending' | 'video-playing' | 'revealing' | 'done';
+  phase: 'idle' | 'wallet-pending' | 'video-playing' | 'revealing';
   receivedCards: ReceivedCard[];
-  packImageUrl: string;
   onDismiss: () => void;
 }
 
-const RevealOverlay: React.FC<RevealOverlayProps> = ({ phase, receivedCards, packImageUrl, onDismiss }) => {
-  const videoRef    = useRef<HTMLVideoElement>(null);
-  const timerRef    = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const [videoMinElapsed, setVideoMinElapsed] = useState(false);
-  const [revealedCount,   setRevealedCount]   = useState(0);
+const RevealOverlay: React.FC<RevealOverlayProps> = ({ phase, receivedCards, onDismiss }) => {
+  const videoRef      = useRef<HTMLVideoElement>(null);
+  const [videoEnded,  setVideoEnded]  = useState(false);
+  const [revealedCount, setRevealedCount] = useState(0);
 
-  const showOverlay   = phase === 'video-playing' || phase === 'revealing';
-  const showReveal    = phase === 'revealing' && videoMinElapsed;
-  const showVideo     = showOverlay && !showReveal;
+  const showOverlay = phase === 'video-playing' || phase === 'revealing';
+  // Show cards when BOTH: tx confirmed AND video has played to the end
+  const showCards   = phase === 'revealing' && videoEnded;
 
-  // Expand cards to individual items (2× card 2 → [2, 2])
+  // Expand receivedCards to individual card slots (2× card 2 → [2, 2])
   const cardList = receivedCards.flatMap(c => Array(c.amount).fill(c.id));
   const cardIds  = cardList.filter((v, i, a) => a.indexOf(v) === i);
-  const meta     = useCardMeta(showReveal ? cardIds : []);
+  const meta     = useCardMeta(showCards ? cardIds : []);
 
-  // Start min-play timer when video phase begins
-  useEffect(() => {
-    if (phase === 'video-playing' && !videoMinElapsed) {
-      timerRef.current = setTimeout(() => setVideoMinElapsed(true), VIDEO_MIN_MS);
-    }
-    return () => { if (timerRef.current) clearTimeout(timerRef.current); };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [phase]);
-
-  // Play / pause video
+  // Play video when overlay opens; it will stop at the end (no loop)
   useEffect(() => {
     const v = videoRef.current;
     if (!v) return;
-    if (showVideo) {
+    if (showOverlay) {
+      setVideoEnded(false);
       v.currentTime = 0;
-      v.play().catch(() => {});
+      v.play().catch(() => {
+        // Autoplay blocked — treat as immediately ended so cards can reveal
+        setVideoEnded(true);
+      });
     } else {
       v.pause();
+      v.currentTime = 0;
     }
-  }, [showVideo]);
+  }, [showOverlay]);
 
-  // Reveal cards one by one once showReveal is true
+  // If tx confirms before video ends: video keeps playing until onEnded.
+  // If video ends before tx confirms: videoEnded = true, showCards waits for phase === 'revealing'.
+  const handleVideoEnded = () => setVideoEnded(true);
+
+  // Reveal cards one by one once showCards is true
   useEffect(() => {
-    if (!showReveal || cardList.length === 0) return;
+    if (!showCards || cardList.length === 0) return;
     setRevealedCount(0);
     cardList.forEach((_, i) => {
-      setTimeout(() => setRevealedCount(n => n + 1), 400 + i * 900);
+      setTimeout(() => setRevealedCount(n => n + 1), 300 + i * 750);
     });
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [showReveal]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showCards]);
 
-  // Reset on close
+  // Reset counters when overlay closes
   useEffect(() => {
     if (!showOverlay) {
-      setVideoMinElapsed(false);
+      setVideoEnded(false);
       setRevealedCount(0);
-      if (timerRef.current) clearTimeout(timerRef.current);
     }
   }, [showOverlay]);
 
   if (!showOverlay) return null;
 
-  const allRevealed = revealedCount >= cardList.length && cardList.length > 0;
+  const allRevealed = cardList.length > 0 && revealedCount >= cardList.length;
 
   return (
     <Overlay>
-      {/* Video is always rendered so browser can buffer it; visibility controlled via opacity */}
       <FullVideo
         ref={videoRef}
         src="/videos/claim-reveal.mp4"
-        loop
         muted
         playsInline
-        style={{ opacity: showVideo ? 1 : 0, transition: 'opacity 0.8s' }}
+        onEnded={handleVideoEnded}
       />
 
-      {showReveal && (
-        <RevealLayer>
-          <RevealTitle>You got {cardList.length} {cardList.length === 1 ? 'card' : 'cards'}!</RevealTitle>
-          <CardRow>
-            {cardList.map((id, i) => {
-              const revealed = i < revealedCount;
-              const cardMeta = meta[id];
-              return (
-                <CardSlot key={i} delay={0} visible={revealed}>
-                  {revealed && cardMeta?.image
-                    ? <CardImg src={cardMeta.image} alt={cardMeta?.name || `Card #${id}`} />
-                    : <CardBack>✦</CardBack>
-                  }
-                  <CardName>{revealed ? (meta[id]?.name || `#${id}`) : '???'}</CardName>
-                </CardSlot>
-              );
-            })}
-          </CardRow>
-          {allRevealed && (
-            <Button styling="purple" width="100%" onClick={onDismiss}>
-              Open another pack
-            </Button>
-          )}
-        </RevealLayer>
-      )}
+      <CardOverlayLayer visible={showCards}>
+        <RevealTitle>
+          You pulled {cardList.length} {cardList.length === 1 ? 'card' : 'cards'}!
+        </RevealTitle>
+        <CardRow>
+          {cardList.map((id, i) => {
+            const revealed = i < revealedCount;
+            return (
+              <CardSlot key={i} visible={revealed}>
+                {meta[id]?.image
+                  ? <CardImg src={meta[id].image} alt={meta[id]?.name} />
+                  : <div style={{ width: '100%', aspectRatio: '2/3', borderRadius: 10, background: 'linear-gradient(135deg,#4f46e5,#7c3aed)', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 28 }}>✦</div>
+                }
+                <CardName>{meta[id]?.name || `#${id}`}</CardName>
+              </CardSlot>
+            );
+          })}
+        </CardRow>
+        {allRevealed && (
+          <Button styling="purple" width="100%" onClick={onDismiss}>
+            Open another pack
+          </Button>
+        )}
+      </CardOverlayLayer>
     </Overlay>
   );
 };
 
 // ─── Main component ───────────────────────────────────────────────────────────
 
+const QUANTITIES = [1, 3, 5];
+
 const StorePacksAside: React.FC<any> = ({ setSelectedPack, selectedPack }) => {
   const [pepemon] = useContext(PepemonProviderContext);
   const { chainId, account } = pepemon;
+  const [quantity, setQuantity] = useState(1);
 
-  const onchainConfig = selectedPack?.onchainConfig ?? null;
-  const isLivePack    = onchainConfig !== null;
+  const onchainConfig  = selectedPack?.onchainConfig ?? null;
+  const isLivePack     = onchainConfig !== null;
   const isOnRightChain = isLivePack && chainId === onchainConfig.chainId;
 
   const { onClaim, phase, receivedCards, claimError, onDismiss } = useClaimBoosterPack(
@@ -290,50 +334,66 @@ const StorePacksAside: React.FC<any> = ({ setSelectedPack, selectedPack }) => {
   const isClaiming = phase === 'wallet-pending' || phase === 'video-playing' || phase === 'revealing';
 
   const handleOpen = async () => {
-    if (!account) { await loadWeb3Modal(); return; }
+    if (!account)      { await loadWeb3Modal(); return; }
     if (!isOnRightChain) { await switchToBaseSepolia(); return; }
-    onClaim();
+    onClaim(quantity);
   };
 
-  const renderButton = () => {
+  const buttonLabel = phase === 'wallet-pending'
+    ? `Confirm in wallet… (${quantity > 1 ? `sign ${quantity}×` : 'signing'})`
+    : isClaiming
+    ? 'Opening pack…'
+    : quantity > 1
+    ? `Open ${quantity} Boosterpacks`
+    : 'Open Boosterpack';
+
+  const renderClaimArea = () => {
     if (!isLivePack) {
       return <Button disabled styling="purple" width="100%">Not available (yet)</Button>;
     }
-    const label = phase === 'wallet-pending' ? 'Confirm in wallet…'
-      : isClaiming ? 'Opening pack…'
-      : 'Open Boosterpack';
     return (
-      <Button styling="purple" width="100%" disabled={isClaiming} onClick={handleOpen}>
-        {label}
-      </Button>
+      <>
+        {!isClaiming && (
+          <QuantityRow>
+            {QUANTITIES.map(q => (
+              <QtyBtn key={q} active={quantity === q} onClick={() => setQuantity(q)}>
+                {q}×
+              </QtyBtn>
+            ))}
+          </QuantityRow>
+        )}
+        <Button styling="purple" width="100%" disabled={isClaiming} onClick={handleOpen}>
+          {buttonLabel}
+        </Button>
+        {claimError && (
+          <>
+            <Spacer size="sm"/>
+            <Text as="p" font={theme.font.inter} size='xs' color="red">{claimError}</Text>
+          </>
+        )}
+      </>
     );
   };
 
   return (
     <>
-      <RevealOverlay
-        phase={phase}
-        receivedCards={receivedCards}
-        packImageUrl={selectedPack.url}
-        onDismiss={onDismiss}
-      />
+      <RevealOverlay phase={phase} receivedCards={receivedCards} onDismiss={onDismiss} />
       <StoreAside close={() => setSelectedPack(null)} title="Selected Pack">
-        <StyledStoreBody>
-          <Title as="h2" font={theme.font.neometric} size='m'>{selectedPack.name}</Title>
-          <Spacer size="sm"/>
-          <Text as="p" font={theme.font.inter} size='s' lineHeight={1.3} color={theme.color.gray[600]}>
-            When claiming this booster pack you will recieve {selectedPack.cardsPerPack} random cards.
-          </Text>
-          <Spacer size="sm"/>
-          <img loading="lazy" src={selectedPack.url} alt={selectedPack.name} style={{ width: '100%' }}/>
-          <Spacer size='md'/>
-          {renderButton()}
-          {claimError && (
-            <>
+        <StyledStoreBody style={{ padding: 0 }}>
+          <AsideContent>
+            <ScrollableContent style={{ padding: '1.1em' }}>
+              <Title as="h2" font={theme.font.neometric} size='m'>{selectedPack.name}</Title>
               <Spacer size="sm"/>
-              <Text as="p" font={theme.font.inter} size='xs' color="red">{claimError}</Text>
-            </>
-          )}
+              <Text as="p" font={theme.font.inter} size='s' lineHeight={1.3} color={theme.color.gray[600]}>
+                When claiming this booster pack you will receive {selectedPack.cardsPerPack} random cards.
+              </Text>
+              <Spacer size="sm"/>
+              <img loading="lazy" src={selectedPack.url} alt={selectedPack.name} style={{ width: '100%', display: 'block' }}/>
+            </ScrollableContent>
+            <StickyBottom style={{ padding: '0 1.1em 1.1em' }}>
+              {renderClaimArea()}
+            </StickyBottom>
+          </AsideContent>
         </StyledStoreBody>
       </StoreAside>
     </>

--- a/packages/app/src/views/Store/components/StorePacksAside.tsx
+++ b/packages/app/src/views/Store/components/StorePacksAside.tsx
@@ -5,7 +5,7 @@ import { Button, Title, Text, Spacer } from '../../../components';
 import { PepemonProviderContext } from '../../../contexts';
 import { StoreAside } from '../components';
 import { theme } from '../../../theme';
-import { useClaimBoosterPack } from '../../../hooks';
+import { useClaimBoosterPack, useWeb3Modal } from '../../../hooks';
 import type { ReceivedCard } from '../../../hooks/useClaimBoosterPack';
 import chains from '../../../constants/chains';
 
@@ -238,7 +238,7 @@ const RevealOverlay: React.FC<RevealOverlayProps> = ({ phase, receivedCards, pac
           </CardRow>
           {allRevealed && (
             <Button styling="purple" width="100%" onClick={onDismiss}>
-              Claim another pack
+              Open another pack
             </Button>
           )}
         </RevealLayer>
@@ -260,6 +260,8 @@ const StorePacksAside: React.FC<any> = ({ setSelectedPack, selectedPack }) => {
   const { onClaim, phase, receivedCards, claimError, onDismiss } = useClaimBoosterPack(
     onchainConfig ?? { chainId: 0, faucetAddress: '', factoryAddress: '', packId: 0, cardIds: [] }
   );
+
+  const [, loadWeb3Modal] = useWeb3Modal() as any;
 
   const switchToBaseSepolia = async () => {
     const chain = chains.find(c => parseInt(c.chainId, 16) === BASE_SEPOLIA_CHAIN_ID);
@@ -287,25 +289,22 @@ const StorePacksAside: React.FC<any> = ({ setSelectedPack, selectedPack }) => {
 
   const isClaiming = phase === 'wallet-pending' || phase === 'video-playing' || phase === 'revealing';
 
+  const handleOpen = async () => {
+    if (!account) { await loadWeb3Modal(); return; }
+    if (!isOnRightChain) { await switchToBaseSepolia(); return; }
+    onClaim();
+  };
+
   const renderButton = () => {
     if (!isLivePack) {
       return <Button disabled styling="purple" width="100%">Not available (yet)</Button>;
     }
-    if (!account) {
-      return <Button disabled styling="purple" width="100%">Connect wallet to claim</Button>;
-    }
-    if (!isOnRightChain) {
-      return <Button styling="purple" width="100%" onClick={switchToBaseSepolia}>Switch to Base Sepolia</Button>;
-    }
-    if (phase === 'done') {
-      return <Button disabled styling="purple" width="100%">✓ Cards sent to your wallet!</Button>;
-    }
+    const label = phase === 'wallet-pending' ? 'Confirm in wallet…'
+      : isClaiming ? 'Opening pack…'
+      : 'Open Boosterpack';
     return (
-      <Button styling="purple" width="100%" disabled={isClaiming} onClick={onClaim}>
-        {phase === 'wallet-pending' ? 'Confirm in wallet…'
-          : phase === 'video-playing' ? 'Opening pack…'
-          : phase === 'revealing' ? 'Revealing…'
-          : 'Claim 3 cards'}
+      <Button styling="purple" width="100%" disabled={isClaiming} onClick={handleOpen}>
+        {label}
       </Button>
     );
   };

--- a/packages/app/src/views/Store/components/StorePacksAside.tsx
+++ b/packages/app/src/views/Store/components/StorePacksAside.tsx
@@ -1,168 +1,344 @@
-import React, { useContext, useRef, useEffect } from "react";
-import styled from "styled-components";
+import React, { useContext, useRef, useEffect, useState } from "react";
+import styled, { keyframes } from "styled-components";
 import { StyledStoreBody } from './index';
 import { Button, Title, Text, Spacer } from '../../../components';
 import { PepemonProviderContext } from '../../../contexts';
 import { StoreAside } from '../components';
 import { theme } from '../../../theme';
 import { useClaimBoosterPack } from '../../../hooks';
+import type { ReceivedCard } from '../../../hooks/useClaimBoosterPack';
 import chains from '../../../constants/chains';
 
 const BASE_SEPOLIA_CHAIN_ID = 84532;
+// Video plays a minimum of this long before card reveal starts, even if the chain confirms faster
+const VIDEO_MIN_MS = 6000;
 
-const FullScreenOverlay = styled.div`
+// ─── Animations ──────────────────────────────────────────────────────────────
+
+const popIn = keyframes`
+  0%   { transform: scale(0.4) translateY(60px); opacity: 0; }
+  70%  { transform: scale(1.08) translateY(-6px); opacity: 1; }
+  100% { transform: scale(1) translateY(0); opacity: 1; }
+`;
+
+const glow = keyframes`
+  0%, 100% { box-shadow: 0 0 18px 4px rgba(168, 85, 247, 0.5); }
+  50%       { box-shadow: 0 0 38px 12px rgba(168, 85, 247, 0.9), 0 0 60px 20px rgba(99,102,241,0.4); }
+`;
+
+// ─── Styled components ────────────────────────────────────────────────────────
+
+const Overlay = styled.div`
   position: fixed;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 100vh;
+  inset: 0;
   z-index: 9999;
   background: #000;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
   overflow: hidden;
 `;
 
-const OverlayVideo = styled.video`
+const FullVideo = styled.video`
+  position: absolute;
+  inset: 0;
   width: 100%;
   height: 100%;
   object-fit: cover;
 `;
 
-const ClaimRevealOverlay: React.FC<{ visible: boolean }> = ({ visible }) => {
-	const videoRef = useRef<HTMLVideoElement>(null);
+const RevealLayer = styled.div`
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+  padding: 24px;
+  width: 100%;
+  max-width: 480px;
+`;
 
-	useEffect(() => {
-		if (visible && videoRef.current) {
-			videoRef.current.currentTime = 0;
-			videoRef.current.play().catch(() => {/* autoplay may be blocked */});
-		} else if (!visible && videoRef.current) {
-			videoRef.current.pause();
-		}
-	}, [visible]);
+const CardRow = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  justify-content: center;
+`;
 
-	if (!visible) return null;
+const CardSlot = styled.div<{ delay: number; visible: boolean }>`
+  width: 120px;
+  opacity: ${p => (p.visible ? 1 : 0)};
+  animation: ${p => (p.visible ? popIn : 'none')} 0.6s cubic-bezier(0.34,1.56,0.64,1) ${p => p.delay}ms both;
+`;
 
-	return (
-		<FullScreenOverlay>
-			<OverlayVideo
-				ref={videoRef}
-				src="/videos/claim-reveal.mp4"
-				loop
-				playsInline
-			/>
-		</FullScreenOverlay>
-	);
+const CardImg = styled.img`
+  width: 100%;
+  border-radius: 12px;
+  animation: ${glow} 2s ease-in-out infinite;
+`;
+
+const CardBack = styled.div`
+  width: 100%;
+  aspect-ratio: 2/3;
+  border-radius: 12px;
+  background: linear-gradient(135deg, #4f46e5 0%, #7c3aed 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 32px;
+`;
+
+const CardName = styled.p`
+  color: #fff;
+  font-size: 11px;
+  text-align: center;
+  margin: 6px 0 0;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+`;
+
+const RevealTitle = styled.h2`
+  color: #fff;
+  font-size: 22px;
+  font-weight: 800;
+  text-align: center;
+  text-shadow: 0 0 20px rgba(168,85,247,0.8);
+  margin: 0;
+`;
+
+// ─── Card metadata ────────────────────────────────────────────────────────────
+
+interface CardMeta { image: string; name: string; }
+
+function useCardMeta(ids: number[]): Record<number, CardMeta> {
+  const [meta, setMeta] = useState<Record<number, CardMeta>>({});
+  useEffect(() => {
+    if (!ids.length) return;
+    const unique = Array.from(new Set(ids));
+    Promise.all(
+      unique.map(id =>
+        fetch(`/metadata/cards/${id}`)
+          .then(r => r.json())
+          .then(d => ({
+            id,
+            image: (d.image || '').replace('https://pepemon.world/', '/'),
+            name: d.name || `Card #${id}`,
+          }))
+          .catch(() => ({ id, image: '', name: `Card #${id}` }))
+      )
+    ).then(results => {
+      const m: Record<number, CardMeta> = {};
+      results.forEach(r => { m[r.id] = { image: r.image, name: r.name }; });
+      setMeta(m);
+    });
+  }, [ids.join(',')]);
+  return meta;
+}
+
+// ─── Reveal overlay ───────────────────────────────────────────────────────────
+
+interface RevealOverlayProps {
+  phase: 'idle' | 'wallet-pending' | 'video-playing' | 'revealing' | 'done';
+  receivedCards: ReceivedCard[];
+  packImageUrl: string;
+  onDismiss: () => void;
+}
+
+const RevealOverlay: React.FC<RevealOverlayProps> = ({ phase, receivedCards, packImageUrl, onDismiss }) => {
+  const videoRef    = useRef<HTMLVideoElement>(null);
+  const timerRef    = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [videoMinElapsed, setVideoMinElapsed] = useState(false);
+  const [revealedCount,   setRevealedCount]   = useState(0);
+
+  const showOverlay   = phase === 'video-playing' || phase === 'revealing';
+  const showReveal    = phase === 'revealing' && videoMinElapsed;
+  const showVideo     = showOverlay && !showReveal;
+
+  // Expand cards to individual items (2× card 2 → [2, 2])
+  const cardList = receivedCards.flatMap(c => Array(c.amount).fill(c.id));
+  const cardIds  = cardList.filter((v, i, a) => a.indexOf(v) === i);
+  const meta     = useCardMeta(showReveal ? cardIds : []);
+
+  // Start min-play timer when video phase begins
+  useEffect(() => {
+    if (phase === 'video-playing' && !videoMinElapsed) {
+      timerRef.current = setTimeout(() => setVideoMinElapsed(true), VIDEO_MIN_MS);
+    }
+    return () => { if (timerRef.current) clearTimeout(timerRef.current); };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [phase]);
+
+  // Play / pause video
+  useEffect(() => {
+    const v = videoRef.current;
+    if (!v) return;
+    if (showVideo) {
+      v.currentTime = 0;
+      v.play().catch(() => {});
+    } else {
+      v.pause();
+    }
+  }, [showVideo]);
+
+  // Reveal cards one by one once showReveal is true
+  useEffect(() => {
+    if (!showReveal || cardList.length === 0) return;
+    setRevealedCount(0);
+    cardList.forEach((_, i) => {
+      setTimeout(() => setRevealedCount(n => n + 1), 400 + i * 900);
+    });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showReveal]);
+
+  // Reset on close
+  useEffect(() => {
+    if (!showOverlay) {
+      setVideoMinElapsed(false);
+      setRevealedCount(0);
+      if (timerRef.current) clearTimeout(timerRef.current);
+    }
+  }, [showOverlay]);
+
+  if (!showOverlay) return null;
+
+  const allRevealed = revealedCount >= cardList.length && cardList.length > 0;
+
+  return (
+    <Overlay>
+      {/* Video is always rendered so browser can buffer it; visibility controlled via opacity */}
+      <FullVideo
+        ref={videoRef}
+        src="/videos/claim-reveal.mp4"
+        loop
+        muted
+        playsInline
+        style={{ opacity: showVideo ? 1 : 0, transition: 'opacity 0.8s' }}
+      />
+
+      {showReveal && (
+        <RevealLayer>
+          <RevealTitle>You got {cardList.length} {cardList.length === 1 ? 'card' : 'cards'}!</RevealTitle>
+          <CardRow>
+            {cardList.map((id, i) => {
+              const revealed = i < revealedCount;
+              const cardMeta = meta[id];
+              return (
+                <CardSlot key={i} delay={0} visible={revealed}>
+                  {revealed && cardMeta?.image
+                    ? <CardImg src={cardMeta.image} alt={cardMeta?.name || `Card #${id}`} />
+                    : <CardBack>✦</CardBack>
+                  }
+                  <CardName>{revealed ? (meta[id]?.name || `#${id}`) : '???'}</CardName>
+                </CardSlot>
+              );
+            })}
+          </CardRow>
+          {allRevealed && (
+            <Button styling="purple" width="100%" onClick={onDismiss}>
+              Claim another pack
+            </Button>
+          )}
+        </RevealLayer>
+      )}
+    </Overlay>
+  );
 };
 
-const StorePacksAside: React.FC<any> = ({setSelectedPack, selectedPack}) => {
-	const [pepemon] = useContext(PepemonProviderContext);
-	const { chainId, account } = pepemon;
+// ─── Main component ───────────────────────────────────────────────────────────
 
-	const onchainConfig = selectedPack?.onchainConfig ?? null;
-	const isLivePack = onchainConfig !== null;
-	const isOnRightChain = isLivePack && chainId === onchainConfig.chainId;
+const StorePacksAside: React.FC<any> = ({ setSelectedPack, selectedPack }) => {
+  const [pepemon] = useContext(PepemonProviderContext);
+  const { chainId, account } = pepemon;
 
-	const { onClaim, isClaiming, isSubmitted, claimError, claimSuccess } = useClaimBoosterPack(
-		onchainConfig ?? { chainId: 0, faucetAddress: '', packId: 0, cardIds: [] }
-	);
+  const onchainConfig = selectedPack?.onchainConfig ?? null;
+  const isLivePack    = onchainConfig !== null;
+  const isOnRightChain = isLivePack && chainId === onchainConfig.chainId;
 
-	const switchToBaseSepolia = async () => {
-		const chain = chains.find(c => parseInt(c.chainId, 16) === BASE_SEPOLIA_CHAIN_ID);
-		if (!chain || !window.ethereum) return;
-		try {
-			await (window.ethereum as any).request({
-				method: 'wallet_switchEthereumChain',
-				params: [{ chainId: chain.chainId }],
-			});
-		} catch (err: any) {
-			if (err.code === 4902) {
-				await (window.ethereum as any).request({
-					method: 'wallet_addEthereumChain',
-					params: [{
-						chainId: chain.chainId,
-						chainName: chain.chainName,
-						nativeCurrency: chain.nativeCurrency,
-						rpcUrls: chain.rpcUrls,
-						blockExplorerUrls: chain.blockExplorerUrls,
-					}],
-				});
-			}
-		}
-	};
+  const { onClaim, phase, receivedCards, claimError, onDismiss } = useClaimBoosterPack(
+    onchainConfig ?? { chainId: 0, faucetAddress: '', factoryAddress: '', packId: 0, cardIds: [] }
+  );
 
-	const renderButton = () => {
-		if (!isLivePack) {
-			return (
-				<Button disabled styling="purple" width="100%">
-					Not available (yet)
-				</Button>
-			);
-		}
+  const switchToBaseSepolia = async () => {
+    const chain = chains.find(c => parseInt(c.chainId, 16) === BASE_SEPOLIA_CHAIN_ID);
+    if (!chain || !window.ethereum) return;
+    try {
+      await (window.ethereum as any).request({
+        method: 'wallet_switchEthereumChain',
+        params: [{ chainId: chain.chainId }],
+      });
+    } catch (err: any) {
+      if (err.code === 4902) {
+        await (window.ethereum as any).request({
+          method: 'wallet_addEthereumChain',
+          params: [{
+            chainId: chain.chainId,
+            chainName: chain.chainName,
+            nativeCurrency: chain.nativeCurrency,
+            rpcUrls: chain.rpcUrls,
+            blockExplorerUrls: chain.blockExplorerUrls,
+          }],
+        });
+      }
+    }
+  };
 
-		if (!account) {
-			return (
-				<Button disabled styling="purple" width="100%">
-					Connect wallet to claim
-				</Button>
-			);
-		}
+  const isClaiming = phase === 'wallet-pending' || phase === 'video-playing' || phase === 'revealing';
 
-		if (!isOnRightChain) {
-			return (
-				<Button styling="purple" width="100%" onClick={switchToBaseSepolia}>
-					Switch to Base Sepolia
-				</Button>
-			);
-		}
+  const renderButton = () => {
+    if (!isLivePack) {
+      return <Button disabled styling="purple" width="100%">Not available (yet)</Button>;
+    }
+    if (!account) {
+      return <Button disabled styling="purple" width="100%">Connect wallet to claim</Button>;
+    }
+    if (!isOnRightChain) {
+      return <Button styling="purple" width="100%" onClick={switchToBaseSepolia}>Switch to Base Sepolia</Button>;
+    }
+    if (phase === 'done') {
+      return <Button disabled styling="purple" width="100%">✓ Cards sent to your wallet!</Button>;
+    }
+    return (
+      <Button styling="purple" width="100%" disabled={isClaiming} onClick={onClaim}>
+        {phase === 'wallet-pending' ? 'Confirm in wallet…'
+          : phase === 'video-playing' ? 'Opening pack…'
+          : phase === 'revealing' ? 'Revealing…'
+          : 'Claim 3 cards'}
+      </Button>
+    );
+  };
 
-		if (claimSuccess) {
-			return (
-				<Button disabled styling="purple" width="100%">
-					✓ Cards sent to your wallet!
-				</Button>
-			);
-		}
-
-		return (
-			<Button
-				styling="purple"
-				width="100%"
-				disabled={isClaiming}
-				onClick={onClaim}
-			>
-				{isClaiming && !isSubmitted ? 'Confirm in wallet…' : isClaiming ? 'Confirming on chain…' : 'Claim 3 cards'}
-			</Button>
-		);
-	};
-
-	return (
-		<>
-			<ClaimRevealOverlay visible={isSubmitted} />
-			<StoreAside close={() => setSelectedPack(null)} title="Selected Pack">
-				<StyledStoreBody>
-					<Title as="h2" font={theme.font.neometric} size='m'>{selectedPack.name}</Title>
-					<Spacer size="sm"/>
-					<Text as="p" font={theme.font.inter} size='s' lineHeight={1.3} color={theme.color.gray[600]}>
-						When claiming this booster pack you will recieve {selectedPack.cardsPerPack} random cards.
-					</Text>
-					<Spacer size="sm"/>
-					<img loading="lazy" src={selectedPack.url} alt={selectedPack.name} style={{width: "100%"}}/>
-					<Spacer size='md'/>
-					{renderButton()}
-					{claimError && (
-						<>
-							<Spacer size="sm"/>
-							<Text as="p" font={theme.font.inter} size='xs' color="red">
-								{claimError}
-							</Text>
-						</>
-					)}
-				</StyledStoreBody>
-			</StoreAside>
-		</>
-	);
+  return (
+    <>
+      <RevealOverlay
+        phase={phase}
+        receivedCards={receivedCards}
+        packImageUrl={selectedPack.url}
+        onDismiss={onDismiss}
+      />
+      <StoreAside close={() => setSelectedPack(null)} title="Selected Pack">
+        <StyledStoreBody>
+          <Title as="h2" font={theme.font.neometric} size='m'>{selectedPack.name}</Title>
+          <Spacer size="sm"/>
+          <Text as="p" font={theme.font.inter} size='s' lineHeight={1.3} color={theme.color.gray[600]}>
+            When claiming this booster pack you will recieve {selectedPack.cardsPerPack} random cards.
+          </Text>
+          <Spacer size="sm"/>
+          <img loading="lazy" src={selectedPack.url} alt={selectedPack.name} style={{ width: '100%' }}/>
+          <Spacer size='md'/>
+          {renderButton()}
+          {claimError && (
+            <>
+              <Spacer size="sm"/>
+              <Text as="p" font={theme.font.inter} size='xs' color="red">{claimError}</Text>
+            </>
+          )}
+        </StyledStoreBody>
+      </StoreAside>
+    </>
+  );
 };
 
 export default StorePacksAside;

--- a/packages/app/src/views/Store/components/StorePacksAside.tsx
+++ b/packages/app/src/views/Store/components/StorePacksAside.tsx
@@ -110,7 +110,7 @@ const AsideContent = styled.div`
   flex-direction: column;
 
   @media (min-width: ${theme.breakpoints.tabletL}) {
-    max-height: calc(100vh - 80px);
+    height: 100%;
     overflow: hidden;
   }
 `;
@@ -125,12 +125,10 @@ const ScrollableContent = styled.div`
 
 const StickyBottom = styled.div`
   @media (min-width: ${theme.breakpoints.tabletL}) {
-    position: sticky;
-    bottom: 0;
+    flex-shrink: 0;
     background: #fff;
     padding-top: 12px;
     border-top: 1px solid ${theme.color.gray[100]};
-    flex-shrink: 0;
   }
 `;
 
@@ -379,7 +377,7 @@ const StorePacksAside: React.FC<any> = ({ setSelectedPack, selectedPack }) => {
     <>
       <RevealOverlay phase={phase} receivedCards={receivedCards} onDismiss={onDismiss} />
       <StoreAside close={() => setSelectedPack(null)} title="Selected Pack">
-        <StyledStoreBody style={{ padding: 0 }}>
+        <StyledStoreBody style={{ padding: 0, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
           <AsideContent>
             <ScrollableContent style={{ padding: '1.1em' }}>
               <Title as="h2" font={theme.font.neometric} size='m'>{selectedPack.name}</Title>

--- a/packages/app/src/views/Store/components/StyledStoreComponents.tsx
+++ b/packages/app/src/views/Store/components/StyledStoreComponents.tsx
@@ -66,6 +66,12 @@ export const StyledStoreBody = styled.div`
     padding: 1.1em;
     border-bottom-left-radius: ${theme.borderRadius}px;;
     border-bottom-right-radius: ${theme.borderRadius}px;
+
+    @media (min-width: ${theme.breakpoints.tabletL}) {
+        flex: 1;
+        min-height: 0;
+        overflow-y: auto;
+    }
 `
 
 export const StyledStoreCardsWrapper = styled.div`

--- a/yarn.lock
+++ b/yarn.lock
@@ -808,7 +808,7 @@
     "@babel/helper-plugin-utils" "^7.20.2"
     "@babel/plugin-syntax-private-property-in-object" "^7.14.5"
 
-"@babel/plugin-proposal-unicode-property-regex@^7.18.6":
+"@babel/plugin-proposal-unicode-property-regex@^7.18.6", "@babel/plugin-proposal-unicode-property-regex@^7.4.4":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.18.6.tgz#af613d2cd5e643643b65cded64207b15c85cb78e"
   integrity sha512-2BShG/d5yoZyXZfVePH91urL5wTG6ASZU9M4o03lKK8u8UW1y08OMttBSOADTcJrnPMpvDXRG3G8fyLh4ovs8w==
@@ -1159,7 +1159,7 @@
     "@babel/helper-create-regexp-features-plugin" "^7.27.1"
     "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-dotall-regex@^7.29.7":
+"@babel/plugin-transform-dotall-regex@^7.29.7", "@babel/plugin-transform-dotall-regex@^7.4.4":
   version "7.29.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.29.7.tgz#b203de9740e4c7ff6b55ce436ed5313b88d70af8"
   integrity sha512-3qc18hsD2RdZiyJNDNc7HQpv6xbncwh8FYtxNFFzclSyh/trPD9KkVR9BDECUjDLvb7yJVF15GfYUuC+LMkkiQ==
@@ -9153,7 +9153,7 @@ esrecurse@^4.3.0:
   dependencies:
     estraverse "^5.2.0"
 
-estraverse@^4.1.1:
+estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
@@ -13049,7 +13049,7 @@ long@^5.0.0:
   resolved "https://registry.yarnpkg.com/long/-/long-5.3.2.tgz#1d84463095999262d7d7b7f8bfd4a8cc55167f83"
   integrity sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==
 
-loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -14000,7 +14000,7 @@ open@^8.0.9, open@^8.4.0:
     is-docker "^2.1.1"
     is-wsl "^2.2.0"
 
-optionator@^0.8.3:
+optionator@^0.8.1, optionator@^0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.3.tgz#84fa1d036fe9d3c7e21d99884b601167ec8fb495"
   integrity sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==


### PR DESCRIPTION
On top of latest main (react-scripts 5.0.1, Node 18.18):

- Add BoosterPackFaucet ABI + useClaimBoosterPack hook claimAndReveal(packId, cardIds[]) sends 3 cards in one tx
- Register Base Sepolia (0x14a34) in chains constant
- Allow chainId 84532 on /store in isSupportedChain
- Wire Battle Monsters 3-card pack to live onchainConfig (faucet 0x353490205cBe9fB473443619C95779Bde640e76C, pack 2)
- Rewrite StorePacksAside: wrong-chain prompt, connect-wallet prompt, claim button with loading/success/error states
- Full-screen video overlay (claim-reveal.mp4) plays between wallet confirmation and chain confirmation, auto-dismisses 🤖 Generated with [Nori](https://noriagentic.com)