### PR TITLE
feat: move boosterpack action buttons to top of Selected Pack panel

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1,95 +1,95 @@
-import React, { Suspense, lazy } from 'react';
-import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
-import { ThemeProvider } from 'styled-components';
-import { Page, TopBar, ScrollToTop } from './components';
-import { ModalsProvider, PepemonProvider } from './contexts';
-import { withConnectedWallet } from './hocs';
-import { theme } from './theme';
-import { metas, LoadingPage } from './views';
+import React, { Suspense, lazy } from "react";
+import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
+import { ThemeProvider } from "styled-components";
+import { Page, TopBar, ScrollToTop } from "./components";
+import { ModalsProvider, PepemonProvider } from "./contexts";
+import { withConnectedWallet } from "./hocs";
+import { theme } from "./theme";
+import { metas, LoadingPage } from "./views";
 const Home = lazy(() =>
-	import('./views/Home').then((module) => ({ default: module.default }))
+  import("./views/Home").then((module) => ({ default: module.default }))
 );
 const Staking = lazy(() =>
-	import('./views/Staking').then((module) => ({ default: module.default }))
+  import("./views/Staking").then((module) => ({ default: module.default }))
 );
 const Bridge = lazy(() =>
-	import('./views/Bridge').then((module) => ({ default: module.default }))
+  import("./views/Bridge").then((module) => ({ default: module.default }))
 );
 const Subscription = lazy(() =>
-	import('./views/Subscription').then((module) => ({ default: module.default }))
+  import("./views/Subscription").then((module) => ({ default: module.default }))
 );
 const Store = lazy(() =>
-	import('./views/Store').then((module) => ({ default: module.default }))
+  import("./views/Store").then((module) => ({ default: module.default }))
 );
 const TermsOfService = lazy(() =>
-	import('./views/TermsOfService').then((module) => ({
-		default: module.default,
-	}))
+  import("./views/TermsOfService").then((module) => ({
+    default: module.default,
+  }))
 );
 const PrivacyPolicy = lazy(() =>
-	import('./views/PrivacyPolicy').then((module) => ({
-		default: module.default,
-	}))
+  import("./views/PrivacyPolicy").then((module) => ({
+    default: module.default,
+  }))
 );
 const Error404 = lazy(() =>
-	import('./views/Error404').then((module) => ({ default: module.default }))
+  import("./views/Error404").then((module) => ({ default: module.default }))
 );
 
 const StakingWithAuth = withConnectedWallet(Staking, {
-	metas: metas.stakingMeta,
+  metas: metas.stakingMeta,
 });
 const SubscriptionWithAuth = withConnectedWallet(Subscription, {
-	metas: metas.subscriptionMeta,
+  metas: metas.subscriptionMeta,
 });
 const StoreWithAuth = withConnectedWallet(Store, { metas: metas.storeMeta });
 const BridgeWithAuth = withConnectedWallet(Bridge, { metas: metas.storeMeta });
 
 const App: React.FC = () => {
-	return (
-		<Providers>
-			<TopBar />
-			<Page>
-				<Suspense fallback={<LoadingPage />}>
-					<Switch>
-						<Route path='/' exact>
-							<Home />
-						</Route>
-						<Route path='/staking'>
-							<StakingWithAuth />
-						</Route>
-						<Route path='/bridge/:bridgeState(testnet|claim-ppblz|mint-pepemon-badges|bid-on-pepesea)?'>
-							<BridgeWithAuth />
-						</Route>
-						<Route path='/subscription'>
-							<SubscriptionWithAuth />
-						</Route>
-						<Route path='/store/:storeState(cards|boosterpacks)?'>
-							<StoreWithAuth />
-						</Route>
-						<Route path='/terms-of-service' component={TermsOfService} />
-						<Route path='/privacy-policy' component={PrivacyPolicy} />
-						<Route path={['/events', '/my-collection']}>
-							<Error404 title='This page will be available soon👀' />
-						</Route>
-						<Route component={Error404} />
-					</Switch>
-				</Suspense>
-			</Page>
-			<ScrollToTop />
-		</Providers>
-	);
+  return (
+    <Providers>
+      <TopBar />
+      <Page>
+        <Suspense fallback={<LoadingPage />}>
+          <Switch>
+            <Route path="/" exact>
+              <Home />
+            </Route>
+            <Route path="/staking">
+              <StakingWithAuth />
+            </Route>
+            <Route path="/bridge/:bridgeState(testnet|claim-ppblz|mint-pepemon-badges|bid-on-pepesea)?">
+              <BridgeWithAuth />
+            </Route>
+            <Route path="/subscription">
+              <SubscriptionWithAuth />
+            </Route>
+            <Route path="/store/:storeState(cards|boosterpacks)?">
+              <StoreWithAuth />
+            </Route>
+            <Route path="/terms-of-service" component={TermsOfService} />
+            <Route path="/privacy-policy" component={PrivacyPolicy} />
+            <Route path={["/events", "/my-collection"]}>
+              <Error404 title="This page will be available soon👀" />
+            </Route>
+            <Route component={Error404} />
+          </Switch>
+        </Suspense>
+      </Page>
+      <ScrollToTop />
+    </Providers>
+  );
 };
 
 const Providers: React.FC<any> = ({ children }) => {
-	return (
-		<ThemeProvider theme={theme}>
-			<Router>
-				<PepemonProvider>
-					<ModalsProvider>{children}</ModalsProvider>
-				</PepemonProvider>
-			</Router>
-		</ThemeProvider>
-	);
+  return (
+    <ThemeProvider theme={theme}>
+      <Router>
+        <PepemonProvider>
+          <ModalsProvider>{children}</ModalsProvider>
+        </PepemonProvider>
+      </Router>
+    </ThemeProvider>
+  );
 };
 
 export default App;

--- a/packages/app/src/assets/img/icons/ActionClose.tsx
+++ b/packages/app/src/assets/img/icons/ActionClose.tsx
@@ -1,9 +1,14 @@
-import * as React from "react"
-import styled from 'styled-components';
+import * as React from "react";
+import styled from "styled-components";
 
 const ActionClose = (props: any) => {
   return (
-    <StyledActionClose width={24} height={24} xmlns="http://www.w3.org/2000/svg" {...props}>
+    <StyledActionClose
+      width={24}
+      height={24}
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
       <g fill="none" fillRule="evenodd" opacity={0.75}>
         <circle fill="#F2F2F2" cx={12} cy={12} r={12} />
         <path
@@ -13,13 +18,17 @@ const ActionClose = (props: any) => {
         />
       </g>
     </StyledActionClose>
-  )
-}
+  );
+};
 
-const StyledActionClose = styled.svg<{width: number, height: number, xmlns: string}>`
-    &:hover {
-        cursor: pointer;
-    }
-`
+const StyledActionClose = styled.svg<{
+  width: number;
+  height: number;
+  xmlns: string;
+}>`
+  &:hover {
+    cursor: pointer;
+  }
+`;
 
 export default ActionClose;

--- a/packages/app/src/assets/img/icons/Check.tsx
+++ b/packages/app/src/assets/img/icons/Check.tsx
@@ -1,11 +1,25 @@
-import React from 'react';
+import React from "react";
 
-const Check : React.FC<{className?: string, strokeWidth?: number}> = ({className, strokeWidth}) => {
-	return (
-		<svg xmlns="http://www.w3.org/2000/svg" className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
-		  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={strokeWidth ? strokeWidth : 5} d="M5 13l4 4L19 7" />
-		</svg>
-	)
-}
+const Check: React.FC<{ className?: string; strokeWidth?: number }> = ({
+  className,
+  strokeWidth,
+}) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth ? strokeWidth : 5}
+        d="M5 13l4 4L19 7"
+      />
+    </svg>
+  );
+};
 
 export default Check;

--- a/packages/app/src/assets/img/icons/ChevronDown.tsx
+++ b/packages/app/src/assets/img/icons/ChevronDown.tsx
@@ -1,11 +1,25 @@
-import React from 'react';
+import React from "react";
 
-const ChevronDown : React.FC<{className?: string, strokeWidth?: number}> = ({className, strokeWidth}) => {
-	return (
-		<svg xmlns="http://www.w3.org/2000/svg" className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
-			<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={strokeWidth ? strokeWidth : 5} d="M19 9l-7 7-7-7" />
-		</svg>
-	)
-}
+const ChevronDown: React.FC<{ className?: string; strokeWidth?: number }> = ({
+  className,
+  strokeWidth,
+}) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={strokeWidth ? strokeWidth : 5}
+        d="M19 9l-7 7-7-7"
+      />
+    </svg>
+  );
+};
 
 export default ChevronDown;

--- a/packages/app/src/assets/img/icons/MenuIcon.tsx
+++ b/packages/app/src/assets/img/icons/MenuIcon.tsx
@@ -1,20 +1,20 @@
-import React from 'react';
-import styled, { keyframes, css } from 'styled-components';
-import { theme } from '../../../theme';
+import React from "react";
+import styled, { keyframes, css } from "styled-components";
+import { theme } from "../../../theme";
 
 interface MenuIconProps {
-	isOpen: boolean
+  isOpen: boolean;
 }
 
 const MenuIcon: React.FC<MenuIconProps> = ({ isOpen }) => {
-	return (
-		<StyledMenuIcon isOpen={isOpen}>
-			<TopStroke/>
-			<MiddleStroke/>
-			<BottomStroke/>
-		</StyledMenuIcon>
-	)
-}
+  return (
+    <StyledMenuIcon isOpen={isOpen}>
+      <TopStroke />
+      <MiddleStroke />
+      <BottomStroke />
+    </StyledMenuIcon>
+  );
+};
 
 const animateTop = keyframes`
 	0% {
@@ -29,7 +29,7 @@ const animateTop = keyframes`
 		top: 50%;
 		transform: translateY(-50%) rotate(45deg);
 	}
-`
+`;
 
 const animateBottom = keyframes`
 	0% {
@@ -44,52 +44,57 @@ const animateBottom = keyframes`
 		top: 50%;
 		transform: translateY(-50%) rotate(-45deg);
 	}
-`
+`;
 
 const animateTopCss = css`
-	animation: ${animateTop} .2s ease-out 0s 1 normal forwards;
-`
+  animation: ${animateTop} 0.2s ease-out 0s 1 normal forwards;
+`;
 
 const animateBottomCss = css`
-	animation: ${animateBottom} .2s ease-out 0s 1 normal forwards;
-`
+  animation: ${animateBottom} 0.2s ease-out 0s 1 normal forwards;
+`;
 
 const StyledSpan = styled.span`
-	left: 0;
-	position: absolute;
-	right: 0;
-`
+  left: 0;
+  position: absolute;
+  right: 0;
+`;
 
 const TopStroke = styled(StyledSpan)`
-	top: 0%;
-`
+  top: 0%;
+`;
 
 const MiddleStroke = styled(StyledSpan)`
-	top: 50%;
-	transform: translateY(-50%);
-`
+  top: 50%;
+  transform: translateY(-50%);
+`;
 
 const BottomStroke = styled(StyledSpan)`
-	top: 100%;
-	transform: translateY(-50%);
-`
+  top: 100%;
+  transform: translateY(-50%);
+`;
 
 const StyledMenuIcon = styled.div<MenuIconProps>`
-	height: 15px;
-	position: relative;
-	transition: all 1s ease-in;
-	width: 20px;
+  height: 15px;
+  position: relative;
+  transition: all 1s ease-in;
+  width: 20px;
 
-	span {
-		background-color: ${theme.color.black};
-		display: block;
-		height: 2px;
-	}
+  span {
+    background-color: ${theme.color.black};
+    display: block;
+    height: 2px;
+  }
 
+  ${TopStroke} {
+    ${({ isOpen }) => isOpen && animateTopCss}
+  }
+  ${MiddleStroke} {
+    ${({ isOpen }) => isOpen && "display: none;"}
+  }
+  ${BottomStroke} {
+    ${({ isOpen }) => isOpen && animateBottomCss}
+  }
+`;
 
-		${TopStroke} { ${({isOpen}) => isOpen && animateTopCss } }
-		${MiddleStroke} { ${({isOpen}) => isOpen && 'display: none;' } }
-		${BottomStroke} { ${({isOpen}) => isOpen && animateBottomCss } }
-`
-
-export default MenuIcon
+export default MenuIcon;

--- a/packages/app/src/components/Accordion/Accordion.tsx
+++ b/packages/app/src/components/Accordion/Accordion.tsx
@@ -1,115 +1,138 @@
-import React, { useState } from 'react';
-import styled from 'styled-components';
-import { Title } from '../../components';
-import { theme } from '../../theme';
-import { pepeball, uparrow, dropdownarrow } from '../../assets';
+import React, { useState } from "react";
+import styled from "styled-components";
+import { Title } from "../../components";
+import { theme } from "../../theme";
+import { pepeball, uparrow, dropdownarrow } from "../../assets";
 
 interface AccordionProps {
-	title: string,
-	isOpen?: boolean,
-	isActive?: boolean,
-	children: any,
+  title: string;
+  isOpen?: boolean;
+  isActive?: boolean;
+  children: any;
 }
 
-const Accordion: React.FC<AccordionProps> = ({title, isOpen = true, isActive = false, children}) => {
-	const [openAccordion, setOpenAccordion] = useState(isOpen);
-	const toggleAccordion = () => {
-		setOpenAccordion(!openAccordion)
-	}
+const Accordion: React.FC<AccordionProps> = ({
+  title,
+  isOpen = true,
+  isActive = false,
+  children,
+}) => {
+  const [openAccordion, setOpenAccordion] = useState(isOpen);
+  const toggleAccordion = () => {
+    setOpenAccordion(!openAccordion);
+  };
 
-	return (
-		<AccordionWrapper isActive={isActive} >
-			<AccordionHeader onClick={toggleAccordion} isOpen={openAccordion}>
-				<AccordionHeaderTitle>
-					<img loading="lazy" src={pepeball} alt="Pepeball" style={{ width: "40px", height: "40px", marginRight: "1em" }}/>
-					<Title as="h2" color={openAccordion ? theme.color.green[200] : theme.color.white} weight={900} font={theme.font.neometric}>{title}</Title>
-				</AccordionHeaderTitle>
-				<AccordionHeaderButton onClick={toggleAccordion}>
-						<span>Show {openAccordion ? "less" : "more"}</span>
-						<img loading="lazy" src={openAccordion ? uparrow : dropdownarrow} alt="logo" style={{ height: "0.5em", alignSelf: "center", }}/>
-				</AccordionHeaderButton>
-			</AccordionHeader>
-			<AccordionBody isOpen={openAccordion}>
-				{children}
-			</AccordionBody>
-		</AccordionWrapper>
-	)
-}
+  return (
+    <AccordionWrapper isActive={isActive}>
+      <AccordionHeader onClick={toggleAccordion} isOpen={openAccordion}>
+        <AccordionHeaderTitle>
+          <img
+            loading="lazy"
+            src={pepeball}
+            alt="Pepeball"
+            style={{ width: "40px", height: "40px", marginRight: "1em" }}
+          />
+          <Title
+            as="h2"
+            color={openAccordion ? theme.color.green[200] : theme.color.white}
+            weight={900}
+            font={theme.font.neometric}
+          >
+            {title}
+          </Title>
+        </AccordionHeaderTitle>
+        <AccordionHeaderButton onClick={toggleAccordion}>
+          <span>Show {openAccordion ? "less" : "more"}</span>
+          <img
+            loading="lazy"
+            src={openAccordion ? uparrow : dropdownarrow}
+            alt="logo"
+            style={{ height: "0.5em", alignSelf: "center" }}
+          />
+        </AccordionHeaderButton>
+      </AccordionHeader>
+      <AccordionBody isOpen={openAccordion}>{children}</AccordionBody>
+    </AccordionWrapper>
+  );
+};
 
 export const AccordionGroup = styled.section`
-	display: flex;
-	flex-direction: column;
-`
+  display: flex;
+  flex-direction: column;
+`;
 
-export const AccordionWrapper = styled.div<{isActive: boolean}>`
-	border: 2px solid ${props => props.isActive ? `${props.theme.color.green[200]}` : 'transparent'};;
-	background-color: ${theme.color.purple[800]};
-	border-radius: ${theme.borderRadius}px;
-	margin-bottom: .8em;
-	width: 100%;
-`
+export const AccordionWrapper = styled.div<{ isActive: boolean }>`
+  border: 2px solid
+    ${(props) =>
+      props.isActive ? `${props.theme.color.green[200]}` : "transparent"};
+  background-color: ${theme.color.purple[800]};
+  border-radius: ${theme.borderRadius}px;
+  margin-bottom: 0.8em;
+  width: 100%;
+`;
 
-export const AccordionHeader = styled.div<{isOpen: boolean}>`
-	cursor: pointer;
-	display: flex;
-	justify-content: space-between;
-	padding: clamp(1.125em,3.75vw,1.2em) clamp(.8em,2.65vw,2em);
-`
+export const AccordionHeader = styled.div<{ isOpen: boolean }>`
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  padding: clamp(1.125em, 3.75vw, 1.2em) clamp(0.8em, 2.65vw, 2em);
+`;
 
 export const AccordionHeaderTitle = styled.div`
-	display: flex;
-	align-items: center;
-`
+  display: flex;
+  align-items: center;
+`;
 
 export const AccordionHeaderButton = styled.button`
-	align-items: center;
-	background-color: ${theme.color.transparent};
-	border: none;
-	border-radius: 8px;
-	color: ${theme.color.white};
-	cursor: pointer;
-	display: flex;
-	font-family: ${theme.font.neometric};
-	font-size: 0.75rem;
+  align-items: center;
+  background-color: ${theme.color.transparent};
+  border: none;
+  border-radius: 8px;
+  color: ${theme.color.white};
+  cursor: pointer;
+  display: flex;
+  font-family: ${theme.font.neometric};
+  font-size: 0.75rem;
 
-	img {
-		margin-left: .7em;
-	}
+  img {
+    margin-left: 0.7em;
+  }
 
-	&:focus-visible {
-		outline: none;
-		box-shadow: 0px 0px 10px 5px ${theme.color.purple[600]};
-	}
+  &:focus-visible {
+    outline: none;
+    box-shadow: 0px 0px 10px 5px ${theme.color.purple[600]};
+  }
 
-	span {
-		display: none;
+  span {
+    display: none;
 
-		@media (min-width: ${theme.breakpoints.tabletP}) {
-			display: inline;
-		}
-	}
-`
+    @media (min-width: ${theme.breakpoints.tabletP}) {
+      display: inline;
+    }
+  }
+`;
 
-export const AccordionBody = styled.div<{isOpen: boolean}>`
-	background-color: ${theme.color.white};
-	border-bottom-left-radius: ${theme.borderRadius}px;
-	border-bottom-right-radius: ${theme.borderRadius}px;
-	display: ${props => props.isOpen ? 'flex' : 'none'};
-	flex-direction: column;
-	justify-content: space-between;
-	padding: clamp(1.125em,3.75vw,1.2em) clamp(.8em,2.65vw,2em) 2em;
+export const AccordionBody = styled.div<{ isOpen: boolean }>`
+  background-color: ${theme.color.white};
+  border-bottom-left-radius: ${theme.borderRadius}px;
+  border-bottom-right-radius: ${theme.borderRadius}px;
+  display: ${(props) => (props.isOpen ? "flex" : "none")};
+  flex-direction: column;
+  justify-content: space-between;
+  padding: clamp(1.125em, 3.75vw, 1.2em) clamp(0.8em, 2.65vw, 2em) 2em;
 
-	@media (min-width: ${theme.breakpoints.tabletP}) {
-		flex-direction: row;
-	}
-`
+  @media (min-width: ${theme.breakpoints.tabletP}) {
+    flex-direction: row;
+  }
+`;
 
-export const AccordionBodyContent = styled.div<{side: "left" | "right"}>`
-	@media (min-width: ${theme.breakpoints.tabletP}) {
-		border-left: ${props => props.side === "right" && `2px solid ${theme.color.colorsLayoutBorders}`};
-		padding-left: ${props => props.side === "right" && "5.5em"};
-		padding-right: ${props => props.side === "left" ? "5.5em" : "2.5em"};
-	}
-`
+export const AccordionBodyContent = styled.div<{ side: "left" | "right" }>`
+  @media (min-width: ${theme.breakpoints.tabletP}) {
+    border-left: ${(props) =>
+      props.side === "right" && `2px solid ${theme.color.colorsLayoutBorders}`};
+    padding-left: ${(props) => props.side === "right" && "5.5em"};
+    padding-right: ${(props) => (props.side === "left" ? "5.5em" : "2.5em")};
+  }
+`;
 
 export default Accordion;

--- a/packages/app/src/components/Accordion/index.ts
+++ b/packages/app/src/components/Accordion/index.ts
@@ -1,1 +1,10 @@
-export { default, AccordionGroup, AccordionWrapper, AccordionHeader, AccordionHeaderTitle, AccordionHeaderButton, AccordionBody, AccordionBodyContent } from './Accordion'
+export {
+  default,
+  AccordionGroup,
+  AccordionWrapper,
+  AccordionHeader,
+  AccordionHeaderTitle,
+  AccordionHeaderButton,
+  AccordionBody,
+  AccordionBodyContent,
+} from "./Accordion";

--- a/packages/app/src/components/AnimatedImg/index.ts
+++ b/packages/app/src/components/AnimatedImg/index.ts
@@ -1,1 +1,1 @@
-export { default } from './AnimatedImg';
+export { default } from "./AnimatedImg";

--- a/packages/app/src/components/Badge/Badge.tsx
+++ b/packages/app/src/components/Badge/Badge.tsx
@@ -1,21 +1,21 @@
-import React from 'react';
-import styled from 'styled-components';
-import { theme } from '../../theme';
+import React from "react";
+import styled from "styled-components";
+import { theme } from "../../theme";
 
-const Badge: React.FC<{text: string}> = ({text}) => {
-	return <StyledBadge>{text}</StyledBadge>
-}
+const Badge: React.FC<{ text: string }> = ({ text }) => {
+  return <StyledBadge>{text}</StyledBadge>;
+};
 
 const StyledBadge = styled.span`
-	background-image: linear-gradient(to bottom,#aa6cd6 -100%,#713aac);
-	border-radius: 8px;
-	padding: 3px 5px;
-	color: ${theme.color.white};
-	font-family: "Inter";
-	font-size: .7rem;
-	position: absolute;
-	right: -2em;
-	top: -1.2em;
-`
+  background-image: linear-gradient(to bottom, #aa6cd6 -100%, #713aac);
+  border-radius: 8px;
+  padding: 3px 5px;
+  color: ${theme.color.white};
+  font-family: "Inter";
+  font-size: 0.7rem;
+  position: absolute;
+  right: -2em;
+  top: -1.2em;
+`;
 
 export default Badge;

--- a/packages/app/src/components/Badge/index.ts
+++ b/packages/app/src/components/Badge/index.ts
@@ -1,1 +1,1 @@
-export { default } from './Badge';
+export { default } from "./Badge";

--- a/packages/app/src/components/Button/Button.tsx
+++ b/packages/app/src/components/Button/Button.tsx
@@ -1,14 +1,14 @@
 import styled, { css, keyframes } from "styled-components";
 import { theme } from "../../theme";
 // import { Link } from "react-router-dom";
-import { HashLink as Link } from 'react-router-hash-link';
+import { HashLink as Link } from "react-router-hash-link";
 
 export interface ButtonProps {
-	disabled?: boolean;
-	styling?: "purple" | "green" | "white" | "link" | "white_borderless";
-	symbol?: boolean;
-	width?: string;
-	onClick?: () => void;
+  disabled?: boolean;
+  styling?: "purple" | "green" | "white" | "link" | "white_borderless";
+  symbol?: boolean;
+  width?: string;
+  onClick?: () => void;
 }
 
 const showAndHide = keyframes`
@@ -21,63 +21,81 @@ const showAndHide = keyframes`
 	100% {
 		opacity: 0;
 	}
-`
+`;
 
 // TODO: any => ButtonProps
 const Button = styled.button<any>`
-	&{
-		border-width: 1px;
-		border-style: solid;
-		border-radius: 8px;
-		box-shadow: ${props => (!props.disabled && props.styling !== "link") && `0 4px 10px 0 ${theme.color.colorsLayoutShadows}`};
-		cursor: ${props => props.disabled ? "not-allowed" : "pointer"};
-		font-family: ${props => props.styling === "link" ? theme.font.inter : theme.font.spaceMace};
-		font-size: ${props => props.symbol ? "clamp(1.4rem, 2.65vw, 2rem)" : "clamp(.9rem, 2vw, 1rem)"};
-		font-weight: ${props => props.styling !== "link" && "bold"};
-		text-align: center;
-		text-transform: ${props => props.styling !== "link" && "uppercase"};
-		opacity: ${props => props.disabled && .5};
-		padding: ${props => props.symbol ? ".22em 0" : ".75em 1.5em"};
-		position: relative;
-		transition: all .4s;
-		width: ${props => props.width && props.width};
-	}
+  & {
+    border-width: 1px;
+    border-style: solid;
+    border-radius: 8px;
+    box-shadow: ${(props) =>
+      !props.disabled &&
+      props.styling !== "link" &&
+      `0 4px 10px 0 ${theme.color.colorsLayoutShadows}`};
+    cursor: ${(props) => (props.disabled ? "not-allowed" : "pointer")};
+    font-family: ${(props) =>
+      props.styling === "link" ? theme.font.inter : theme.font.spaceMace};
+    font-size: ${(props) =>
+      props.symbol ? "clamp(1.4rem, 2.65vw, 2rem)" : "clamp(.9rem, 2vw, 1rem)"};
+    font-weight: ${(props) => props.styling !== "link" && "bold"};
+    text-align: center;
+    text-transform: ${(props) => props.styling !== "link" && "uppercase"};
+    opacity: ${(props) => props.disabled && 0.5};
+    padding: ${(props) => (props.symbol ? ".22em 0" : ".75em 1.5em")};
+    position: relative;
+    transition: all 0.4s;
+    width: ${(props) => props.width && props.width};
+  }
 
-	&:focus-visible {
-		outline: none;
-		box-shadow: ${props => (!props.disabled && props.styling !== "link") && `0px 0px 10px 5px ${theme.color.purple[600]}`};
-		filter: ${props => (!props.disabled && props.styling === "link") && `drop-shadow(2px 2px 3px ${theme.color.purple[600]})`};
-	}
+  &:focus-visible {
+    outline: none;
+    box-shadow: ${(props) =>
+      !props.disabled &&
+      props.styling !== "link" &&
+      `0px 0px 10px 5px ${theme.color.purple[600]}`};
+    filter: ${(props) =>
+      !props.disabled &&
+      props.styling === "link" &&
+      `drop-shadow(2px 2px 3px ${theme.color.purple[600]})`};
+  }
 
-	&[aria-label]:not([aria-label=""]) {
-		&::after {
-			background-image: linear-gradient(to bottom, #aa6cd6 -100%, ${theme.color.purple[600]});
-			border-radius: 8px;
-			color: ${theme.color.white};
-			content: attr(aria-label);
-			font-family: ${theme.font.inter};
-			font-size: 0.4em;
-			left: 50%;
-			opacity: 0;
-			position: absolute;
-			bottom: 100%;
-			padding: .2em .3em;
-			transition: opacity .4s ease-in;
-			transform: translateY(-.2em) translateX(-50%);
-			z-index: 1;
-		}
+  &[aria-label]:not([aria-label=""]) {
+    &::after {
+      background-image: linear-gradient(
+        to bottom,
+        #aa6cd6 -100%,
+        ${theme.color.purple[600]}
+      );
+      border-radius: 8px;
+      color: ${theme.color.white};
+      content: attr(aria-label);
+      font-family: ${theme.font.inter};
+      font-size: 0.4em;
+      left: 50%;
+      opacity: 0;
+      position: absolute;
+      bottom: 100%;
+      padding: 0.2em 0.3em;
+      transition: opacity 0.4s ease-in;
+      transform: translateY(-0.2em) translateX(-50%);
+      z-index: 1;
+    }
 
-		&:hover::after {
-			animation: 2s ${showAndHide} ease-out;
-		}
-	}
+    &:hover::after {
+      animation: 2s ${showAndHide} ease-out;
+    }
+  }
 
-
-	${({disabled}) => disabled && `
+  ${({ disabled }) =>
+    disabled &&
+    `
 		pointer-events: none;
 	`}
 
-	${({styling}) => styling === "purple" && `
+  ${({ styling }) =>
+    styling === "purple" &&
+    `
 		background-image: linear-gradient(to bottom, #aa6cd6 -100%, ${theme.color.purple[600]});
 		border-color: transparent;
 		color: ${theme.color.white};
@@ -89,7 +107,9 @@ const Button = styled.button<any>`
 		}
 	`}
 
-	${({styling}) => styling === "white" && `
+	${({ styling }) =>
+    styling === "white" &&
+    `
 		background-image: linear-gradient(${theme.color.white}, ${theme.color.white});
 		border-color: ${theme.color.purple[600]};
 		color: ${theme.color.purple[600]};
@@ -101,13 +121,17 @@ const Button = styled.button<any>`
 		}
 	`}
 
-	${({styling}) => styling === "white_borderless" && `
+	${({ styling }) =>
+    styling === "white_borderless" &&
+    `
 		background-color: ${theme.color.white};
 		border-color: transparent;
 		color: ${theme.color.purple[600]};
 	`}
 
-	${({styling}) => styling === "green" && `
+	${({ styling }) =>
+    styling === "green" &&
+    `
 		background-image: linear-gradient(to bottom, ${theme.color.green[100]}, ${theme.color.green[200]});
 		border-color: transparent;
 		color: ${theme.color.purple[800]};
@@ -118,7 +142,9 @@ const Button = styled.button<any>`
 		}
 	`}
 
-	${({styling}) => styling === "link" && `
+	${({ styling }) =>
+    styling === "link" &&
+    `
 		background-color: transparent;
 		border-color: transparent;
 		color: ${theme.color.purple[600]};
@@ -131,42 +157,50 @@ const Button = styled.button<any>`
 `;
 
 export interface ButtonLinkProps {
-	light?: boolean;
-	shadow?: boolean;
+  light?: boolean;
+  shadow?: boolean;
 }
 
 export const buttonLinksStyling = css<ButtonLinkProps>`
-	background: ${props => props.light ? props.theme.color.white : `linear-gradient(to bottom, #aa6cd6 -100%, ${props.theme.color.purple[600]})`};
-	border-color: ${props => props.light ? props.theme.color.purple[600] : 'transparent'};
-	border-radius: 8px;
-	border-style: solid;
-	border-width: 1px;
-	box-shadow: ${props => props.shadow && `0 4px 10px 0 ${theme.color.colorsLayoutShadows}`};
-	color: ${props => props.light ? props.theme.color.purple[600] : props.theme.color.typographyAllTextOnDark};
-	font-family: ${props => props.theme.font.spaceMace};
-	padding: .75em 1.5em;
-	text-align: center;
-	text-decoration: none;
-	text-transform: uppercase;
-	transition-property: opacity, background, border-color, color, box-shadow;
-	transition-duration: .2s;
-	transition-timing-function: ease-in-out;
-	position: relative;
-	z-index: 1;
+  background: ${(props) =>
+    props.light
+      ? props.theme.color.white
+      : `linear-gradient(to bottom, #aa6cd6 -100%, ${props.theme.color.purple[600]})`};
+  border-color: ${(props) =>
+    props.light ? props.theme.color.purple[600] : "transparent"};
+  border-radius: 8px;
+  border-style: solid;
+  border-width: 1px;
+  box-shadow: ${(props) =>
+    props.shadow && `0 4px 10px 0 ${theme.color.colorsLayoutShadows}`};
+  color: ${(props) =>
+    props.light
+      ? props.theme.color.purple[600]
+      : props.theme.color.typographyAllTextOnDark};
+  font-family: ${(props) => props.theme.font.spaceMace};
+  padding: 0.75em 1.5em;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition-property: opacity, background, border-color, color, box-shadow;
+  transition-duration: 0.2s;
+  transition-timing-function: ease-in-out;
+  position: relative;
+  z-index: 1;
 
-	&:hover {
-		opacity: .7;
-		box-shadow: 0 4px 10px 0 ${theme.color.colorsLayoutShadows};
-	}
+  &:hover {
+    opacity: 0.7;
+    box-shadow: 0 4px 10px 0 ${theme.color.colorsLayoutShadows};
+  }
 
-	&:focus-visible {
-		filter: drop-shadow(2px 2px 3px ${theme.color.purple[600]});
-		outline: none;
-	}
-`
+  &:focus-visible {
+    filter: drop-shadow(2px 2px 3px ${theme.color.purple[600]});
+    outline: none;
+  }
+`;
 
 export const ButtonLink = styled(Link)<ButtonLinkProps>`
-	${buttonLinksStyling}
-`
+  ${buttonLinksStyling}
+`;
 
 export default Button;

--- a/packages/app/src/components/Button/index.ts
+++ b/packages/app/src/components/Button/index.ts
@@ -1,2 +1,2 @@
-export { default, ButtonLink } from './Button'
-export type { ButtonProps } from './Button';
+export { default, ButtonLink } from "./Button";
+export type { ButtonProps } from "./Button";

--- a/packages/app/src/components/Card/Card.tsx
+++ b/packages/app/src/components/Card/Card.tsx
@@ -1,28 +1,30 @@
-import React from 'react'
-import styled from 'styled-components'
+import React from "react";
+import styled from "styled-components";
 
 interface CardProps {
-    children?: React.ReactNode,
-    disabled?: boolean,
-    boosted?: boolean,
+  children?: React.ReactNode;
+  disabled?: boolean;
+  boosted?: boolean;
 }
 
-const Card: React.FC<CardProps> = (
-    {
-        children ,
-        disabled,
-        boosted,
-    }) => {
-    return disabled || boosted ? (disabled ? <StyledDisabledCard>{children}</StyledDisabledCard> :
-        <StyledBoostedCard>{children}</StyledBoostedCard>) : <StyledCard>{children}</StyledCard>
-}
+const Card: React.FC<CardProps> = ({ children, disabled, boosted }) => {
+  return disabled || boosted ? (
+    disabled ? (
+      <StyledDisabledCard>{children}</StyledDisabledCard>
+    ) : (
+      <StyledBoostedCard>{children}</StyledBoostedCard>
+    )
+  ) : (
+    <StyledCard>{children}</StyledCard>
+  );
+};
 
 const StyledCard = styled.div`
   border-radius: 12px;
   display: flex;
   flex: 1;
   flex-direction: column;
-`
+`;
 
 const StyledDisabledCard = styled.div`
   border-radius: 12px;
@@ -30,15 +32,15 @@ const StyledDisabledCard = styled.div`
   flex: 1;
   flex-direction: column;
   opacity: 0.4;
-`
+`;
 
 const StyledBoostedCard = styled.div`
   border-radius: 12px;
-  margin: -.3rem;
-  box-shadow: 0 0 10px rgb(239,0,111,.9);
+  margin: -0.3rem;
+  box-shadow: 0 0 10px rgb(239, 0, 111, 0.9);
   display: flex;
   flex: 1;
   flex-direction: column;
-`
+`;
 
-export default Card
+export default Card;

--- a/packages/app/src/components/Card/index.ts
+++ b/packages/app/src/components/Card/index.ts
@@ -1,1 +1,1 @@
-export { default } from './Card'
+export { default } from "./Card";

--- a/packages/app/src/components/CardContent/CardContent.tsx
+++ b/packages/app/src/components/CardContent/CardContent.tsx
@@ -1,15 +1,15 @@
-import React from 'react'
-import styled from 'styled-components'
+import React from "react";
+import styled from "styled-components";
 
 const CardContent: React.FC = ({ children }) => (
   <StyledCardContent>{children}</StyledCardContent>
-)
+);
 
 const StyledCardContent = styled.div`
   display: flex;
   flex: 1;
   flex-direction: column;
   padding: ${(props) => props.theme.spacing[3]}px;
-`
+`;
 
-export default CardContent
+export default CardContent;

--- a/packages/app/src/components/CardContent/index.ts
+++ b/packages/app/src/components/CardContent/index.ts
@@ -1,1 +1,1 @@
-export { default } from './CardContent'
+export { default } from "./CardContent";

--- a/packages/app/src/components/CardDropdown/index.tsx
+++ b/packages/app/src/components/CardDropdown/index.tsx
@@ -1,111 +1,119 @@
-import React, { useRef, useState } from 'react';
-import { useOutsideClick } from '../../hooks';
-import { Check, ChevronDown } from '../../assets';
-import styled from 'styled-components'
-import { theme } from '../../theme';
+import React, { useRef, useState } from "react";
+import { useOutsideClick } from "../../hooks";
+import { Check, ChevronDown } from "../../assets";
+import styled from "styled-components";
+import { theme } from "../../theme";
 
 interface DropdownOption {
-    title: string;
-    onClick: () => void;
+  title: string;
+  onClick: () => void;
 }
 
 interface DropdownMenuProps {
-    title: string,
-    style?: any;
-    options: DropdownOption[];
-    setActive: (option: DropdownOption) => void;
+  title: string;
+  style?: any;
+  options: DropdownOption[];
+  setActive: (option: DropdownOption) => void;
 }
 
 const CardDropdown: React.FC<DropdownMenuProps> = (props) => {
-    const dropdownRef = useRef(null);
-    const [isActive, setIsActive] = useState(false);
-    const toggleDropdown = () => setIsActive(!isActive);
-    const {style, options, setActive} = props;
-    const [activeOption, setActiveOption] = useState(0);
+  const dropdownRef = useRef(null);
+  const [isActive, setIsActive] = useState(false);
+  const toggleDropdown = () => setIsActive(!isActive);
+  const { style, options, setActive } = props;
+  const [activeOption, setActiveOption] = useState(0);
 
-    useOutsideClick(dropdownRef, () => {
-        if (isActive) {
-            setIsActive(!isActive);
-        }
-    })
+  useOutsideClick(dropdownRef, () => {
+    if (isActive) {
+      setIsActive(!isActive);
+    }
+  });
 
-    return (
-        <StyledMenuContainer>
-            <StyledMenuTrigger onClick={toggleDropdown} width={style ? style.width : null} bgColor={style ? style.bgColor : null}>
-                <span>{options[activeOption].title}</span>
-                <ChevronDown/>
-            </StyledMenuTrigger>
-            <StyledMenu active={isActive} ref={dropdownRef}>
-                {(options.length > 1 || (options.length === 1)) &&
-                    <StyledList>
-                        {options.map((option, key) => {
-                            const isActive = activeOption === key;
-                            return (
-                                <StyledListItem key={key} active={isActive}>
-                                    <StyledListItemLink
-                                        onClick={() => { option.onClick(); setActiveOption(key); setActive(option);  }}>
-                                        {isActive && <Check/> } {option.title}
-                                    </StyledListItemLink>
-                                </StyledListItem>
-                            )
-                        })}
-                    </StyledList>
-                }
-            </StyledMenu>
-        </StyledMenuContainer>
-    );
+  return (
+    <StyledMenuContainer>
+      <StyledMenuTrigger
+        onClick={toggleDropdown}
+        width={style ? style.width : null}
+        bgColor={style ? style.bgColor : null}
+      >
+        <span>{options[activeOption].title}</span>
+        <ChevronDown />
+      </StyledMenuTrigger>
+      <StyledMenu active={isActive} ref={dropdownRef}>
+        {(options.length > 1 || options.length === 1) && (
+          <StyledList>
+            {options.map((option, key) => {
+              const isActive = activeOption === key;
+              return (
+                <StyledListItem key={key} active={isActive}>
+                  <StyledListItemLink
+                    onClick={() => {
+                      option.onClick();
+                      setActiveOption(key);
+                      setActive(option);
+                    }}
+                  >
+                    {isActive && <Check />} {option.title}
+                  </StyledListItemLink>
+                </StyledListItem>
+              );
+            })}
+          </StyledList>
+        )}
+      </StyledMenu>
+    </StyledMenuContainer>
+  );
 };
 
 interface StyledMenuProps {
-    active: boolean
+  active: boolean;
 }
 
 interface StyledProps {
-    width?: string;
-    bgColor?: string;
+  width?: string;
+  bgColor?: string;
 }
 
 const StyledMenuContainer = styled.div`
-	display: flex;
-	justify-content: flex-end;
-	position: relative;
-`
-
+  display: flex;
+  justify-content: flex-end;
+  position: relative;
+`;
 
 const StyledMenuTrigger = styled.button<StyledProps>`
-	background: ${(props) => props.bgColor ? props.bgColor : props.theme.color.white};
-	border-radius: 1em;
-	color: ${props => props.theme.color.purple[600]};
-	cursor: pointer;
-	display: flex;
-	font-family: ${props => props.theme.font.spaceMace};
-	font-size: 0.625rem;
-	justify-content: center;
-	align-items: center;
-	padding: .8em 1.2em;
-	text-align: center;
-	text-transform: uppercase;
-	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.0);
-	border: 2px solid ${props => props.theme.color.purple[600]};
-	vertical-align: middle;
-	transition: box-shadow 0.4s ease;
+  background: ${(props) =>
+    props.bgColor ? props.bgColor : props.theme.color.white};
+  border-radius: 1em;
+  color: ${(props) => props.theme.color.purple[600]};
+  cursor: pointer;
+  display: flex;
+  font-family: ${(props) => props.theme.font.spaceMace};
+  font-size: 0.625rem;
+  justify-content: center;
+  align-items: center;
+  padding: 0.8em 1.2em;
+  text-align: center;
+  text-transform: uppercase;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0);
+  border: 2px solid ${(props) => props.theme.color.purple[600]};
+  vertical-align: middle;
+  transition: box-shadow 0.4s ease;
 
-	&:hover {
-	   box-shadow: 0 1px 8px ${theme.color.colorsLayoutShadows};
-	}
+  &:hover {
+    box-shadow: 0 1px 8px ${theme.color.colorsLayoutShadows};
+  }
 
-	&:focus-visible {
-		outline: none;
-		box-shadow: 0px 0px 10px 5px ${theme.color.purple[600]};
-	}
+  &:focus-visible {
+    outline: none;
+    box-shadow: 0px 0px 10px 5px ${theme.color.purple[600]};
+  }
 
-	svg {
-		height: 1em;
-		width: 1em;
-		margin-left: .7em
-	}
-`
-
+  svg {
+    height: 1em;
+    width: 1em;
+    margin-left: 0.7em;
+  }
+`;
 
 const StyledMenu = styled.div<StyledMenuProps>`
   z-index: 99;
@@ -113,68 +121,70 @@ const StyledMenu = styled.div<StyledMenuProps>`
   position: absolute;
   top: 3.5em;
   right: 0;
-  opacity: ${(props) => props.active ? 1 : 0};
-  visibility: ${(props) => props.active ? 'visible' : 'hidden'};
-  transform: ${(props) => props.active ? 'translateY(0)' : 'translateY(-20px)'};
+  opacity: ${(props) => (props.active ? 1 : 0)};
+  visibility: ${(props) => (props.active ? "visible" : "hidden")};
+  transform: ${(props) =>
+    props.active ? "translateY(0)" : "translateY(-20px)"};
   transition: opacity 0.4s ease, transform 0.4s ease, visibility 0.4s;
   font-size: 1rem;
   border-radius: 1em;
   box-shadow: 0 4px 8px 0 ${theme.color.colorsLayoutShadows};
-  border: solid 1px ${props => props.theme.color.purple[600]};
+  border: solid 1px ${(props) => props.theme.color.purple[600]};
   width: 18.75em;
 
   &:before {
 	  content: "";
 	  display: inline-block;
-	  background-color: ${props => props.theme.color.white};
+	  background-color: ${(props) => props.theme.color.white};
 	  height: 1em;
 	  width: 1em;
 	  transform: rotate(45deg) translateY(-50%);
 	  position: absolute;
 	  right: 2.5em;
-	  border-color: ${props => props.theme.color.purple[600]};
+	  border-color: ${(props) => props.theme.color.purple[600]};
 	  transform-origin: top;
 	  border-left-style: solid;
 	  border-top-style: solid;
 	  border-top-width: 1px;
 	  border-left-width: 1px;
-`
+`;
 
 const StyledList = styled.ul`
   list-style: none;
   padding: 1em 2.75em;
   margin: 0;
   position: relative;
-`
+`;
 
-const StyledListItem = styled.li<{active?: boolean}>`
-	color: ${props => props.active ? theme.color.purple[600] : theme.color.gray[500]};
-	font-weight: ${props => props.active && 'bold'};
-`
+const StyledListItem = styled.li<{ active?: boolean }>`
+  color: ${(props) =>
+    props.active ? theme.color.purple[600] : theme.color.gray[500]};
+  font-weight: ${(props) => props.active && "bold"};
+`;
 
 const StyledListItemLink = styled.a`
   text-decoration: none;
   cursor: pointer;
   color: currentColor;
-  padding: .5em 0;
+  padding: 0.5em 0;
   display: flex;
   align-items: center;
 
   &:hover {
-	  color: ${props => props.theme.color.purple[600]};
+    color: ${(props) => props.theme.color.purple[600]};
   }
 
   svg {
-	  left: 1em;
-	  height: 1em;
-	  width: 1em;
-	  position: absolute;
+    left: 1em;
+    height: 1em;
+    width: 1em;
+    position: absolute;
   }
 
   &.active {
-	  color: ${props => props.theme.color.purple[600]};
-	  font-weight: bold;
+    color: ${(props) => props.theme.color.purple[600]};
+    font-weight: bold;
   }
-`
+`;
 
 export default CardDropdown;

--- a/packages/app/src/components/CardDropdown/wrapper.tsx
+++ b/packages/app/src/components/CardDropdown/wrapper.tsx
@@ -1,29 +1,25 @@
 import React from "react";
-import styled from 'styled-components';
+import styled from "styled-components";
 
-const CardDropdownWrapper: React.FC<any> = ({children}) => {
-    return (
-        <StyledCardDropdownWrapper>
-            {children}
-        </StyledCardDropdownWrapper>
-    )
-}
+const CardDropdownWrapper: React.FC<any> = ({ children }) => {
+  return <StyledCardDropdownWrapper>{children}</StyledCardDropdownWrapper>;
+};
 
 const StyledCardDropdownWrapper = styled.div`
-	display: flex;
-	color: ${props => props.theme.color.purple[600]};
-	position: absolute;
-	font-family: ${props => props.theme.font.inter};
-	top: 1.1em;
-	right: 1.1em;
-	font-size: .9rem;
-	align-items: center;
+  display: flex;
+  color: ${(props) => props.theme.color.purple[600]};
+  position: absolute;
+  font-family: ${(props) => props.theme.font.inter};
+  top: 1.1em;
+  right: 1.1em;
+  font-size: 0.9rem;
+  align-items: center;
 
-	> button {
-		margin-right: 1.2em;
-		font-size: 0.625rem;
-		text-decoration: none;
-	}
+  > button {
+    margin-right: 1.2em;
+    font-size: 0.625rem;
+    text-decoration: none;
+  }
 `;
 
 export default CardDropdownWrapper;

--- a/packages/app/src/components/CardIcon/CardIcon.tsx
+++ b/packages/app/src/components/CardIcon/CardIcon.tsx
@@ -1,18 +1,15 @@
-import React from 'react'
-import styled from 'styled-components'
+import React from "react";
+import styled from "styled-components";
 
 interface CardIconProps {
-  children?: React.ReactNode,
+  children?: React.ReactNode;
 }
 
 const CardIcon: React.FC<CardIconProps> = ({ children }) => (
-  <StyledCardIcon>
-    {children}
-  </StyledCardIcon>
-)
+  <StyledCardIcon>{children}</StyledCardIcon>
+);
 
 const StyledCardIcon = styled.div`
-
   font-size: 36px;
   height: 80px;
   width: 80px;
@@ -21,8 +18,7 @@ const StyledCardIcon = styled.div`
   display: flex;
   justify-content: center;
 
+  margin: 0 auto ${(props) => props.theme.spacing[3]}px;
+`;
 
-  margin: 0 auto ${props => props.theme.spacing[3]}px;
-`
-
-export default CardIcon
+export default CardIcon;

--- a/packages/app/src/components/CardIcon/index.ts
+++ b/packages/app/src/components/CardIcon/index.ts
@@ -1,1 +1,1 @@
-export { default } from './CardIcon'
+export { default } from "./CardIcon";

--- a/packages/app/src/components/CardTitle/CardTitle.tsx
+++ b/packages/app/src/components/CardTitle/CardTitle.tsx
@@ -1,20 +1,19 @@
-import React from 'react'
-import styled from 'styled-components'
+import React from "react";
+import styled from "styled-components";
 
 interface CardTitleProps {
-  text?: string
+  text?: string;
 }
 
 const CardTitle: React.FC<CardTitleProps> = ({ text }) => (
   <StyledCardTitle>{text}</StyledCardTitle>
-)
+);
 
 const StyledCardTitle = styled.div`
-
   font-size: 18px;
   font-weight: 700;
   padding: ${(props) => props.theme.spacing[4]}px;
   text-align: center;
-`
+`;
 
-export default CardTitle
+export default CardTitle;

--- a/packages/app/src/components/CardTitle/index.ts
+++ b/packages/app/src/components/CardTitle/index.ts
@@ -1,1 +1,1 @@
-export { default } from './CardTitle'
+export { default } from "./CardTitle";

--- a/packages/app/src/components/Container/Container.tsx
+++ b/packages/app/src/components/Container/Container.tsx
@@ -1,42 +1,38 @@
-import React, { useContext } from 'react'
-import styled, { ThemeContext } from 'styled-components'
+import React, { useContext } from "react";
+import styled, { ThemeContext } from "styled-components";
 
 interface ContainerProps {
-  children?: React.ReactNode,
-  size?: 'sm' | 'md' | 'lg'
+  children?: React.ReactNode;
+  size?: "sm" | "md" | "lg";
 }
 
-const Container: React.FC<ContainerProps> = ({ children, size = 'md' }) => {
-  const { siteWidth } = useContext<{ siteWidth: number }>(ThemeContext)
-  let width: number
+const Container: React.FC<ContainerProps> = ({ children, size = "md" }) => {
+  const { siteWidth } = useContext<{ siteWidth: number }>(ThemeContext);
+  let width: number;
   switch (size) {
-    case 'sm':
-      width = siteWidth / 2
-      break
-    case 'md':
-      width = siteWidth * 2 / 3
-      break
-    case 'lg':
+    case "sm":
+      width = siteWidth / 2;
+      break;
+    case "md":
+      width = (siteWidth * 2) / 3;
+      break;
+    case "lg":
     default:
-      width = siteWidth
+      width = siteWidth;
   }
-  return (
-    <StyledContainer width={width}>
-      {children}
-    </StyledContainer>
-  )
-}
+  return <StyledContainer width={width}>{children}</StyledContainer>;
+};
 
 interface StyledContainerProps {
-  width: number
+  width: number;
 }
 
 const StyledContainer = styled.div<StyledContainerProps>`
   box-sizing: border-box;
   margin: 0 auto;
-  max-width: ${props => props.width}px;
-  padding: 0 ${props => props.theme.spacing[4]}px;
+  max-width: ${(props) => props.width}px;
+  padding: 0 ${(props) => props.theme.spacing[4]}px;
   width: 100%;
-`
+`;
 
-export default Container
+export default Container;

--- a/packages/app/src/components/Container/index.ts
+++ b/packages/app/src/components/Container/index.ts
@@ -1,1 +1,1 @@
-export { default } from './Container'
+export { default } from "./Container";

--- a/packages/app/src/components/Content/ContentBox.tsx
+++ b/packages/app/src/components/Content/ContentBox.tsx
@@ -1,39 +1,42 @@
 import styled from "styled-components";
-import { theme } from '../../theme';
+import { theme } from "../../theme";
 
-const ContentBox = styled.div<{bgColor?: string, shadow?: boolean}>`
-	background-color: ${props => props.bgColor ? props.bgColor : props.theme.color.white};
-	border-radius: 8px;
-	padding: 1em 1.25em;
-	display: flex;
-	flex-direction: column;
-	height: 100%;
-	justify-content: center;
-	position: relative;
+const ContentBox = styled.div<{ bgColor?: string; shadow?: boolean }>`
+  background-color: ${(props) =>
+    props.bgColor ? props.bgColor : props.theme.color.white};
+  border-radius: 8px;
+  padding: 1em 1.25em;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  justify-content: center;
+  position: relative;
 
-	${({shadow}) => shadow && `
+  ${({ shadow }) =>
+    shadow &&
+    `
 		box-shadow: 0 4.5px 1px 0 rgba(0, 0, 0, 0.06), 0 10.3px 6.9px 0 ${theme.color.iconBackgroundGrey8}, 0 18.7px 14.2px 0 rgba(0, 0, 0, 0.1), 0 33.2px 29.2px 0 rgba(0, 0, 0, 0.13), 0 71px 80px 0 rgba(0, 0, 0, 0.19);
 	`}
-`
+`;
 
 export const ContentBoxNumber = styled.span`
-	color: ${props => props.theme.color.white};
-	font-size: 1.125rem;
-	font-weight: 700;
-	left: 50%;
-	margin-bottom: auto;
-	margin-top: 0;
-	position: relative;
-	text-align: center;
-	top: 0;
-	transform: translateX(-50%) translateY(-80%);
+  color: ${(props) => props.theme.color.white};
+  font-size: 1.125rem;
+  font-weight: 700;
+  left: 50%;
+  margin-bottom: auto;
+  margin-top: 0;
+  position: relative;
+  text-align: center;
+  top: 0;
+  transform: translateX(-50%) translateY(-80%);
 
-	span {
-		background-color: ${props => props.theme.color.headers};
-		display: inline-block;
-		border-radius: 8px;
-		padding: 0.6em 1em;
-	}
-`
+  span {
+    background-color: ${(props) => props.theme.color.headers};
+    display: inline-block;
+    border-radius: 8px;
+    padding: 0.6em 1em;
+  }
+`;
 
 export default ContentBox;

--- a/packages/app/src/components/Content/ContentBoxGrid.tsx
+++ b/packages/app/src/components/Content/ContentBoxGrid.tsx
@@ -1,19 +1,19 @@
 import styled from "styled-components";
-import { theme } from  '../../theme';
+import { theme } from "../../theme";
 
 interface ContentBoxGridProps {
-	gridTemplate?: string;
+  gridTemplate?: string;
 }
 
 const ContentBoxGrid = styled.div<ContentBoxGridProps>`
-	display: grid;
-	grid-auto-columns: 1fr;
-	row-gap: 1.25em;
-	grid-template: ${props => props.gridTemplate && props.gridTemplate};
+  display: grid;
+  grid-auto-columns: 1fr;
+  row-gap: 1.25em;
+  grid-template: ${(props) => props.gridTemplate && props.gridTemplate};
 
-	@media (min-width: ${theme.breakpoints.tabletL}) {
-		column-gap: 1.25em;
-	}
-`
+  @media (min-width: ${theme.breakpoints.tabletL}) {
+    column-gap: 1.25em;
+  }
+`;
 
 export default ContentBoxGrid;

--- a/packages/app/src/components/Content/ContentCentered.tsx
+++ b/packages/app/src/components/Content/ContentCentered.tsx
@@ -1,24 +1,25 @@
 import styled from "styled-components";
-import { theme } from  '../../theme';
+import { theme } from "../../theme";
 
 interface ContentCenteredProps {
-	bgColor?: string;
-	direction?: string;
-	maxWidth?: string;
-	padding?: string;
+  bgColor?: string;
+  direction?: string;
+  maxWidth?: string;
+  padding?: string;
 }
 
 const ContentCentered = styled.div<ContentCenteredProps>`
-	align-items: center;
-	background-color: ${ props => props.bgColor && props.bgColor };
-	display: flex;
-	flex-direction: column;
-	flex-direction: ${ props => props.direction ? props.direction : "column"};
-	justify-content: center;
-	max-width: ${ props => props.maxWidth ? props.maxWidth : `min(100%, ${theme.breakpoints.ultra})`};
-	margin-left: auto;
-	margin-right: auto;
-	padding: ${ props => props.padding && props.padding };
-`
+  align-items: center;
+  background-color: ${(props) => props.bgColor && props.bgColor};
+  display: flex;
+  flex-direction: column;
+  flex-direction: ${(props) => (props.direction ? props.direction : "column")};
+  justify-content: center;
+  max-width: ${(props) =>
+    props.maxWidth ? props.maxWidth : `min(100%, ${theme.breakpoints.ultra})`};
+  margin-left: auto;
+  margin-right: auto;
+  padding: ${(props) => props.padding && props.padding};
+`;
 
 export default ContentCentered;

--- a/packages/app/src/components/Content/ContentColumn.tsx
+++ b/packages/app/src/components/Content/ContentColumn.tsx
@@ -1,38 +1,40 @@
-import styled from 'styled-components';
-import { theme } from '../../theme';
+import styled from "styled-components";
+import { theme } from "../../theme";
 
 interface ContentColumnProps {
-	width?: string;
-	space?: string
-	desktopStyle?: any;
-	tabletLStyle?: any;
-	mobileStyle?: any;
+  width?: string;
+  space?: string;
+  desktopStyle?: any;
+  tabletLStyle?: any;
+  mobileStyle?: any;
   align?: "flex-start" | "center" | "flex-end";
 }
 
 const ContentColumn = styled.div<ContentColumnProps>`
-  ${({align}) => align && `
+  ${({ align }) =>
+    align &&
+    `
     display: flex;
     flex-direction: column;
     justify-content: ${align};
   `}
 
-	@media (max-width: ${theme.breakpoints.desktop}) {
-		${props => props.mobileStyle && props.mobileStyle}
-	}
+  @media (max-width: ${theme.breakpoints.desktop}) {
+    ${(props) => props.mobileStyle && props.mobileStyle}
+  }
 
-	@media (min-width: ${theme.breakpoints.desktop}) {
-		${props => props.desktopStyle && props.desktopStyle}
-	}
+  @media (min-width: ${theme.breakpoints.desktop}) {
+    ${(props) => props.desktopStyle && props.desktopStyle}
+  }
 
-	@media (min-width: ${theme.breakpoints.tabletL}) {
-		width: ${ props => props.width && props.width };
-		${props => props.tabletLStyle && props.tabletLStyle}
+  @media (min-width: ${theme.breakpoints.tabletL}) {
+    width: ${(props) => props.width && props.width};
+    ${(props) => props.tabletLStyle && props.tabletLStyle}
 
-		&:not(:first-child) {
-			margin-left: ${props => props.space && props.space};
-		}
-	}
-`
+    &:not(:first-child) {
+      margin-left: ${(props) => props.space && props.space};
+    }
+  }
+`;
 
 export default ContentColumn;

--- a/packages/app/src/components/Content/ContentColumns.tsx
+++ b/packages/app/src/components/Content/ContentColumns.tsx
@@ -1,35 +1,36 @@
-import styled from 'styled-components';
-import { theme } from  '../../theme';
+import styled from "styled-components";
+import { theme } from "../../theme";
 
 interface ContentColumnsProps {
-	justify?: string;
-	width?: string;
-	maxWidth?: string;
-	desktopStyle?: any;
-	mobileStyle?: any;
+  justify?: string;
+  width?: string;
+  maxWidth?: string;
+  desktopStyle?: any;
+  mobileStyle?: any;
 }
 
 const ContentColumns = styled.div<ContentColumnsProps>`
-	display: flex;
-	flex-direction: column;
-	justify-content: ${ props => props.justify && props.justify};
-	width: ${ props => props.width && props.width};
-	max-width: 100%;
-	margin-left: auto;
-	margin-right: auto;
+  display: flex;
+  flex-direction: column;
+  justify-content: ${(props) => props.justify && props.justify};
+  width: ${(props) => props.width && props.width};
+  max-width: 100%;
+  margin-left: auto;
+  margin-right: auto;
 
-	@media (max-width: ${theme.breakpoints.desktop}) {
-		${props => props.mobileStyle && props.mobileStyle}
-	}
+  @media (max-width: ${theme.breakpoints.desktop}) {
+    ${(props) => props.mobileStyle && props.mobileStyle}
+  }
 
-	@media (min-width: ${theme.breakpoints.desktop}) {
-		${props => props.desktopStyle && props.desktopStyle}
-	}
+  @media (min-width: ${theme.breakpoints.desktop}) {
+    ${(props) => props.desktopStyle && props.desktopStyle}
+  }
 
-	@media (min-width: ${theme.breakpoints.tabletL}) {
-		flex-direction: row;
-		max-width: ${ props => props.maxWidth ? props.maxWidth : theme.breakpoints.ultra};
-	}
-`
+  @media (min-width: ${theme.breakpoints.tabletL}) {
+    flex-direction: row;
+    max-width: ${(props) =>
+      props.maxWidth ? props.maxWidth : theme.breakpoints.ultra};
+  }
+`;
 
 export default ContentColumns;

--- a/packages/app/src/components/Content/index.ts
+++ b/packages/app/src/components/Content/index.ts
@@ -1,5 +1,5 @@
-export { default as ContentBox, ContentBoxNumber } from './ContentBox';
-export { default as ContentBoxGrid } from './ContentBoxGrid';
-export { default as ContentCentered } from './ContentCentered';
-export { default as ContentColumn } from './ContentColumn';
-export { default as ContentColumns } from './ContentColumns';
+export { default as ContentBox, ContentBoxNumber } from "./ContentBox";
+export { default as ContentBoxGrid } from "./ContentBoxGrid";
+export { default as ContentCentered } from "./ContentCentered";
+export { default as ContentColumn } from "./ContentColumn";
+export { default as ContentColumns } from "./ContentColumns";

--- a/packages/app/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/packages/app/src/components/DropdownMenu/DropdownMenu.tsx
@@ -1,113 +1,127 @@
-import React, { useRef, useState } from 'react';
-import { useOutsideClick } from '../../hooks';
-import { Check, ChevronDown } from '../../assets';
-import styled from 'styled-components'
-import { theme } from '../../theme';
+import React, { useRef, useState } from "react";
+import { useOutsideClick } from "../../hooks";
+import { Check, ChevronDown } from "../../assets";
+import styled from "styled-components";
+import { theme } from "../../theme";
 
 interface DropdownMenuProps {
-	title: string,
-	options: {
-		title: string,
-		onClick: () => void,
-	}[]
-	style?: any;
+  title: string;
+  options: {
+    title: string;
+    onClick: () => void;
+  }[];
+  style?: any;
 }
 
-const DropdownMenu: React.FC<any> = ({ title, options, activeOptions, style, setActiveSeries}) => {
-	const dropdownRef = useRef(null);
-	const [isActive, setIsActive] = useState(false);
-	const toggleDropdown = () => setIsActive(!isActive);
+const DropdownMenu: React.FC<any> = ({
+  title,
+  options,
+  activeOptions,
+  style,
+  setActiveSeries,
+}) => {
+  const dropdownRef = useRef(null);
+  const [isActive, setIsActive] = useState(false);
+  const toggleDropdown = () => setIsActive(!isActive);
 
-	useOutsideClick(dropdownRef, () => {
-		if (isActive) {
-			setIsActive(!isActive);
-		}
-	})
+  useOutsideClick(dropdownRef, () => {
+    if (isActive) {
+      setIsActive(!isActive);
+    }
+  });
 
-	// const editedTitle = () => {
-	// 	if (activeOptions.length === options.length) { return 'all' }
-	// 	else if (activeOptions.length !== 1) { return `${activeOptions.length} selected` }
-	// 	else { return activeOptions[0].title };
-	// }
+  // const editedTitle = () => {
+  // 	if (activeOptions.length === options.length) { return 'all' }
+  // 	else if (activeOptions.length !== 1) { return `${activeOptions.length} selected` }
+  // 	else { return activeOptions[0].title };
+  // }
 
-	return (
-		<StyledMenuContainer>
-			<StyledMenuTrigger onClick={toggleDropdown} width={style ? style.width : null} bgColor={style ? style.bgColor : null}>
-				<span>{activeOptions.title}</span>
-				<ChevronDown/>
-			</StyledMenuTrigger>
-			<StyledMenu active={isActive} ref={dropdownRef}>
-				{(options.length > 1 || (options.length === 1 && title !== options[0].title)) &&
-					<StyledList>
-						{options.map((option, key) => {
-							// const index = activeOptions.findIndex(serie => serie.title === option.title);
-							const isActive = activeOptions.title === option.title;
-							return (
-								<StyledListItem key={key} active={isActive}>
-									<StyledListItemLink
-										onClick={() => { option.onClick(); setIsActive(false); }}>
-										{isActive && <Check/> } {option.title}
-									</StyledListItemLink>
-								</StyledListItem>
-							)
-						})}
-					</StyledList>
-				}
-			</StyledMenu>
-		</StyledMenuContainer>
-	);
+  return (
+    <StyledMenuContainer>
+      <StyledMenuTrigger
+        onClick={toggleDropdown}
+        width={style ? style.width : null}
+        bgColor={style ? style.bgColor : null}
+      >
+        <span>{activeOptions.title}</span>
+        <ChevronDown />
+      </StyledMenuTrigger>
+      <StyledMenu active={isActive} ref={dropdownRef}>
+        {(options.length > 1 ||
+          (options.length === 1 && title !== options[0].title)) && (
+          <StyledList>
+            {options.map((option, key) => {
+              // const index = activeOptions.findIndex(serie => serie.title === option.title);
+              const isActive = activeOptions.title === option.title;
+              return (
+                <StyledListItem key={key} active={isActive}>
+                  <StyledListItemLink
+                    onClick={() => {
+                      option.onClick();
+                      setIsActive(false);
+                    }}
+                  >
+                    {isActive && <Check />} {option.title}
+                  </StyledListItemLink>
+                </StyledListItem>
+              );
+            })}
+          </StyledList>
+        )}
+      </StyledMenu>
+    </StyledMenuContainer>
+  );
 };
 
 interface StyledMenuProps {
-	active: boolean
+  active: boolean;
 }
 
 interface StyledProps {
-	width?: string;
-	bgColor?: string;
+  width?: string;
+  bgColor?: string;
 }
 
 const StyledMenuContainer = styled.div`
-	display: flex;
-	justify-content: flex-end;
-	position: relative;
-`
-
+  display: flex;
+  justify-content: flex-end;
+  position: relative;
+`;
 
 const StyledMenuTrigger = styled.button<StyledProps>`
-	background: ${(props) => props.bgColor ? props.bgColor : props.theme.color.white};
-	border-radius: 1em;
-	color: ${props => props.theme.color.purple[600]};
-	cursor: pointer;
-	display: flex;
-	font-family: ${props => props.theme.font.spaceMace};
-	font-size: 0.625rem;
-	justify-content: center;
-	align-items: center;
-	padding: .8em 1.2em;
-	text-align: center;
-	text-transform: uppercase;
-	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.0);
-	border: 2px solid ${props => props.theme.color.purple[600]};
-	vertical-align: middle;
-	transition: box-shadow 0.4s ease;
+  background: ${(props) =>
+    props.bgColor ? props.bgColor : props.theme.color.white};
+  border-radius: 1em;
+  color: ${(props) => props.theme.color.purple[600]};
+  cursor: pointer;
+  display: flex;
+  font-family: ${(props) => props.theme.font.spaceMace};
+  font-size: 0.625rem;
+  justify-content: center;
+  align-items: center;
+  padding: 0.8em 1.2em;
+  text-align: center;
+  text-transform: uppercase;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0);
+  border: 2px solid ${(props) => props.theme.color.purple[600]};
+  vertical-align: middle;
+  transition: box-shadow 0.4s ease;
 
-	&:hover {
-	   box-shadow: 0 1px 8px ${theme.color.colorsLayoutShadows};
-	}
+  &:hover {
+    box-shadow: 0 1px 8px ${theme.color.colorsLayoutShadows};
+  }
 
-	&:focus-visible {
-		outline: none;
-		box-shadow: 0px 0px 10px 5px ${theme.color.purple[600]};
-	}
+  &:focus-visible {
+    outline: none;
+    box-shadow: 0px 0px 10px 5px ${theme.color.purple[600]};
+  }
 
-	svg {
-		height: 1em;
-		width: 1em;
-		margin-left: .7em
-	}
-`
-
+  svg {
+    height: 1em;
+    width: 1em;
+    margin-left: 0.7em;
+  }
+`;
 
 const StyledMenu = styled.div<StyledMenuProps>`
   z-index: 99;
@@ -115,68 +129,70 @@ const StyledMenu = styled.div<StyledMenuProps>`
   position: absolute;
   top: 3.5em;
   right: 0;
-  opacity: ${(props) => props.active ? 1 : 0};
-  visibility: ${(props) => props.active ? 'visible' : 'hidden'};
-  transform: ${(props) => props.active ? 'translateY(0)' : 'translateY(-20px)'};
+  opacity: ${(props) => (props.active ? 1 : 0)};
+  visibility: ${(props) => (props.active ? "visible" : "hidden")};
+  transform: ${(props) =>
+    props.active ? "translateY(0)" : "translateY(-20px)"};
   transition: opacity 0.4s ease, transform 0.4s ease, visibility 0.4s;
   font-size: 1rem;
   border-radius: 1em;
   box-shadow: 0 4px 8px 0 ${theme.color.colorsLayoutShadows};
-  border: solid 1px ${props => props.theme.color.purple[600]};
+  border: solid 1px ${(props) => props.theme.color.purple[600]};
   width: 18.75em;
 
   &:before {
 	  content: "";
 	  display: inline-block;
-	  background-color: ${props => props.theme.color.white};
+	  background-color: ${(props) => props.theme.color.white};
 	  height: 1em;
 	  width: 1em;
 	  transform: rotate(45deg) translateY(-50%);
 	  position: absolute;
 	  right: 2.5em;
-	  border-color: ${props => props.theme.color.purple[600]};
+	  border-color: ${(props) => props.theme.color.purple[600]};
 	  transform-origin: top;
 	  border-left-style: solid;
 	  border-top-style: solid;
 	  border-top-width: 1px;
 	  border-left-width: 1px;
-`
+`;
 
 const StyledList = styled.ul`
   list-style: none;
   padding: 1em 2.75em;
   margin: 0;
   position: relative;
-`
+`;
 
-const StyledListItem = styled.li<{active?: boolean}>`
-	color: ${props => props.active ? theme.color.purple[600] : theme.color.gray[500]};
-	font-weight: ${props => props.active && 'bold'};
-`
+const StyledListItem = styled.li<{ active?: boolean }>`
+  color: ${(props) =>
+    props.active ? theme.color.purple[600] : theme.color.gray[500]};
+  font-weight: ${(props) => props.active && "bold"};
+`;
 
 const StyledListItemLink = styled.a`
   text-decoration: none;
   cursor: pointer;
   color: currentColor;
-  padding: .5em 0;
+  padding: 0.5em 0;
   display: flex;
   align-items: center;
 
   &:hover {
-	  color: ${props => props.theme.color.purple[600]};
+    color: ${(props) => props.theme.color.purple[600]};
   }
 
   svg {
-	  left: 1em;
-	  height: 1em;
-	  width: 1em;
-	  position: absolute;
+    left: 1em;
+    height: 1em;
+    width: 1em;
+    position: absolute;
   }
 
   &.active {
-	  color: ${props => props.theme.color.purple[600]};
-	  font-weight: bold;
+    color: ${(props) => props.theme.color.purple[600]};
+    font-weight: bold;
   }
-`
+`;
 
-export default DropdownMenu
+export default DropdownMenu;

--- a/packages/app/src/components/DropdownMenu/index.ts
+++ b/packages/app/src/components/DropdownMenu/index.ts
@@ -1,1 +1,1 @@
-export { default } from './DropdownMenu'
+export { default } from "./DropdownMenu";

--- a/packages/app/src/components/Evolve/Evolve.tsx
+++ b/packages/app/src/components/Evolve/Evolve.tsx
@@ -5,79 +5,94 @@ import { theme } from "../../theme";
 import { pepertle, warpertle, rektoise } from "../../assets";
 
 const Evolve = () => {
-	return (
-		<>
-			<EvolveGrid>
-				<EvolveImgWrapper>
-					<EvolveImgContainer>
-						<AnimatedImg width={313} height={434} src={pepertle} alt="pepertle" />
-					</EvolveImgContainer>
-				</EvolveImgWrapper>
-				<EvolveImgWrapper>
-					<EvolveImgContainer>
-						<AnimatedImg width={313} height={434} src={warpertle} alt="warpertle" />
-					</EvolveImgContainer>
-				</EvolveImgWrapper>
-				<EvolveImgWrapper>
-					<EvolveImgContainer>
-						<AnimatedImg width={313} height={434} src={rektoise} alt="rektoise" />
-					</EvolveImgContainer>
-				</EvolveImgWrapper>
-			</EvolveGrid>
-		</>
-	)
-}
+  return (
+    <>
+      <EvolveGrid>
+        <EvolveImgWrapper>
+          <EvolveImgContainer>
+            <AnimatedImg
+              width={313}
+              height={434}
+              src={pepertle}
+              alt="pepertle"
+            />
+          </EvolveImgContainer>
+        </EvolveImgWrapper>
+        <EvolveImgWrapper>
+          <EvolveImgContainer>
+            <AnimatedImg
+              width={313}
+              height={434}
+              src={warpertle}
+              alt="warpertle"
+            />
+          </EvolveImgContainer>
+        </EvolveImgWrapper>
+        <EvolveImgWrapper>
+          <EvolveImgContainer>
+            <AnimatedImg
+              width={313}
+              height={434}
+              src={rektoise}
+              alt="rektoise"
+            />
+          </EvolveImgContainer>
+        </EvolveImgWrapper>
+      </EvolveGrid>
+    </>
+  );
+};
 
 const EvolveGrid = styled.div`
-	display: grid;
-	position: relative;
+  display: grid;
+  position: relative;
 
-	@media (min-width: ${theme.breakpoints.tabletL}) {
-		grid-auto-rows: 1fr;
-		width: 250%;
-	}
-`
+  @media (min-width: ${theme.breakpoints.tabletL}) {
+    grid-auto-rows: 1fr;
+    width: 250%;
+  }
+`;
 
 interface EvolveImgWrapperProps {
-	width?: string;
-	margin?: string;
-	transform?: string
+  width?: string;
+  margin?: string;
+  transform?: string;
 }
 
 interface EvolveImgContainerProps {
-	absolute?: boolean,
-	left?: string,
-	transform?: string,
-	right?: string
+  absolute?: boolean;
+  left?: string;
+  transform?: string;
+  right?: string;
 }
 
 const EvolveImgContainer = styled.div<EvolveImgContainerProps>`
-	position: relative;
-	text-align: center;
-	width: fit-content;
-`
+  position: relative;
+  text-align: center;
+  width: fit-content;
+`;
 
 const EvolveImgWrapper = styled.div<EvolveImgWrapperProps>`
-	margin: ${props => props.margin && props.margin};
-	position: sticky;
-	top: calc(${theme.topBarSize}px + 2em);
+  margin: ${(props) => props.margin && props.margin};
+  position: sticky;
+  top: calc(${theme.topBarSize}px + 2em);
 
-	&:first-child {
-			margin-right: auto;
-	}
+  &:first-child {
+    margin-right: auto;
+  }
 
-	&:nth-child(2) {
-		padding-top: ${theme.topBarSize}px;
+  &:nth-child(2) {
+    padding-top: ${theme.topBarSize}px;
 
-			margin-left: auto;
-			margin-right: auto;
-	}
+    margin-left: auto;
+    margin-right: auto;
+  }
 
-	&:nth-child(3) {
-		padding-top: ${2*theme.topBarSize}px;
+  &:nth-child(3) {
+    padding-top: ${2 * theme.topBarSize}px;
 
-			margin-left: auto;
-	}
-`
+    margin-left: auto;
+  }
+`;
 
 export default Evolve;

--- a/packages/app/src/components/Evolve/index.ts
+++ b/packages/app/src/components/Evolve/index.ts
@@ -1,1 +1,1 @@
-export { default } from './Evolve';
+export { default } from "./Evolve";

--- a/packages/app/src/components/Footer/index.ts
+++ b/packages/app/src/components/Footer/index.ts
@@ -1,1 +1,1 @@
-export { default } from './Footer';
+export { default } from "./Footer";

--- a/packages/app/src/components/Head/Head.tsx
+++ b/packages/app/src/components/Head/Head.tsx
@@ -1,30 +1,52 @@
-import React from 'react';
-import { Helmet } from 'react-helmet';
+import React from "react";
+import { Helmet } from "react-helmet";
 
 export interface HelmetProps {
-	title: string,
-	description: string,
-	ogTitle?: string,
-	ogDescription?: string,
-	twitterTitle?: string,
-	twitterDescription?: string,
-	index?: boolean,
-	follow?: boolean,
+  title: string;
+  description: string;
+  ogTitle?: string;
+  ogDescription?: string;
+  twitterTitle?: string;
+  twitterDescription?: string;
+  index?: boolean;
+  follow?: boolean;
 }
 
-const Head: React.FC<HelmetProps> = ({title, description, ogTitle, ogDescription, twitterTitle, twitterDescription, index=true, follow=true}) => {
-	return (
-		<Helmet>
-			<title>{title}</title>
-			<meta name="description" content={description}/>
-			<meta name="og:title" content={ogTitle ? ogTitle : title}/>
-			<meta name="og:description" content={ogDescription ? ogDescription : description}/>
-			<meta name="twitter:title" content={twitterTitle ? twitterTitle : title}/>
-			<meta name="twitter:description" content={twitterDescription ? twitterDescription : description}/>
-			<meta name="robots" content={`${index ? 'index' : 'noindex'},${follow ? 'follow' : 'nofollow'}`}/>
-		</Helmet>
-	)
-}
-
+const Head: React.FC<HelmetProps> = ({
+  title,
+  description,
+  ogTitle,
+  ogDescription,
+  twitterTitle,
+  twitterDescription,
+  index = true,
+  follow = true,
+}) => {
+  return (
+    <Helmet>
+      <title>{title}</title>
+      <meta name="description" content={description} />
+      <meta name="og:title" content={ogTitle ? ogTitle : title} />
+      <meta
+        name="og:description"
+        content={ogDescription ? ogDescription : description}
+      />
+      <meta
+        name="twitter:title"
+        content={twitterTitle ? twitterTitle : title}
+      />
+      <meta
+        name="twitter:description"
+        content={twitterDescription ? twitterDescription : description}
+      />
+      <meta
+        name="robots"
+        content={`${index ? "index" : "noindex"},${
+          follow ? "follow" : "nofollow"
+        }`}
+      />
+    </Helmet>
+  );
+};
 
 export default Head;

--- a/packages/app/src/components/Head/index.ts
+++ b/packages/app/src/components/Head/index.ts
@@ -1,2 +1,2 @@
-export { default } from './Head';
-export type { HelmetProps } from './Head';
+export { default } from "./Head";
+export type { HelmetProps } from "./Head";

--- a/packages/app/src/components/Hero/Hero.tsx
+++ b/packages/app/src/components/Hero/Hero.tsx
@@ -27,7 +27,10 @@ const Hero: React.FC<any> = ({ apy }) => {
             desktopStyle={{ paddingTop: "16px", maxWidth: "460px" }}
           >
             <Text as="p" font={theme.font.inter} size="l">
-              Get ready for Degen Battleground – where every battle, trade, and collectible isn't just a play, it's piece of nostalgia. One click, one wallet, endless rewards. Ready to claim your stake in the Pepemon universe?
+              Get ready for Degen Battleground – where every battle, trade, and
+              collectible isn't just a play, it's piece of nostalgia. One click,
+              one wallet, endless rewards. Ready to claim your stake in the
+              Pepemon universe?
             </Text>
           </ContentColumn>
           <ContentColumn
@@ -52,7 +55,8 @@ const Hero: React.FC<any> = ({ apy }) => {
                 <span>1</span>
               </ContentBoxNumber>
               <Text as="p" align="center">
-                Collect rare on-chain TCG cards.<br></br>Battle, trade &amp; own your Pepemon deck.
+                Collect rare on-chain TCG cards.<br></br>Battle, trade &amp; own
+                your Pepemon deck.
               </Text>
               <Spacer size="md" />
               <ExternalLink

--- a/packages/app/src/components/Hero/index.ts
+++ b/packages/app/src/components/Hero/index.ts
@@ -1,1 +1,1 @@
-export { default } from './Hero';
+export { default } from "./Hero";

--- a/packages/app/src/components/IButtonPopover/IButtonPopover.tsx
+++ b/packages/app/src/components/IButtonPopover/IButtonPopover.tsx
@@ -6,140 +6,177 @@ import { useModal } from "../../hooks";
 import { ExternalLink, Spacer, Text, Title } from "../../components";
 
 export type IButtonPopoverProps = {
-	apy: number;
-	heading: string;
-	cursor?: string,
-	button?: { text: string, href: string };
-	ppdexPrice: number
+  apy: number;
+  heading: string;
+  cursor?: string;
+  button?: { text: string; href: string };
+  ppdexPrice: number;
 };
 
 interface DataProps {
-	key: number,
-	title: string,
-	roi: string,
-	ppdexPer1kUSD: string
+  key: number;
+  title: string;
+  roi: string;
+  ppdexPer1kUSD: string;
 }
 
-const TableRow: React.FC<DataProps> = ({title, roi, ppdexPer1kUSD}) => {
-	return (
-		<tr>
-			<td style={{ paddingLeft: "0px" }}>{title}</td>
-			<td>{roi}%</td>
-			<td>{ppdexPer1kUSD}</td>
-		</tr>
-	)
-}
+const TableRow: React.FC<DataProps> = ({ title, roi, ppdexPer1kUSD }) => {
+  return (
+    <tr>
+      <td style={{ paddingLeft: "0px" }}>{title}</td>
+      <td>{roi}%</td>
+      <td>{ppdexPer1kUSD}</td>
+    </tr>
+  );
+};
 
-const IButtonPopover: React.FC<IButtonPopoverProps> = ({ apy, heading, cursor = 'pointer', button, ppdexPrice}) => {
-	// const ppdexPer1kUSD = 1000*roi_1d/ppdexPrice
-	const apyPercentage = apy/100;
+const IButtonPopover: React.FC<IButtonPopoverProps> = ({
+  apy,
+  heading,
+  cursor = "pointer",
+  button,
+  ppdexPrice,
+}) => {
+  // const ppdexPer1kUSD = 1000*roi_1d/ppdexPrice
+  const apyPercentage = apy / 100;
 
-	const data = [
-		{
-			title: '1d',
-			roi: (apy/365).toFixed(2),
-			ppdexPer1kUSD: (1000*(apyPercentage/365)/ppdexPrice).toFixed(2),
-		},
-		{
-			title: '7d',
-			roi: (apy/365*7).toFixed(2),
-			ppdexPer1kUSD: (1000*(apyPercentage/365*7)/ppdexPrice).toFixed(2),
-		},
-		{
-			title: '30d',
-			roi: (apy/365*30).toFixed(2),
-			ppdexPer1kUSD: (1000*(apyPercentage/365*30)/ppdexPrice).toFixed(2),
-		},
-		{
-			title: '365d(APY)',
-			roi: (apy).toFixed(2),
-			ppdexPer1kUSD: (1000*(apyPercentage)/ppdexPrice).toFixed(2),
-		},
-	];
+  const data = [
+    {
+      title: "1d",
+      roi: (apy / 365).toFixed(2),
+      ppdexPer1kUSD: ((1000 * (apyPercentage / 365)) / ppdexPrice).toFixed(2),
+    },
+    {
+      title: "7d",
+      roi: ((apy / 365) * 7).toFixed(2),
+      ppdexPer1kUSD: (
+        (1000 * ((apyPercentage / 365) * 7)) /
+        ppdexPrice
+      ).toFixed(2),
+    },
+    {
+      title: "30d",
+      roi: ((apy / 365) * 30).toFixed(2),
+      ppdexPer1kUSD: (
+        (1000 * ((apyPercentage / 365) * 30)) /
+        ppdexPrice
+      ).toFixed(2),
+    },
+    {
+      title: "365d(APY)",
+      roi: apy.toFixed(2),
+      ppdexPer1kUSD: ((1000 * apyPercentage) / ppdexPrice).toFixed(2),
+    },
+  ];
 
-	const [handlePresent] = useModal({
-		title: <Title as="h1" size='xxs' align="center" font={theme.font.inter} color={theme.color.purple[600]} weight="bold">{heading}</Title>,
-		content: <>
-				<hr/>
-				<Table>
-					<thead>
-						<tr>
-							<th style={{ paddingLeft: "0px" }}>Timeframe</th>
-							<th>ROI</th>
-							<th>PPDEX per $1,000</th>
-						</tr>
-					</thead>
-					<tbody>
-						{data.map((set, key) => {
-							return <TableRow key={key} {...set}/>
-						})}
-					</tbody>
-				</Table>
-				<Spacer size="sm"/>
-				<Text as="p" size='xs' lineHeight={1.33}>
-					Rates are estimates provided for your convenience only, and by no means represent guaranteed returns.
-				</Text>
-				<Spacer size="sm"/>
-				<Text as="p" size='xs' lineHeight={1.33}>
-					All estimated rates take into account this pool’s 2% performance fee.
-				</Text>
-				<Spacer size='sm'/>
-				<ExternalLink size={.75} href={button.href}>{button.text}</ExternalLink>
-			</>,
-		maxWidth: theme.page.maxWidth/3
-	})
+  const [handlePresent] = useModal({
+    title: (
+      <Title
+        as="h1"
+        size="xxs"
+        align="center"
+        font={theme.font.inter}
+        color={theme.color.purple[600]}
+        weight="bold"
+      >
+        {heading}
+      </Title>
+    ),
+    content: (
+      <>
+        <hr />
+        <Table>
+          <thead>
+            <tr>
+              <th style={{ paddingLeft: "0px" }}>Timeframe</th>
+              <th>ROI</th>
+              <th>PPDEX per $1,000</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.map((set, key) => {
+              return <TableRow key={key} {...set} />;
+            })}
+          </tbody>
+        </Table>
+        <Spacer size="sm" />
+        <Text as="p" size="xs" lineHeight={1.33}>
+          Rates are estimates provided for your convenience only, and by no
+          means represent guaranteed returns.
+        </Text>
+        <Spacer size="sm" />
+        <Text as="p" size="xs" lineHeight={1.33}>
+          All estimated rates take into account this pool’s 2% performance fee.
+        </Text>
+        <Spacer size="sm" />
+        <ExternalLink size={0.75} href={button.href}>
+          {button.text}
+        </ExternalLink>
+      </>
+    ),
+    maxWidth: theme.page.maxWidth / 3,
+  });
 
-	return (
-		<div>
-			<ImgButton aria-label="show APY informations" cursor={cursor}>
-				<img height="18px" width="18px" src={ibutton} alt="info" onClick={handlePresent}/>
-			</ImgButton>
-		</div>
-	);
+  return (
+    <div>
+      <ImgButton aria-label="show APY informations" cursor={cursor}>
+        <img
+          height="18px"
+          width="18px"
+          src={ibutton}
+          alt="info"
+          onClick={handlePresent}
+        />
+      </ImgButton>
+    </div>
+  );
 };
 
 const ImgButton = styled.button.attrs({
-	type: "button"
-})<{absolute?: boolean, cursor?: string}>`
-	background: unset;
-	border: none;
-	cursor: ${props => props.cursor ? props.cursor : 'pointer'};
-	padding: 0;
-	display: flex;
+  type: "button",
+})<{ absolute?: boolean; cursor?: string }>`
+  background: unset;
+  border: none;
+  cursor: ${(props) => (props.cursor ? props.cursor : "pointer")};
+  padding: 0;
+  display: flex;
 
-	${({absolute}) => absolute && `
+  ${({ absolute }) =>
+    absolute &&
+    `
 		position: absolute;
 		right: 0;
 		top: -3px;
 	`}
 
-	&:focus-visible {
-		outline: none;
-		box-shadow: 0px 0px 10px 5px ${theme.color.purple[600]};
-	}
-`
+  &:focus-visible {
+    outline: none;
+    box-shadow: 0px 0px 10px 5px ${theme.color.purple[600]};
+  }
+`;
 
 const Table = styled.table`
-	width: 100%;
+  width: 100%;
 
-	th, td {
-		font-family: ${theme.font.inter};
-		font-size: .625rem;
-		padding-bottom: .5em;
-		padding-top: .5em;
-	}
+  th,
+  td {
+    font-family: ${theme.font.inter};
+    font-size: 0.625rem;
+    padding-bottom: 0.5em;
+    padding-top: 0.5em;
+  }
 
-	th {
-		color: ${theme.color.gray[400]};
-		font-weight: normal;
-		letter-spacing: 1px;
-		text-align: left;
-	}
+  th {
+    color: ${theme.color.gray[400]};
+    font-weight: normal;
+    letter-spacing: 1px;
+    text-align: left;
+  }
 
-	td {
-		color: ${theme.color.headers};
-		font-weight: bold;
-	}
-`
+  td {
+    color: ${theme.color.headers};
+    font-weight: bold;
+  }
+`;
 
 export default IButtonPopover;

--- a/packages/app/src/components/IButtonPopover/index.ts
+++ b/packages/app/src/components/IButtonPopover/index.ts
@@ -1,2 +1,2 @@
-export { default } from './IButtonPopover';
-export type { IButtonPopoverProps } from './IButtonPopover';
+export { default } from "./IButtonPopover";
+export type { IButtonPopoverProps } from "./IButtonPopover";

--- a/packages/app/src/components/Label/Label.tsx
+++ b/packages/app/src/components/Label/Label.tsx
@@ -1,16 +1,14 @@
-import React from 'react'
-import styled from 'styled-components'
+import React from "react";
+import styled from "styled-components";
 
 interface LabelProps {
-  text?: string
+  text?: string;
 }
 
 const Label: React.FC<LabelProps> = ({ text }) => (
   <StyledLabel>{text}</StyledLabel>
-)
+);
 
-const StyledLabel = styled.div`
+const StyledLabel = styled.div``;
 
-`
-
-export default Label
+export default Label;

--- a/packages/app/src/components/Label/index.ts
+++ b/packages/app/src/components/Label/index.ts
@@ -1,1 +1,1 @@
-export { default } from './Label'
+export { default } from "./Label";

--- a/packages/app/src/components/Link/Link.tsx
+++ b/packages/app/src/components/Link/Link.tsx
@@ -1,24 +1,25 @@
 import styled from "styled-components";
 import { theme } from "../../theme";
-import { buttonLinksStyling } from '../Button/Button';
+import { buttonLinksStyling } from "../Button/Button";
 
 export interface ExternalLinkProps {
-	styling?: 'button',
-	light?: boolean,
-	shadow?: boolean,
-	size?: number
+  styling?: "button";
+  light?: boolean;
+  shadow?: boolean;
+  size?: number;
 }
 
 const ExternalLink = styled.a.attrs({
-	target: "_blank",
-	rel: "external noopener noreferrer",
+  target: "_blank",
+  rel: "external noopener noreferrer",
 })<ExternalLinkProps>`
-	${({styling}) => styling === 'button' ?
-		buttonLinksStyling
-	: `
+  ${({ styling }) =>
+    styling === "button"
+      ? buttonLinksStyling
+      : `
 		color: ${theme.color.purple[600]};
 		cursor: pointer;
-		font-size: ${props => props.size && props.size}rem;
+		font-size: ${(props) => props.size && props.size}rem;
 		text-decoration: underline;
 
 		&:hover {

--- a/packages/app/src/components/Link/index.ts
+++ b/packages/app/src/components/Link/index.ts
@@ -1,2 +1,2 @@
-export { default } from './Link';
-export type { ExternalLinkProps } from './Link';
+export { default } from "./Link";
+export type { ExternalLinkProps } from "./Link";

--- a/packages/app/src/components/Loader/Loader.tsx
+++ b/packages/app/src/components/Loader/Loader.tsx
@@ -1,22 +1,24 @@
-import React from 'react'
-import styled, { keyframes } from 'styled-components'
+import React from "react";
+import styled, { keyframes } from "styled-components";
 
-import CardIcon from '../CardIcon'
+import CardIcon from "../CardIcon";
 
 interface LoaderProps {
-  text?: string
+  text?: string;
 }
 
 const Loader: React.FC<LoaderProps> = ({ text }) => {
   return (
     <StyledLoader>
       <CardIcon>
-        <StyledPepemon><img src={'pepeballImg'} alt="pepeballImg" style={{ height: 32 }}/></StyledPepemon>
+        <StyledPepemon>
+          <img src={"pepeballImg"} alt="pepeballImg" style={{ height: 32 }} />
+        </StyledPepemon>
       </CardIcon>
       {!!text && <StyledText>{text}</StyledText>}
     </StyledLoader>
-  )
-}
+  );
+};
 
 const spin = keyframes`
   0% {
@@ -25,23 +27,21 @@ const spin = keyframes`
   100% {
     transform: rotate(360deg);
   }
-`
+`;
 
 const StyledLoader = styled.div`
   align-items: center;
   display: flex;
   flex-direction: column;
   justify-content: center;
-`
+`;
 
 const StyledPepemon = styled.div`
   font-size: 32px;
   position: relative;
   animation: 1s ${spin} infinite;
-`
+`;
 
-const StyledText = styled.div`
+const StyledText = styled.div``;
 
-`
-
-export default Loader
+export default Loader;

--- a/packages/app/src/components/Loader/index.ts
+++ b/packages/app/src/components/Loader/index.ts
@@ -1,1 +1,1 @@
-export { default } from './Loader'
+export { default } from "./Loader";

--- a/packages/app/src/components/Loading/Loading.tsx
+++ b/packages/app/src/components/Loading/Loading.tsx
@@ -1,32 +1,34 @@
-import React from 'react';
-import styled, { keyframes } from 'styled-components';
-import { walk1, walk2, walk3 } from '../../assets';
-import { Title } from '../../components';
-import { theme } from '../../theme';
+import React from "react";
+import styled, { keyframes } from "styled-components";
+import { walk1, walk2, walk3 } from "../../assets";
+import { Title } from "../../components";
+import { theme } from "../../theme";
 
 interface LoadingProps {
-	text?: string;
+  text?: string;
 }
 
-const Loading = ({text}: {text?: string|undefined}) => {
-	return (
-		<StyledLoading>
-			{ text &&
-				<Title as="h1" size='l' font={theme.font.inter} weight="900">{text}</Title>
-			}
-			<AnimatedImg1 src={walk1} alt="loading"/>
-			<AnimatedImg2 src={walk2} alt="loading"/>
-			<AnimatedImg3 src={walk3} alt="loading"/>
-		</StyledLoading>
-	)
-}
+const Loading = ({ text }: { text?: string | undefined }) => {
+  return (
+    <StyledLoading>
+      {text && (
+        <Title as="h1" size="l" font={theme.font.inter} weight="900">
+          {text}
+        </Title>
+      )}
+      <AnimatedImg1 src={walk1} alt="loading" />
+      <AnimatedImg2 src={walk2} alt="loading" />
+      <AnimatedImg3 src={walk3} alt="loading" />
+    </StyledLoading>
+  );
+};
 
 const StyledLoading = styled.div`
-	align-items: center;
-	display: flex;
-	flex-direction: column;
-	justify-content: flex-start;
-`
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+`;
 
 const walkAnim1 = keyframes`
   0% {
@@ -59,18 +61,18 @@ const walkAnim3 = keyframes`
 `;
 
 const AnimatedImg1 = styled.img`
-  	width: 96px;
-	animation: ${walkAnim1} 5.5s ease-in infinite;
-`
+  width: 96px;
+  animation: ${walkAnim1} 5.5s ease-in infinite;
+`;
 
 const AnimatedImg2 = styled.img`
-  	width: 96px;
-	animation: ${walkAnim2} 5s linear infinite;
-`
+  width: 96px;
+  animation: ${walkAnim2} 5s linear infinite;
+`;
 
 const AnimatedImg3 = styled.img`
-  	width: 96px;
-	animation: ${walkAnim3} 6s ease-out infinite;
-`
+  width: 96px;
+  animation: ${walkAnim3} 6s ease-out infinite;
+`;
 
 export default Loading;

--- a/packages/app/src/components/Loading/index.ts
+++ b/packages/app/src/components/Loading/index.ts
@@ -1,1 +1,1 @@
-export { default } from './Loading';
+export { default } from "./Loading";

--- a/packages/app/src/components/Logo/Logo.tsx
+++ b/packages/app/src/components/Logo/Logo.tsx
@@ -1,17 +1,20 @@
-import React from 'react'
-import { Link } from 'react-router-dom'
-import styled from 'styled-components'
+import React from "react";
+import { Link } from "react-router-dom";
+import styled from "styled-components";
 
 const Logo: React.FC = () => {
   return (
     <StyledLogo to="/">
-      <img src={'pepeballImg'} height="32" style={{ marginTop: -4 }} alt="pepeball"/>
-      <StyledText>
-        PEPEMON.finance
-      </StyledText>
+      <img
+        src={"pepeballImg"}
+        height="32"
+        style={{ marginTop: -4 }}
+        alt="pepeball"
+      />
+      <StyledText>PEPEMON.finance</StyledText>
     </StyledLogo>
-  )
-}
+  );
+};
 
 const StyledLogo = styled(Link)`
   align-items: center;
@@ -22,7 +25,7 @@ const StyledLogo = styled(Link)`
   min-width: 44px;
   padding: 0;
   text-decoration: none;
-`
+`;
 
 const StyledText = styled.span`
   color: ${(props) => props.theme.color[2]};
@@ -33,6 +36,6 @@ const StyledText = styled.span`
   @media (max-width: 400px) {
     display: flex;
   }
-`
+`;
 
-export default Logo
+export default Logo;

--- a/packages/app/src/components/Logo/index.ts
+++ b/packages/app/src/components/Logo/index.ts
@@ -1,1 +1,1 @@
-export { default } from './Logo'
+export { default } from "./Logo";

--- a/packages/app/src/components/MintCard/MintCard.tsx
+++ b/packages/app/src/components/MintCard/MintCard.tsx
@@ -96,11 +96,12 @@ const MintCard: React.FC<any> = () => {
           </Text>
           <Spacer size="md" />
           <Text as="p" font={theme.font.inter}>
-            Use PPDEX to mint rare Pepemon NFT cards. The NFTs are
-            created by upcoming artists all over the web3.
+            Use PPDEX to mint rare Pepemon NFT cards. The NFTs are created by
+            upcoming artists all over the web3.
             <br />
             <br />
-            Once you minted your cards, you can start playing by dueling with your NFTs in a play and earn card game on blockchain!
+            Once you minted your cards, you can start playing by dueling with
+            your NFTs in a play and earn card game on blockchain!
             <br />
             <br />
             "Pepechu, I choose you!"

--- a/packages/app/src/components/MintCard/index.ts
+++ b/packages/app/src/components/MintCard/index.ts
@@ -1,1 +1,1 @@
-export { default } from './MintCard';
+export { default } from "./MintCard";

--- a/packages/app/src/components/MobileMenu/MobileMenu.tsx
+++ b/packages/app/src/components/MobileMenu/MobileMenu.tsx
@@ -1,11 +1,11 @@
-import React from 'react'
-import styled, { keyframes } from 'styled-components'
+import React from "react";
+import styled, { keyframes } from "styled-components";
 
-import { NavLink } from 'react-router-dom'
+import { NavLink } from "react-router-dom";
 
 interface MobileMenuProps {
-  onDismiss: () => void
-  visible?: boolean
+  onDismiss: () => void;
+  visible?: boolean;
 }
 
 const MobileMenu: React.FC<MobileMenuProps> = ({ onDismiss, visible }) => {
@@ -26,12 +26,12 @@ const MobileMenu: React.FC<MobileMenuProps> = ({ onDismiss, visible }) => {
             Staking
           </StyledLink>
           <StyledLink
-              exact
-              activeClassName="active"
-              to="/store"
-              onClick={onDismiss}
+            exact
+            activeClassName="active"
+            to="/store"
+            onClick={onDismiss}
           >
-              Store
+            Store
           </StyledLink>
           {/*<StyledLink*/}
           {/*    exact*/}
@@ -43,19 +43,18 @@ const MobileMenu: React.FC<MobileMenuProps> = ({ onDismiss, visible }) => {
           {/*</StyledLink>*/}
         </StyledMobileMenu>
       </StyledMobileMenuWrapper>
-    )
+    );
   }
-  return null
-}
+  return null;
+};
 
 const StyledBackdrop = styled.div`
-
   position: absolute;
   top: 0;
   right: 0;
   bottom: 0;
   left: 0;
-`
+`;
 
 const StyledMobileMenuWrapper = styled.div`
   display: flex;
@@ -66,7 +65,7 @@ const StyledMobileMenuWrapper = styled.div`
   bottom: 0;
   left: 0;
   z-index: 1000;
-`
+`;
 
 const slideIn = keyframes`
   0% {
@@ -75,7 +74,7 @@ const slideIn = keyframes`
   100% {
     transform: translateX(-100%);
   }
-`
+`;
 
 const StyledMobileMenu = styled.div`
   animation: ${slideIn} 0.3s forwards ease-out;
@@ -89,7 +88,7 @@ const StyledMobileMenu = styled.div`
   left: 100%;
   bottom: 0;
   width: calc(100% - 48px);
-`
+`;
 
 const StyledLink = styled(NavLink)`
   box-sizing: border-box;
@@ -102,11 +101,9 @@ const StyledLink = styled(NavLink)`
   text-decoration: none;
   width: 100%;
   &:hover {
-
   }
   &.active {
-
   }
-`
+`;
 
-export default MobileMenu
+export default MobileMenu;

--- a/packages/app/src/components/MobileMenu/index.ts
+++ b/packages/app/src/components/MobileMenu/index.ts
@@ -1,1 +1,1 @@
-export { default } from './MobileMenu'
+export { default } from "./MobileMenu";

--- a/packages/app/src/components/Modal/Modal.tsx
+++ b/packages/app/src/components/Modal/Modal.tsx
@@ -1,24 +1,24 @@
-import React from 'react';
-import styled, { keyframes } from 'styled-components';
-import { ActionClose } from '../../assets';
-import { theme } from '../../theme';
+import React from "react";
+import styled, { keyframes } from "styled-components";
+import { ActionClose } from "../../assets";
+import { theme } from "../../theme";
 
 export interface ModalProps {
-	ref?: any;
-	onDismiss?: () => void;
-	maxWidth?: number;
-	rounded?: boolean;
+  ref?: any;
+  onDismiss?: () => void;
+  maxWidth?: number;
+  rounded?: boolean;
 }
 
 const Modal: React.FC<ModalProps> = ({ children, onDismiss, maxWidth }) => {
-	return (
-		<StyledResponsiveWrapper>
-			<StyledModal maxWidth={maxWidth}>
-				<ActionClose onClick={onDismiss} />
-				{children}
-			</StyledModal>
-		</StyledResponsiveWrapper>
-	);
+  return (
+    <StyledResponsiveWrapper>
+      <StyledModal maxWidth={maxWidth}>
+        <ActionClose onClick={onDismiss} />
+        {children}
+      </StyledModal>
+    </StyledResponsiveWrapper>
+  );
 };
 
 const mobileKeyframes = keyframes`
@@ -31,50 +31,50 @@ const mobileKeyframes = keyframes`
 `;
 
 const StyledResponsiveWrapper = styled.div`
-	align-items: center;
-	animation: ${mobileKeyframes} 0.3s forwards ease-in;
-	background: rgba(0, 0, 0, 0.3);
-	display: flex;
-	flex-direction: column;
-	height: 100vh;
-	justify-content: center;
-	left: 0;
-	padding: 1em;
-	position: fixed;
-	top: 0;
-	width: 100vw;
-	z-index: 10;
+  align-items: center;
+  animation: ${mobileKeyframes} 0.3s forwards ease-in;
+  background: rgba(0, 0, 0, 0.3);
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  justify-content: center;
+  left: 0;
+  padding: 1em;
+  position: fixed;
+  top: 0;
+  width: 100vw;
+  z-index: 10;
 
-	@media (max-width: ${(props) => props.theme.breakpoints.tablet}px) {
-		flex: 1;
-		position: absolute;
-		top: 100%;
-		right: 0;
-		left: 0;
-		animation: ${mobileKeyframes} 0.3s forwards ease-out;
-		max-width: 100vw;
-	}
+  @media (max-width: ${(props) => props.theme.breakpoints.tablet}px) {
+    flex: 1;
+    position: absolute;
+    top: 100%;
+    right: 0;
+    left: 0;
+    animation: ${mobileKeyframes} 0.3s forwards ease-out;
+    max-width: 100vw;
+  }
 
-	& svg:first-child {
-		position: absolute;
-		top: 1em;
-		right: 1em;
-		z-index: 10;
-	}
+  & svg:first-child {
+    position: absolute;
+    top: 1em;
+    right: 1em;
+    z-index: 10;
+  }
 `;
 
 const StyledModal = styled.div<ModalProps>`
-	padding: 2em;
-	background-color: ${props => props.theme.color.white};
-	border-radius: ${props => props.rounded ? "32px" : "10px"};
-	box-shadow: 0 5px 10px 0px ${theme.color.colorsLayoutShadows};
-	display: flex;
-	flex-direction: column;
-	max-width: ${(props) => props.maxWidth ? props.maxWidth : 800}px;
-	align-items: center;
-	position: relative;
-	width: 100%;
-	min-height: 0;
+  padding: 2em;
+  background-color: ${(props) => props.theme.color.white};
+  border-radius: ${(props) => (props.rounded ? "32px" : "10px")};
+  box-shadow: 0 5px 10px 0px ${theme.color.colorsLayoutShadows};
+  display: flex;
+  flex-direction: column;
+  max-width: ${(props) => (props.maxWidth ? props.maxWidth : 800)}px;
+  align-items: center;
+  position: relative;
+  width: 100%;
+  min-height: 0;
 `;
 
 export default Modal;

--- a/packages/app/src/components/Modal/index.ts
+++ b/packages/app/src/components/Modal/index.ts
@@ -1,2 +1,2 @@
-export { default } from './Modal'
-export type { ModalProps } from './Modal'
+export { default } from "./Modal";
+export type { ModalProps } from "./Modal";

--- a/packages/app/src/components/ModalActions/ModalActions.tsx
+++ b/packages/app/src/components/ModalActions/ModalActions.tsx
@@ -1,37 +1,45 @@
-import React from 'react';
-import styled from 'styled-components';
-import { ExternalLink, ExternalLinkProps, Button, ButtonProps, Spacer } from '../../components';
+import React from "react";
+import styled from "styled-components";
+import {
+  ExternalLink,
+  ExternalLinkProps,
+  Button,
+  ButtonProps,
+  Spacer,
+} from "../../components";
 
 interface ModalActionProps {
-	text: string,
-	buttonProps: ButtonProps|ExternalLinkProps,
-	href?: string
+  text: string;
+  buttonProps: ButtonProps | ExternalLinkProps;
+  href?: string;
 }
 
 export interface ModalActionsProps {
-	modalActions?: ModalActionProps[],
+  modalActions?: ModalActionProps[];
 }
 
 const ModalActions: React.FC<ModalActionsProps> = ({ modalActions }) => {
-	const l = modalActions.length;
+  const l = modalActions.length;
 
-	return (
-		<div>
-			{modalActions.map((modalAction, i) => (
-				<StyledModalActions key={i}>
-					<StyledModalAction>
-						{modalAction.href ?
-								<ExternalLink href={modalAction.href} styling='button'>{modalAction.text}</ExternalLink>
-							:
-								<Button {...modalAction.buttonProps}>{modalAction.text}</Button>
-						}
-					</StyledModalAction>
-					{i < l - 1 && <Spacer size='sm'/>}
-				</StyledModalActions>
-			))}
-		</div>
-	)
-}
+  return (
+    <div>
+      {modalActions.map((modalAction, i) => (
+        <StyledModalActions key={i}>
+          <StyledModalAction>
+            {modalAction.href ? (
+              <ExternalLink href={modalAction.href} styling="button">
+                {modalAction.text}
+              </ExternalLink>
+            ) : (
+              <Button {...modalAction.buttonProps}>{modalAction.text}</Button>
+            )}
+          </StyledModalAction>
+          {i < l - 1 && <Spacer size="sm" />}
+        </StyledModalActions>
+      ))}
+    </div>
+  );
+};
 
 const StyledModalActions = styled.div`
   align-items: center;
@@ -40,16 +48,16 @@ const StyledModalActions = styled.div`
   justify-content: center;
   margin: 0;
   width: 100%;
-`
+`;
 
 const StyledModalAction = styled.div`
-	display: block;
-	margin-bottom: 1em;
-	width: fit-content;
+  display: block;
+  margin-bottom: 1em;
+  width: fit-content;
 
-	a {
-		display: block;
-	}
-`
+  a {
+    display: block;
+  }
+`;
 
-export default ModalActions
+export default ModalActions;

--- a/packages/app/src/components/ModalActions/index.ts
+++ b/packages/app/src/components/ModalActions/index.ts
@@ -1,2 +1,2 @@
-export { default } from './ModalActions'
-export type { ModalActionsProps } from './ModalActions';
+export { default } from "./ModalActions";
+export type { ModalActionsProps } from "./ModalActions";

--- a/packages/app/src/components/ModalContent/ModalContent.tsx
+++ b/packages/app/src/components/ModalContent/ModalContent.tsx
@@ -1,12 +1,12 @@
-import React from 'react'
-import styled from 'styled-components'
+import React from "react";
+import styled from "styled-components";
 
 const ModalContent: React.FC = ({ children }) => {
-	return <StyledModalContent>{children}</StyledModalContent>
-}
+  return <StyledModalContent>{children}</StyledModalContent>;
+};
 
 const StyledModalContent = styled.div`
-	padding: ${(props) => props.theme.spacing[2]}px;
-`
+  padding: ${(props) => props.theme.spacing[2]}px;
+`;
 
-export default ModalContent
+export default ModalContent;

--- a/packages/app/src/components/ModalContent/index.ts
+++ b/packages/app/src/components/ModalContent/index.ts
@@ -1,1 +1,1 @@
-export { default } from './ModalContent'
+export { default } from "./ModalContent";

--- a/packages/app/src/components/ModalTitle/ModalTitle.tsx
+++ b/packages/app/src/components/ModalTitle/ModalTitle.tsx
@@ -1,15 +1,13 @@
-import React from 'react'
-import styled from 'styled-components'
+import React from "react";
+import styled from "styled-components";
 
 interface ModalTitleProps {
-  text?: string
+  text?: string;
 }
 
 const ModalTitle: React.FC<ModalTitleProps> = ({ text }) => (
-  <StyledModalTitle>
-    {text}
-  </StyledModalTitle>
-)
+  <StyledModalTitle>{text}</StyledModalTitle>
+);
 
 const StyledModalTitle = styled.div`
   align-items: center;
@@ -17,6 +15,6 @@ const StyledModalTitle = styled.div`
   font-size: 1.375rem;
   font-weight: 700;
   justify-content: center;
-`
+`;
 
-export default ModalTitle
+export default ModalTitle;

--- a/packages/app/src/components/ModalTitle/index.ts
+++ b/packages/app/src/components/ModalTitle/index.ts
@@ -1,1 +1,1 @@
-export { default } from './ModalTitle'
+export { default } from "./ModalTitle";

--- a/packages/app/src/components/Navigation/Navigation.tsx
+++ b/packages/app/src/components/Navigation/Navigation.tsx
@@ -1,91 +1,96 @@
-import React, { useState, useRef } from 'react';
-import { Link, useLocation } from 'react-router-dom';
-import styled from 'styled-components';
-import { isMobile } from 'web3modal';
-import { useOutsideClick } from '../../hooks';
+import React, { useState, useRef } from "react";
+import { Link, useLocation } from "react-router-dom";
+import styled from "styled-components";
+import { isMobile } from "web3modal";
+import { useOutsideClick } from "../../hooks";
 import {
-	pepemonLogoSmall,
-	events,
-	home,
-	my_collection,
-	staking,
-	store,
-	bridge,
-	subscriptions,
-	logoexpand,
-	MenuIcon,
-} from '../../assets';
-import { theme } from '../../theme';
+  pepemonLogoSmall,
+  events,
+  home,
+  my_collection,
+  staking,
+  store,
+  bridge,
+  subscriptions,
+  logoexpand,
+  MenuIcon,
+} from "../../assets";
+import { theme } from "../../theme";
 
 const Navigation = () => {
-	const [navLogo, setNavLogo] = useState(pepemonLogoSmall);
-	const [isOpen, setIsOpen] = useState(false);
-	const { pathname } = useLocation();
+  const [navLogo, setNavLogo] = useState(pepemonLogoSmall);
+  const [isOpen, setIsOpen] = useState(false);
+  const { pathname } = useLocation();
 
-	const navRef = useRef(null);
-	useOutsideClick(navRef, () => isOpen && setIsOpen(false));
+  const navRef = useRef(null);
+  useOutsideClick(navRef, () => isOpen && setIsOpen(false));
 
-	return (
-		<StyledMenuOuterWrapper
-			{...(!isMobile() && {
-				onMouseEnter: () => setNavLogo(logoexpand),
-				onMouseLeave: () => setNavLogo(pepemonLogoSmall),
-			})}
-			ref={navRef}>
-			<StyledMenuInnerWrapper isOpen={isOpen}>
-				<StyledLogoWrapper>
-					<StyledMenuIcon onClick={() => setIsOpen(!isOpen)}>
-						<MenuIcon isOpen={isOpen} />
-					</StyledMenuIcon>
-					<StyledLogoLink to='/'>
-						<img src={navLogo} alt='logo' />
-					</StyledLogoLink>
-				</StyledLogoWrapper>
+  return (
+    <StyledMenuOuterWrapper
+      {...(!isMobile() && {
+        onMouseEnter: () => setNavLogo(logoexpand),
+        onMouseLeave: () => setNavLogo(pepemonLogoSmall),
+      })}
+      ref={navRef}
+    >
+      <StyledMenuInnerWrapper isOpen={isOpen}>
+        <StyledLogoWrapper>
+          <StyledMenuIcon onClick={() => setIsOpen(!isOpen)}>
+            <MenuIcon isOpen={isOpen} />
+          </StyledMenuIcon>
+          <StyledLogoLink to="/">
+            <img src={navLogo} alt="logo" />
+          </StyledLogoLink>
+        </StyledLogoWrapper>
 
-				<StyledMenuList isOpen={isOpen}>
-					<StyledMenuListItem
-						onClick={() => setIsOpen(false)}
-						isActive={pathname === '/' && true}>
-						<StyledLink to='/'>
-							<StyledLinkIcon loading='lazy' src={home} alt='home' />
-							<span>Home</span>
-						</StyledLink>
-					</StyledMenuListItem>
-					<StyledMenuListItem
-						onClick={() => setIsOpen(false)}
-						isActive={pathname.startsWith('/staking') && true}>
-						<StyledLink to='/staking'>
-							<StyledLinkIcon loading='lazy' src={staking} alt='staking' />
-							<span>Earning</span>
-						</StyledLink>
-					</StyledMenuListItem>
-					<StyledMenuListItem
-						onClick={() => setIsOpen(false)}
-						isActive={pathname.startsWith('/subscription') && true}>
-						<StyledLink to='/subscription'>
-							<StyledLinkIcon
-								loading='lazy'
-								src={subscriptions}
-								alt='subscriptions'
-							/>
-							<span>Subscription</span>
-						</StyledLink>
-					</StyledMenuListItem>
-					<StyledMenuListItem
-						onClick={() => setIsOpen(false)}
-						isActive={pathname.startsWith('/store') && true}>
-						<StyledLink to='/store'>
-							<StyledLinkIcon loading='lazy' src={store} alt='store' />
-							<span>Store</span>
-						</StyledLink>
-					</StyledMenuListItem>
-					<StyledMenuListItem ended isActive={false}>
-						<StyledLink to='/bridge'>
-							<StyledLinkIcon loading='lazy' src={bridge} alt='bridge' />
-							<span>Portal</span>
-						</StyledLink>
-					</StyledMenuListItem>
-					{/* <StyledMenuListItem onClick={() => setIsOpen(false)} isActive={false}>
+        <StyledMenuList isOpen={isOpen}>
+          <StyledMenuListItem
+            onClick={() => setIsOpen(false)}
+            isActive={pathname === "/" && true}
+          >
+            <StyledLink to="/">
+              <StyledLinkIcon loading="lazy" src={home} alt="home" />
+              <span>Home</span>
+            </StyledLink>
+          </StyledMenuListItem>
+          <StyledMenuListItem
+            onClick={() => setIsOpen(false)}
+            isActive={pathname.startsWith("/staking") && true}
+          >
+            <StyledLink to="/staking">
+              <StyledLinkIcon loading="lazy" src={staking} alt="staking" />
+              <span>Earning</span>
+            </StyledLink>
+          </StyledMenuListItem>
+          <StyledMenuListItem
+            onClick={() => setIsOpen(false)}
+            isActive={pathname.startsWith("/subscription") && true}
+          >
+            <StyledLink to="/subscription">
+              <StyledLinkIcon
+                loading="lazy"
+                src={subscriptions}
+                alt="subscriptions"
+              />
+              <span>Subscription</span>
+            </StyledLink>
+          </StyledMenuListItem>
+          <StyledMenuListItem
+            onClick={() => setIsOpen(false)}
+            isActive={pathname.startsWith("/store") && true}
+          >
+            <StyledLink to="/store">
+              <StyledLinkIcon loading="lazy" src={store} alt="store" />
+              <span>Store</span>
+            </StyledLink>
+          </StyledMenuListItem>
+          <StyledMenuListItem ended isActive={false}>
+            <StyledLink to="/bridge">
+              <StyledLinkIcon loading="lazy" src={bridge} alt="bridge" />
+              <span>Portal</span>
+            </StyledLink>
+          </StyledMenuListItem>
+          {/* <StyledMenuListItem onClick={() => setIsOpen(false)} isActive={false}>
 						<ExternalStyledLink href='https://pepesea.pepemon.world/'>
 							<StyledLinkIcon
 								loading='lazy'
@@ -95,50 +100,50 @@ const Navigation = () => {
 							<span>Marketplace</span>
 						</ExternalStyledLink>
 					</StyledMenuListItem> */}
-					<StyledMenuListItem soon isActive={false}>
-						<StyledLink to='/'>
-							<StyledLinkIcon loading='lazy' src={events} alt='events' />
-							<span>Evolution Events</span>
-						</StyledLink>
-					</StyledMenuListItem>
-				</StyledMenuList>
-			</StyledMenuInnerWrapper>
-		</StyledMenuOuterWrapper>
-	);
+          <StyledMenuListItem soon isActive={false}>
+            <StyledLink to="/">
+              <StyledLinkIcon loading="lazy" src={events} alt="events" />
+              <span>Evolution Events</span>
+            </StyledLink>
+          </StyledMenuListItem>
+        </StyledMenuList>
+      </StyledMenuInnerWrapper>
+    </StyledMenuOuterWrapper>
+  );
 };
 
 const StyledLogoWrapper = styled.div`
-	align-self: flex-start;
-	align-items: center;
-	display: flex;
-	height: ${theme.topBarSize}px;
-	right: -100%;
-	position: relative;
+  align-self: flex-start;
+  align-items: center;
+  display: flex;
+  height: ${theme.topBarSize}px;
+  right: -100%;
+  position: relative;
 
-	@media (min-width: ${theme.breakpoints.desktop}) {
-		right: 0;
-		margin-bottom: 2em;
-		margin-top: 2em;
-	}
+  @media (min-width: ${theme.breakpoints.desktop}) {
+    right: 0;
+    margin-bottom: 2em;
+    margin-top: 2em;
+  }
 `;
 
 const StyledMenuInnerWrapper = styled.div<{ isOpen: boolean }>`
-	align-items: center;
-	display: flex;
-	flex-direction: column;
-	height: 100vh;
-	transform: translateX(-100%);
-	transition: transform 0.2s cubic-bezier(0.04, 0.8, 0.61, 0.89);
-	max-width: ${theme.sideBar.width.opened}px;
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  transform: translateX(-100%);
+  transition: transform 0.2s cubic-bezier(0.04, 0.8, 0.61, 0.89);
+  max-width: ${theme.sideBar.width.opened}px;
 
-	@media (min-width: ${theme.breakpoints.desktop}) {
-		background-color: ${theme.color.white};
-		transform: translateX(0);
-	}
+  @media (min-width: ${theme.breakpoints.desktop}) {
+    background-color: ${theme.color.white};
+    transform: translateX(0);
+  }
 
-	${({ isOpen }) =>
-		isOpen &&
-		`
+  ${({ isOpen }) =>
+    isOpen &&
+    `
 		transform: translateX(0);
 
 		${StyledLogoWrapper} {
@@ -147,107 +152,107 @@ const StyledMenuInnerWrapper = styled.div<{ isOpen: boolean }>`
 	`}
 `;
 const StyledMenuList = styled.ul<{ isOpen: boolean }>`
-	align-items: center;
-	background-color: ${theme.color.white};
-	display: flex;
-	flex-direction: column;
-	height: 100%;
-	list-style-type: none;
-	margin-bottom: 0;
-	margin-top: 0;
-	padding-left: 1em;
-	width: 100%;
+  align-items: center;
+  background-color: ${theme.color.white};
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  list-style-type: none;
+  margin-bottom: 0;
+  margin-top: 0;
+  padding-left: 1em;
+  width: 100%;
 
-	@media (min-width: ${theme.breakpoints.desktop}) {
-		padding-left: 2em;
-	}
+  @media (min-width: ${theme.breakpoints.desktop}) {
+    padding-left: 2em;
+  }
 `;
 
 interface StyledLinkProps {
-	isActive?: boolean;
-	soon?: boolean;
-	ended?: boolean;
+  isActive?: boolean;
+  soon?: boolean;
+  ended?: boolean;
 }
 
 const StyledLink = styled(Link)<StyledLinkProps>`
-	align-items: flex-start;
-	display: flex;
-	justify-content: flex-start;
-	margin-bottom: 1.6em;
-	margin-top: 1.6em;
-	overflow: hidde;
-	text-decoration: none;
+  align-items: flex-start;
+  display: flex;
+  justify-content: flex-start;
+  margin-bottom: 1.6em;
+  margin-top: 1.6em;
+  overflow: hidde;
+  text-decoration: none;
 
-	@media (min-width: ${theme.breakpoints.desktop}) {
-		align-items: center;
-	}
+  @media (min-width: ${theme.breakpoints.desktop}) {
+    align-items: center;
+  }
 
-	span {
-		flex: 1 0 auto;
-		font-size: 1.25rem;
-		margin-left: 1em;
-		padding-right: 1em;
-		position: relative;
+  span {
+    flex: 1 0 auto;
+    font-size: 1.25rem;
+    margin-left: 1em;
+    padding-right: 1em;
+    position: relative;
 
-		@media (min-width: ${theme.breakpoints.desktop}) {
-			opacity: 0;
-			padding-right: 1.9em;
-			transform: translateX(-100%);
-			transition: all 0.4s cubic-bezier(0.04, 0.8, 0.61, 0.89);
-		}
-	}
+    @media (min-width: ${theme.breakpoints.desktop}) {
+      opacity: 0;
+      padding-right: 1.9em;
+      transform: translateX(-100%);
+      transition: all 0.4s cubic-bezier(0.04, 0.8, 0.61, 0.89);
+    }
+  }
 `;
 
 interface ExternalStyledLinkProps {
-	isActive?: boolean;
+  isActive?: boolean;
 }
 
 const ExternalStyledLink = styled.a<ExternalStyledLinkProps>`
-	align-items: flex-start;
-	display: flex;
-	justify-content: flex-start;
-	margin-bottom: 1.6em;
-	margin-top: 1.6em;
-	overflow: hidden;
-	text-decoration: none;
+  align-items: flex-start;
+  display: flex;
+  justify-content: flex-start;
+  margin-bottom: 1.6em;
+  margin-top: 1.6em;
+  overflow: hidden;
+  text-decoration: none;
 
-	@media (min-width: ${theme.breakpoints.desktop}) {
-		align-items: center;
-	}
+  @media (min-width: ${theme.breakpoints.desktop}) {
+    align-items: center;
+  }
 
-	span {
-		flex: 1 0 auto;
-		font-size: 1.25rem;
-		margin-left: 1em;
-		padding-right: 1em;
-		position: relative;
+  span {
+    flex: 1 0 auto;
+    font-size: 1.25rem;
+    margin-left: 1em;
+    padding-right: 1em;
+    position: relative;
 
-		@media (min-width: ${theme.breakpoints.desktop}) {
-			opacity: 0;
-			padding-right: 1.9em;
-			transform: translateX(-100%);
-			transition: all 0.4s cubic-bezier(0.04, 0.8, 0.61, 0.89);
-		}
-	}
+    @media (min-width: ${theme.breakpoints.desktop}) {
+      opacity: 0;
+      padding-right: 1.9em;
+      transform: translateX(-100%);
+      transition: all 0.4s cubic-bezier(0.04, 0.8, 0.61, 0.89);
+    }
+  }
 `;
 
 const StyledMenuListItem = styled.li<StyledLinkProps>`
-	overflow: hidden;
-	width: 100%;
+  overflow: hidden;
+  width: 100%;
 
-	${StyledLink},${ExternalStyledLink} {
-		color: ${(props) =>
-			props.isActive ? theme.color.layoutPrimary : theme.color.layoutOverlay};
-		pointer-events: ${(props) => (props.soon || props.ended) && 'none'};
+  ${StyledLink},${ExternalStyledLink} {
+    color: ${(props) =>
+      props.isActive ? theme.color.layoutPrimary : theme.color.layoutOverlay};
+    pointer-events: ${(props) => (props.soon || props.ended) && "none"};
 
-		img {
-			opacity: ${(props) => (props.isActive ? 1 : 0.6)};
-		}
+    img {
+      opacity: ${(props) => (props.isActive ? 1 : 0.6)};
+    }
 
-		span {
-			${({ soon }) =>
-				soon &&
-				`
+    span {
+      ${({ soon }) =>
+        soon &&
+        `
 				&::after {
 					background-image: linear-gradient(to bottom, #aa6cd6 -100%, #713aac);
 					border-radius: 8px;
@@ -262,9 +267,9 @@ const StyledMenuListItem = styled.li<StyledLinkProps>`
 					top: -1.7em;
 				}
 			`}
-			${({ ended }) =>
-				ended &&
-				`
+      ${({ ended }) =>
+        ended &&
+        `
 				&::after {
 					background-image: linear-gradient(to bottom, #888888 -100%, #555555);
 					border-radius: 8px;
@@ -279,85 +284,85 @@ const StyledMenuListItem = styled.li<StyledLinkProps>`
 					top: -1.7em;
 				}
 			`}
-		}
-	}
+    }
+  }
 `;
 
 const StyledMenuIcon = styled.button`
-	background-color: transparent;
-	border: none;
-	padding-left: 1em;
-	padding-right: 1em;
+  background-color: transparent;
+  border: none;
+  padding-left: 1em;
+  padding-right: 1em;
 
-	@media (min-width: ${theme.breakpoints.desktop}) {
-		display: none;
-	}
+  @media (min-width: ${theme.breakpoints.desktop}) {
+    display: none;
+  }
 `;
 
 const StyledLogoLink = styled(StyledLink)<StyledLinkProps>`
-	align-items: center;
-	height: ${theme.topBarSize}px;
-	margin-bottom: 0;
-	margin-top: 0;
+  align-items: center;
+  height: ${theme.topBarSize}px;
+  margin-bottom: 0;
+  margin-top: 0;
 
-	img {
-		width: 40px;
-	}
+  img {
+    width: 40px;
+  }
 
-	@media (min-width: ${theme.breakpoints.desktop}) {
-		margin-left: ${(theme.sideBar.width.closed - 80) / 2}px;
-		margin-right: ${(theme.sideBar.width.closed - 80) / 2}px;
-		height: 107px;
+  @media (min-width: ${theme.breakpoints.desktop}) {
+    margin-left: ${(theme.sideBar.width.closed - 80) / 2}px;
+    margin-right: ${(theme.sideBar.width.closed - 80) / 2}px;
+    height: 107px;
 
-		img {
-			width: 80px;
-		}
-	}
+    img {
+      width: 80px;
+    }
+  }
 `;
 
 const StyledLinkIcon = styled.img`
-	width: ${theme.sideBar.width.closed / 4}px;
-	height: ${theme.sideBar.width.closed / 4}px;
-	object-fit: contain;
+  width: ${theme.sideBar.width.closed / 4}px;
+  height: ${theme.sideBar.width.closed / 4}px;
+  object-fit: contain;
 `;
 
 const StyledMenuOuterWrapper = styled.div`
-	& {
-		background-color: ${theme.color.typographyAllTextOnDark};
-		box-shadow: 0 4px 8px 0 ${theme.color.iconBackgroundGrey8};
-		height: ${theme.topBarSize}px;
-		left: 0;
-		position: fixed;
-		top: 0;
-		transition: width 0.2s cubic-bezier(0.04, 0.8, 0.61, 0.89);
-		width: 100vw;
-		z-index: 30;
+  & {
+    background-color: ${theme.color.typographyAllTextOnDark};
+    box-shadow: 0 4px 8px 0 ${theme.color.iconBackgroundGrey8};
+    height: ${theme.topBarSize}px;
+    left: 0;
+    position: fixed;
+    top: 0;
+    transition: width 0.2s cubic-bezier(0.04, 0.8, 0.61, 0.89);
+    width: 100vw;
+    z-index: 30;
 
-		@media (min-width: ${theme.breakpoints.desktop}) {
-			box-shadow: none;
-			width: ${theme.sideBar.width.closed}px;
-		}
-	}
+    @media (min-width: ${theme.breakpoints.desktop}) {
+      box-shadow: none;
+      width: ${theme.sideBar.width.closed}px;
+    }
+  }
 
-	&:hover {
-		@media (min-width: ${theme.breakpoints.desktop}) {
-			width: ${theme.sideBar.width.opened}px;
-			box-shadow: 0 4px 15px 10px ${theme.color.colorsLayoutShadows};
+  &:hover {
+    @media (min-width: ${theme.breakpoints.desktop}) {
+      width: ${theme.sideBar.width.opened}px;
+      box-shadow: 0 4px 15px 10px ${theme.color.colorsLayoutShadows};
 
-			${StyledLogoLink} {
-				margin-left: 2em;
+      ${StyledLogoLink} {
+        margin-left: 2em;
 
-				img {
-					width: 200px;
-				}
-			}
+        img {
+          width: 200px;
+        }
+      }
 
-			span {
-				opacity: 1;
-				transform: translateX(0%);
-			}
-		}
-	}
+      span {
+        opacity: 1;
+        transform: translateX(0%);
+      }
+    }
+  }
 `;
 
 export default Navigation;

--- a/packages/app/src/components/Navigation/index.ts
+++ b/packages/app/src/components/Navigation/index.ts
@@ -1,1 +1,1 @@
-export { default } from './Navigation';
+export { default } from "./Navigation";

--- a/packages/app/src/components/Newsletter/Newsletter.tsx
+++ b/packages/app/src/components/Newsletter/Newsletter.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import styled from "styled-components";
-import { LazyLoadImage } from 'react-lazy-load-image-component';
+import { LazyLoadImage } from "react-lazy-load-image-component";
 import { theme } from "../../theme";
 import { useModal } from "../../hooks";
 import { api } from "../../constants";
@@ -8,156 +8,189 @@ import { Button, ContentCentered, Title, Text, Spacer } from "../../components";
 import { walk1, walk2, walk3 } from "../../assets";
 
 const Newsletter: React.FC<any> = () => {
+  const randomNumber = Math.floor(Math.random() * 3);
+  const walkingPepemon = [walk1, walk2, walk3][randomNumber];
 
-	const randomNumber = Math.floor(Math.random() * 3);
-	const walkingPepemon = [walk1, walk2, walk3][randomNumber];
+  const [email, setEmail] = useState("");
 
-	const [email, setEmail] = useState('');
+  const initSignUpState = {
+    success: undefined,
+    title: "",
+    message: "",
+  };
+  const [signUpState, setSignUpState] = useState(initSignUpState);
 
-	const initSignUpState = {
-		success: undefined,
-		title: '',
-		message: ''
-	};
-	const [signUpState, setSignUpState] = useState(initSignUpState);
+  // @dev: run `netlify dev --live` to test the function
+  const handleSignUp = async () => {
+    const lambdaApiEndpoint = api.lambdaApi.endpoint;
+    const lambdaApiFunction = api.lambdaApi.functions.subsNewsletter;
 
-	// @dev: run `netlify dev --live` to test the function
-	const handleSignUp = async () => {
-		const lambdaApiEndpoint = api.lambdaApi.endpoint;
-		const lambdaApiFunction = api.lambdaApi.functions.subsNewsletter;
+    const req = await fetch(
+      `${lambdaApiEndpoint + lambdaApiFunction}?email=${email}`
+    );
 
-		const req = await fetch(`${lambdaApiEndpoint+lambdaApiFunction}?email=${email}`);
+    if (req.status === 202) {
+      setSignUpState({
+        success: true,
+        title: "Sign up succeeded",
+        message: "You are now subscribed to the pepemon newsletter.",
+      });
+    } else {
+      setSignUpState({
+        success: false,
+        title: "Sign up failed",
+        message: "Something went wrong. Please try again.",
+      });
+    }
+    // reset input
+    setEmail("");
+  };
 
-		if (req.status === 202) {
-			setSignUpState({
-				success: true,
-				title: 'Sign up succeeded',
-				message: 'You are now subscribed to the pepemon newsletter.'
-			});
-		} else {
-			setSignUpState({
-				success: false,
-				title: 'Sign up failed',
-				message: 'Something went wrong. Please try again.'
-			});
-		}
-		// reset input
-		setEmail('');
-	}
+  const [handlePresent, onDismiss] = useModal({
+    title: signUpState.title,
+    content: (
+      <Text
+        align="center"
+        font={theme.font.inter}
+        size="s"
+        color={theme.color.gray[600]}
+      >
+        {signUpState.message}
+      </Text>
+    ),
+    modalActions: [
+      {
+        text: signUpState.success ? "Great!" : "I'll try again",
+        buttonProps: {
+          styling: "purple",
+          onClick: () => setSignUpState(initSignUpState),
+        },
+      },
+    ],
+  });
 
-	const [handlePresent, onDismiss] = useModal({
-		title: signUpState.title,
-		content: <Text align='center' font={theme.font.inter} size='s' color={theme.color.gray[600]}>
-					{signUpState.message}
-				</Text>,
-		modalActions: [
-			{
-				text: signUpState.success ? 'Great!' : 'I\'ll try again',
-				buttonProps: { styling: 'purple', onClick: () => setSignUpState(initSignUpState) },
-			}
-		]
-	})
+  useEffect(() => {
+    if (signUpState.success !== undefined) {
+      handlePresent();
+    } else if (signUpState.success) {
+      onDismiss();
+    }
+  }, [signUpState, handlePresent, onDismiss]);
 
-	useEffect(() => {
-		if (signUpState.success !== undefined) {
-			handlePresent();
-		} else if (signUpState.success) {
-			onDismiss();
-		}
-	}, [signUpState, handlePresent, onDismiss]);
-
-	return (
-		<>
-			<ContentCentered id="newsletter" style={{paddingTop: "6em", paddingBottom: "12em"}}>
-				<Title as="h1" font={theme.font.neometric} size='xxl' weight={900} align="center">
-					Stay up to date and claim ‘em all
-				</Title>
-				<Spacer size="md"/>
-				<Text as="p" font={theme.font.spaceMace} align="center" underline>Newsletter</Text>
-				<Spacer size="md"/>
-				<Text as="p" font={theme.font.inter} lineHeight={1.5} align="center">
-					Be the first to collect all the new Pepemons.
-				</Text>
-				<Spacer size="md"/>
-				<ContentCentered 
-					direction="row" 
-					bgColor={theme.color.white} 
-					style={{ 
-						borderRadius: "8px", 
-						border: `1px solid ${theme.color.purple[600]}`, 
-						position: 'relative'
-				}}>
-					<StyledInput onChange={(e) => setEmail(e.target.value)} type="email" />
-					<Button styling="purple" disabled={email ? false : true} onClick={handleSignUp}>Sign up</Button>
-					<WalkingPepemon src={walkingPepemon} alt="walking pepemon" />
-				</ContentCentered>
-			</ContentCentered>
-		</>
-	)
-}
+  return (
+    <>
+      <ContentCentered
+        id="newsletter"
+        style={{ paddingTop: "6em", paddingBottom: "12em" }}
+      >
+        <Title
+          as="h1"
+          font={theme.font.neometric}
+          size="xxl"
+          weight={900}
+          align="center"
+        >
+          Stay up to date and claim ‘em all
+        </Title>
+        <Spacer size="md" />
+        <Text as="p" font={theme.font.spaceMace} align="center" underline>
+          Newsletter
+        </Text>
+        <Spacer size="md" />
+        <Text as="p" font={theme.font.inter} lineHeight={1.5} align="center">
+          Be the first to collect all the new Pepemons.
+        </Text>
+        <Spacer size="md" />
+        <ContentCentered
+          direction="row"
+          bgColor={theme.color.white}
+          style={{
+            borderRadius: "8px",
+            border: `1px solid ${theme.color.purple[600]}`,
+            position: "relative",
+          }}
+        >
+          <StyledInput
+            onChange={(e) => setEmail(e.target.value)}
+            type="email"
+          />
+          <Button
+            styling="purple"
+            disabled={email ? false : true}
+            onClick={handleSignUp}
+          >
+            Sign up
+          </Button>
+          <WalkingPepemon src={walkingPepemon} alt="walking pepemon" />
+        </ContentCentered>
+      </ContentCentered>
+    </>
+  );
+};
 
 const StyledInput = styled.input`
-	background: none;
-	border: none;
-	flex: 1 1 0%;
-	font-size: 1.2rem;
-	min-width: 0;
-	padding: 0.5em;
-	&:focus-visible {
-		outline: none;
-	}
-`
+  background: none;
+  border: none;
+  flex: 1 1 0%;
+  font-size: 1.2rem;
+  min-width: 0;
+  padding: 0.5em;
+  &:focus-visible {
+    outline: none;
+  }
+`;
 
 const WalkingPepemon = styled(LazyLoadImage)`
-	position: absolute;
-	width: 96px;
-	height: 96px;
-	transform: rotate(180deg) scale(-1);
-	animation: walk-pepemon-newsletter ${(props) => props.duration || "10s"} linear infinite;
-  	animation-delay: ${(props) => props.delay || "0s"};
-	bottom: -96px;
+  position: absolute;
+  width: 96px;
+  height: 96px;
+  transform: rotate(180deg) scale(-1);
+  animation: walk-pepemon-newsletter ${(props) => props.duration || "10s"}
+    linear infinite;
+  animation-delay: ${(props) => props.delay || "0s"};
+  bottom: -96px;
 
   @keyframes walk-pepemon-newsletter {
     0% {
       left: calc(50% - 48px);
-	  transform: rotate(180deg) scaleX(-1);
+      transform: rotate(180deg) scaleX(-1);
     }
-	20% {
-		left: calc(100% - 70px);
-	}
-	23% {
-		left: calc(100% - 70px);
-		transform: rotate(180deg) scaleX(-1);
-	}
-	27% {
-		left: calc(100% - 70px);
-		transform: rotate(180deg) scaleX(1);
-	}
-	30% {
-		left: calc(100% - 70px);
-	}
+    20% {
+      left: calc(100% - 70px);
+    }
+    23% {
+      left: calc(100% - 70px);
+      transform: rotate(180deg) scaleX(-1);
+    }
+    27% {
+      left: calc(100% - 70px);
+      transform: rotate(180deg) scaleX(1);
+    }
+    30% {
+      left: calc(100% - 70px);
+    }
     50% {
-    	left: calc(50% - 48px);
+      left: calc(50% - 48px);
     }
-	70% {
-		left: calc(0% - 16px);
-	}
-	73% {
-		left: calc(0% - 16px);
-		transform: rotate(180deg) scaleX(1);
-	}
-	77% {
-		left: calc(0% - 16px);
-		transform: rotate(180deg) scaleX(-1);
+    70% {
+      left: calc(0% - 16px);
     }
-	80% {
-		left: calc(0% - 16px);
-	}
+    73% {
+      left: calc(0% - 16px);
+      transform: rotate(180deg) scaleX(1);
+    }
+    77% {
+      left: calc(0% - 16px);
+      transform: rotate(180deg) scaleX(-1);
+    }
+    80% {
+      left: calc(0% - 16px);
+    }
     100% {
-		left: calc(50% - 48px);
-		transform: rotate(180deg) scaleX(-1);
+      left: calc(50% - 48px);
+      transform: rotate(180deg) scaleX(-1);
     }
   }
-`
+`;
 
 export default Newsletter;

--- a/packages/app/src/components/Newsletter/index.ts
+++ b/packages/app/src/components/Newsletter/index.ts
@@ -1,1 +1,1 @@
-export { default } from './Newsletter';
+export { default } from "./Newsletter";

--- a/packages/app/src/components/NotSupportedModal/NotSupportedModal.tsx
+++ b/packages/app/src/components/NotSupportedModal/NotSupportedModal.tsx
@@ -1,48 +1,71 @@
-import React, { useState } from 'react';
-import { UnhandledError, Modal, ModalTitle, ModalContent, ModalActions, Spacer, Text } from '../../components';
-import { theme } from '../../theme';
+import React, { useState } from "react";
+import {
+  UnhandledError,
+  Modal,
+  ModalTitle,
+  ModalContent,
+  ModalActions,
+  Spacer,
+  Text,
+} from "../../components";
+import { theme } from "../../theme";
 
-const NotSupportedModal: React.FC<{page: string}> = ({ page }) => {
-	const [unhandledError, setUnhandledError] = useState({errCode: null, errMsg: ''})
+const NotSupportedModal: React.FC<{ page: string }> = ({ page }) => {
+  const [unhandledError, setUnhandledError] = useState({
+    errCode: null,
+    errMsg: "",
+  });
 
-	const handleSwitch = async () => {
-		try {
-			await window.ethereum.request({
-				method: 'wallet_switchEthereumChain',
-				params: [{ chainId: '0x1' }],
-			});
-		} catch (error: any) {
-			setUnhandledError({
-				errCode: error.code,
-				errMsg: error.message
-			})
-		}
-	}
+  const handleSwitch = async () => {
+    try {
+      await window.ethereum.request({
+        method: "wallet_switchEthereumChain",
+        params: [{ chainId: "0x1" }],
+      });
+    } catch (error: any) {
+      setUnhandledError({
+        errCode: error.code,
+        errMsg: error.message,
+      });
+    }
+  };
 
-    return (<>{ unhandledError.errCode ?
-		<UnhandledError
-			errCode={unhandledError.errCode}
-			errMsg={unhandledError.errMsg}
-			onDismiss={() => setUnhandledError({errCode: null, errMsg: ''})}/>
-		:
+  return (
+    <>
+      {unhandledError.errCode ? (
+        <UnhandledError
+          errCode={unhandledError.errCode}
+          errMsg={unhandledError.errMsg}
+          onDismiss={() => setUnhandledError({ errCode: null, errMsg: "" })}
+        />
+      ) : (
         <Modal>
-            <ModalTitle text='Not (yet) supported' />
-            <ModalContent>
-				<Text align='center' font={theme.font.inter} size='s' color={theme.color.gray[600]}>
-                	{`Your chosen network is currently not supported on the ${page} page.`}
-					<br/>
-					Please change your wallet provider's network to ETH.
-				</Text>
-            </ModalContent>
-			<Spacer size='md'/>
-            <ModalActions modalActions={[
-				{
-					text: 'Switch to ETH',
-					buttonProps: { styling: 'purple', onClick: handleSwitch }
-				}
-			]}/>
+          <ModalTitle text="Not (yet) supported" />
+          <ModalContent>
+            <Text
+              align="center"
+              font={theme.font.inter}
+              size="s"
+              color={theme.color.gray[600]}
+            >
+              {`Your chosen network is currently not supported on the ${page} page.`}
+              <br />
+              Please change your wallet provider's network to ETH.
+            </Text>
+          </ModalContent>
+          <Spacer size="md" />
+          <ModalActions
+            modalActions={[
+              {
+                text: "Switch to ETH",
+                buttonProps: { styling: "purple", onClick: handleSwitch },
+              },
+            ]}
+          />
         </Modal>
-    }</>)
-}
+      )}
+    </>
+  );
+};
 
-export default NotSupportedModal
+export default NotSupportedModal;

--- a/packages/app/src/components/NotSupportedModal/index.tsx
+++ b/packages/app/src/components/NotSupportedModal/index.tsx
@@ -1,1 +1,1 @@
-export { default } from './NotSupportedModal'
+export { default } from "./NotSupportedModal";

--- a/packages/app/src/components/Page/Page.tsx
+++ b/packages/app/src/components/Page/Page.tsx
@@ -1,89 +1,95 @@
-import React, { useContext } from 'react';
-import styled from 'styled-components';
-import { useLocation } from 'react-router-dom';
-import { Footer, Navigation, NotSupportedModal } from '../../components';
-import { PepemonProviderContext } from '../../contexts';
-import { darktealTiles } from '../../assets';
-import { theme } from '../../theme';
-import { isSupportedChain } from '../../utils';
+import React, { useContext } from "react";
+import styled from "styled-components";
+import { useLocation } from "react-router-dom";
+import { Footer, Navigation, NotSupportedModal } from "../../components";
+import { PepemonProviderContext } from "../../contexts";
+import { darktealTiles } from "../../assets";
+import { theme } from "../../theme";
+import { isSupportedChain } from "../../utils";
 
-const Page: React.FC<any> = ({children}) => {
-	const [pepemon] = useContext(PepemonProviderContext);
-	const { chainId } = pepemon;
+const Page: React.FC<any> = ({ children }) => {
+  const [pepemon] = useContext(PepemonProviderContext);
+  const { chainId } = pepemon;
 
-	const { pathname } = useLocation();
+  const { pathname } = useLocation();
 
-	// go to top
-	window.scrollTo(0,0);
+  // go to top
+  window.scrollTo(0, 0);
 
-	return (
-		<StyledPageWrapper>
-			<StyledPageInner>
-				<Navigation/>
-				{ (!isSupportedChain(chainId, pathname) && chainId) ? <NotSupportedModal page='Home'/>
-				: children
-				}
-			</StyledPageInner>
-			<Footer/>
-		</StyledPageWrapper>
-	)
-}
+  return (
+    <StyledPageWrapper>
+      <StyledPageInner>
+        <Navigation />
+        {!isSupportedChain(chainId, pathname) && chainId ? (
+          <NotSupportedModal page="Home" />
+        ) : (
+          children
+        )}
+      </StyledPageInner>
+      <Footer />
+    </StyledPageWrapper>
+  );
+};
 
 export const StyledPageWrapper = styled.div`
-	display: flex;
-	flex-direction: column;
-	min-height: 100vh;
-	position: relative;
-`
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  position: relative;
+`;
 
 export const StyledPageInner = styled.div`
-	display: flex;
-`
+  display: flex;
+`;
 
 export const StyledPageWrapperMain = styled.main`
-	background-attachment: fixed;
-	background-image: url(${darktealTiles});
-	background-repeat: no-repeat;
-	background-size: cover;
-	padding-left: clamp(1em, 2.65vw, 2em);
-	padding-right: clamp(1em, 2.65vw, 2em);
-	min-height: 100vh;
-	padding-bottom: ${theme.footer.spaceTop}px;
-	width: 100vw;
-	position: relative;
+  background-attachment: fixed;
+  background-image: url(${darktealTiles});
+  background-repeat: no-repeat;
+  background-size: cover;
+  padding-left: clamp(1em, 2.65vw, 2em);
+  padding-right: clamp(1em, 2.65vw, 2em);
+  min-height: 100vh;
+  padding-bottom: ${theme.footer.spaceTop}px;
+  width: 100vw;
+  position: relative;
 
-	@supports ( -webkit-touch-callout : none) {
-		background-attachment: scroll;
-	}
+  @supports (-webkit-touch-callout: none) {
+    background-attachment: scroll;
+  }
 
-	@media (min-width: ${theme.breakpoints.desktop}) {
-		margin-left: ${theme.sideBar.width.closed}px;
-		width: calc(100vw - ${theme.sideBar.width.closed}px);
-	}
+  @media (min-width: ${theme.breakpoints.desktop}) {
+    margin-left: ${theme.sideBar.width.closed}px;
+    width: calc(100vw - ${theme.sideBar.width.closed}px);
+  }
 
-	&::before {
-		content: '';
-		position: absolute;
-		top: 0;
-		left: 0;
-		width: 100%;
-		height: 100vh;
-		background: linear-gradient(to bottom, rgba(255, 255, 255, .5) 0%, rgba(255, 255, 255, 0) 100%);
-		z-index: 0;
-	}
-`
+  &::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100vh;
+    background: linear-gradient(
+      to bottom,
+      rgba(255, 255, 255, 0.5) 0%,
+      rgba(255, 255, 255, 0) 100%
+    );
+    z-index: 0;
+  }
+`;
 
 export const StyledPageWrapperMainInner = styled.div`
-	max-width: ${theme.breakpoints.ultra};
-	margin-left: auto;
-	margin-right: auto;
-	padding-top: 6em;
-	z-index: 1;
-	position: relative;
+  max-width: ${theme.breakpoints.ultra};
+  margin-left: auto;
+  margin-right: auto;
+  padding-top: 6em;
+  z-index: 1;
+  position: relative;
 
-	@media (min-width: ${theme.breakpoints.desktop}) {
-		padding-top: 10em;
-	}
-`
+  @media (min-width: ${theme.breakpoints.desktop}) {
+    padding-top: 10em;
+  }
+`;
 
-export default Page
+export default Page;

--- a/packages/app/src/components/Page/index.ts
+++ b/packages/app/src/components/Page/index.ts
@@ -1,1 +1,6 @@
-export { default, StyledPageWrapper, StyledPageWrapperMain, StyledPageWrapperMainInner } from './Page';
+export {
+  default,
+  StyledPageWrapper,
+  StyledPageWrapperMain,
+  StyledPageWrapperMainInner,
+} from "./Page";

--- a/packages/app/src/components/Pages/DefaultPage.tsx
+++ b/packages/app/src/components/Pages/DefaultPage.tsx
@@ -1,20 +1,24 @@
-import React from 'react';
-import { StyledPageWrapperMain, StyledPageWrapperMainInner, StyledPageTitle } from "../../components";
+import React from "react";
+import {
+  StyledPageWrapperMain,
+  StyledPageWrapperMainInner,
+  StyledPageTitle,
+} from "../../components";
 
 interface DefaultPageProps {
-	children: any,
-	title?: string
+  children: any;
+  title?: string;
 }
 
-const DefaultPage: React.FC<DefaultPageProps> = ({children, title}) => {
-	return (
-		<StyledPageWrapperMain>
-			<StyledPageWrapperMainInner>
-				{ title && <StyledPageTitle as="h1">{title}</StyledPageTitle> }
-				{children}
-			</StyledPageWrapperMainInner>
-		</StyledPageWrapperMain>
-	)
-}
+const DefaultPage: React.FC<DefaultPageProps> = ({ children, title }) => {
+  return (
+    <StyledPageWrapperMain>
+      <StyledPageWrapperMainInner>
+        {title && <StyledPageTitle as="h1">{title}</StyledPageTitle>}
+        {children}
+      </StyledPageWrapperMainInner>
+    </StyledPageWrapperMain>
+  );
+};
 
 export default DefaultPage;

--- a/packages/app/src/components/Pages/PlainText.tsx
+++ b/packages/app/src/components/Pages/PlainText.tsx
@@ -1,23 +1,18 @@
-import React from 'react';
-import styled from 'styled-components';
-import { theme } from '../../theme';
+import React from "react";
+import styled from "styled-components";
+import { theme } from "../../theme";
 
-const PlainText: React.FC<any> = ({children}) => {
-
-	return (
-		<StyledPlainText>
-			{children}
-		</StyledPlainText>
-	)
-}
+const PlainText: React.FC<any> = ({ children }) => {
+  return <StyledPlainText>{children}</StyledPlainText>;
+};
 
 const StyledPlainText = styled.div`
-	background-color: ${theme.color.white};
-	border-radius: ${theme.borderRadius}px;
-	color: ${theme.color.headers};
-	font-family: ${theme.font.inter};
-	font-weight: normal;
-	padding: clamp(1.125em,3.75vw,1.2em) clamp(.8em,2.65vw,2em) 2em;
-`
+  background-color: ${theme.color.white};
+  border-radius: ${theme.borderRadius}px;
+  color: ${theme.color.headers};
+  font-family: ${theme.font.inter};
+  font-weight: normal;
+  padding: clamp(1.125em, 3.75vw, 1.2em) clamp(0.8em, 2.65vw, 2em) 2em;
+`;
 
-export default PlainText
+export default PlainText;

--- a/packages/app/src/components/Pages/index.ts
+++ b/packages/app/src/components/Pages/index.ts
@@ -1,2 +1,2 @@
-export { default as PlainText } from './PlainText';
-export { default as DefaultPage } from './DefaultPage';
+export { default as PlainText } from "./PlainText";
+export { default as DefaultPage } from "./DefaultPage";

--- a/packages/app/src/components/PepemonCard/PepemonCard.tsx
+++ b/packages/app/src/components/PepemonCard/PepemonCard.tsx
@@ -1,285 +1,331 @@
-import React, {useCallback,
-	// useEffect, useState
-} from 'react'
-import styled from 'styled-components'
-import { StyledSpacer, Spacer, Title } from '../../components';
-import { CardMetadata, CardBalances } from '../../hooks';
-import { coin } from '../../assets';
-import { theme } from '../../theme';
-import BigNumber from 'bignumber.js';
-import {getDisplayBalance} from '../../utils/formatBalance';
-import {getCardInfo} from '../../utils/nftCards';
+import React, {
+  useCallback,
+  // useEffect, useState
+} from "react";
+import styled from "styled-components";
+import { StyledSpacer, Spacer, Title } from "../../components";
+import { CardMetadata, CardBalances } from "../../hooks";
+import { coin } from "../../assets";
+import { theme } from "../../theme";
+import BigNumber from "bignumber.js";
+import { getDisplayBalance } from "../../utils/formatBalance";
+import { getCardInfo } from "../../utils/nftCards";
 
 interface PepemonCardProps {
-	active: boolean;
-    pepemon: any;
-    ppdexBalance: any;
-	tokenId: number;
-	metadata: CardMetadata;
-	balances: CardBalances;
-	price: BigNumber;
-	allowance:  any;
-	transactions: number;
-    setTransactions: any;
-    setDelayApprove: any;
-    setImageModal: any;
-    onRedeemCard: (tokenId: number, amount?: string) => Promise<void>;
-    isRedeemingCard: Array<string | boolean> | number;
-    token?: {name: string, decimals: number};
-    providerChainId?: number;
-	selectCard: () => void;
+  active: boolean;
+  pepemon: any;
+  ppdexBalance: any;
+  tokenId: number;
+  metadata: CardMetadata;
+  balances: CardBalances;
+  price: BigNumber;
+  allowance: any;
+  transactions: number;
+  setTransactions: any;
+  setDelayApprove: any;
+  setImageModal: any;
+  onRedeemCard: (tokenId: number, amount?: string) => Promise<void>;
+  isRedeemingCard: Array<string | boolean> | number;
+  token?: { name: string; decimals: number };
+  providerChainId?: number;
+  selectCard: () => void;
 }
 
 const PepemonCard: React.FC<any> = ({
-									 active,
-                                     pepemon,
-                                     ppdexBalance,
-                                     tokenId,
-                                     metadata,
-                                     balances,
-                                     price,
-                                     allowance,
-                                     transactions,
-                                     setTransactions,
-                                     setDelayApprove,
-                                     setImageModal,
-                                     onRedeemCard,
-                                     isRedeemingCard,
-                                     token,
-                                     providerChainId,
-									 setSelectedCard
+  active,
+  pepemon,
+  ppdexBalance,
+  tokenId,
+  metadata,
+  balances,
+  price,
+  allowance,
+  transactions,
+  setTransactions,
+  setDelayApprove,
+  setImageModal,
+  onRedeemCard,
+  isRedeemingCard,
+  token,
+  providerChainId,
+  setSelectedCard,
 }) => {
-    const isItemCard = (cardId: number) => {
-        return [17, 18, 19].includes(cardId);
+  const isItemCard = (cardId: number) => {
+    return [17, 18, 19].includes(cardId);
+  };
+
+  const daysForSale = useCallback(() => {
+    if (isItemCard(tokenId)) {
+      return 1000000;
     }
+    return tokenId > 5 ? (tokenId > 12 ? 28 : 21) : 14;
+  }, [tokenId]);
 
-    const daysForSale = useCallback(() => {
-        if (isItemCard(tokenId)) {
-            return 1000000
-        }
-        return tokenId > 5 ? (tokenId > 12 ? 28 : 21) : 14;
-    }, [tokenId])
-
-    const isMintable = () => {
-        return balances && (parseFloat(balances.totalSupply) < parseFloat(balances.maxSupply));
-    }
-    const isAffordable = () => {
-        if (price.isEqualTo(ppdexBalance)) {
-            return true;
-        }
-        return price.comparedTo(ppdexBalance) === -1;
-    }
-    const isAllowedSpending = () => {
-        // No allowance needed for native BNB payments
-        if (providerChainId === 56) {
-            return true;
-        }
-        return price.comparedTo(allowance) === -1;
-    }
-
-	const isReleasingSoon = useCallback(() => {
-        const birthdayMetaData = metadata.attributes.find(attribute => attribute.trait_type === 'birthday');
-        if (parseFloat(birthdayMetaData.value) === 0) {
-            return true;
-        }
-        return parseFloat(birthdayMetaData.value) > (Date.now() / 1000);
-    }, [metadata.attributes])
-
-    const isForSale = () => {
-        const birthdayMetaData = metadata.attributes.find(attribute => attribute.trait_type === 'birthday');
-        if (parseFloat(birthdayMetaData.value) === 0) {
-            return false;
-        }
-        return (parseFloat(birthdayMetaData.value) + (daysForSale() * 24 * 60 * 60)) > (Date.now() / 1000)
-    }
-    const isSoldOut = () => {
-        return (!isMintable() && !isReleasingSoon()) || (!isForSale() && !isReleasingSoon());
-    }
-    const isNoLongerForSale = () => {
-        return !isReleasingSoon() && !isForSale()
-    }
-
-    // const calculateTimeLeft = useCallback(() => {
-    //     const birthdayMetaData = metadata.attributes.find(attribute => attribute.trait_type === 'birthday');
-    //     if (parseFloat(birthdayMetaData.value) === 0) {
-    //         return 0;
-    //     }
-	//
-    //     if (isReleasingSoon()) {
-    //         return parseFloat(birthdayMetaData.value) - (Date.now() / 1000);
-    //     }
-	//
-    //     if ((parseFloat(birthdayMetaData.value) + (daysForSale() * 60 * 60 * 24)) - (Date.now() / 1000) <= 0) {
-    //         return 0;
-    //     }
-    //     return (parseFloat(birthdayMetaData.value) + (daysForSale() * 60 * 60 * 24)) - (Date.now() / 1000);
-    // }, [metadata.attributes, isReleasingSoon, daysForSale])
-
-    // const [timeLeft, setTimeLeft] = useState(calculateTimeLeft());
-    // useEffect(() => {
-    //     const timer = setInterval(() => {
-    //         setTimeLeft(calculateTimeLeft());
-    //     }, 60000)
-	//
-    //     return () => {
-    //         clearInterval(timer)
-    //     }
-    // }, [calculateTimeLeft]);
-
-    // const countdown = (pre: string = ' ', after: string = '', fontSize?: number) => {
-    //     const days = timeLeft / (60 * 60 * 24);
-	//
-    //     if (days > 1) {
-    //         return (<span>
-    //             {Math.ceil(days).toFixed(0)}{pre} {Math.ceil(days).toFixed(0) === '1' ? 'day' : 'days'} {after}
-    //         </span>);
-    //     }
-	//
-    //     const hours = timeLeft / (60 * 60);
-    //     if (hours > 1) {
-    //         return (<span style={{fontSize: fontSize ? `${fontSize}px` : '55px'}}>
-    //             {Math.ceil(hours).toFixed(0)}{pre} {Math.ceil(hours).toFixed(0) === '1' ? 'hour' : 'hours'} {after}
-    //         </span>);
-    //     }
-	//
-    //     const minutes = timeLeft / 60;
-	//
-    //     if (minutes <= 0) {
-    //         return null;
-    //     }
-    //     return (<span style={{fontSize: fontSize ? `${fontSize}px` : '50px'}}>
-    //         {minutes.toFixed(0)}{pre} {minutes.toFixed(0) === '1' ? 'minute' : 'minutes'} {after}
-    //     </span>);
-    // }
-    const isRedeemingThisCard = isRedeemingCard && isRedeemingCard[0] === tokenId && isRedeemingCard[1];
-    const priceOfCard = parseFloat(getDisplayBalance(price, token ? token.decimals : 18)).toFixed(2);
-
+  const isMintable = () => {
     return (
-		<StyledPepemonCard style={{ opacity: isSoldOut() ? "50%" : "100%" }}>
-			<StyledPepemonCardPrice>
-				{parseFloat(priceOfCard) === 0 ? "Unavailable" :
-					<>
-						<img loading="lazy" src={coin} alt="coin"/>
-						{priceOfCard} PPDEX
-					</>
-				}
-			</StyledPepemonCardPrice>
-			<div>
-				<StyledPepemonCardImage loading="lazy" active={active} src={isReleasingSoon() ? getCardInfo(0).img : metadata.image} alt={isReleasingSoon() ? 'Coming soon' : metadata.name} onClick={() => setSelectedCard({
-					tokenId: tokenId,
-					token: token,
-					priceOfCard: priceOfCard,
-					title: metadata.name,
-					description: metadata.description,
-					image: metadata.image,
-					rarity: metadata.attributes[1],
-					type: metadata.attributes[4],
-					set: metadata.attributes[0],
-					artist: metadata.attributes[3],
-					isSoldOut: isSoldOut,
-					isAllowedSpending: isAllowedSpending,
-					isRedeemingCard: isRedeemingCard,
-					isRedeemingThisCard: isRedeemingThisCard,
-					isAffordable: isAffordable,
-					isReleasingSoon: isReleasingSoon,
-					isMintable: isMintable,
-					isNoLongerForSale: isNoLongerForSale,
-					setDelayApprove: setDelayApprove,
-					onRedeemCard: onRedeemCard,
-					setTransactions: setTransactions,
-				})}/>
-				<Title as="h4" size='xxs' font={theme.font.neometric}>{isReleasingSoon() ? 'Coming soon' : metadata.name}</Title>
-				<StyledSpacer bg={theme.color.gray[100]} size={2}/>
-				<Spacer size="sm"/>
-				<StyledPepemonCardMeta>
-					<dt>Minted</dt>
-					<dd>{isReleasingSoon() ? '0 / 0' : `${balances.totalSupply} / ${parseFloat(balances.maxSupply) > 10000 ? '∞': balances.maxSupply}`}</dd>
-				</StyledPepemonCardMeta>
-				<StyledPepemonCardMeta>
-					<dt>Time</dt>
-					<dd>24 hours</dd>
-				</StyledPepemonCardMeta>
-			</div>
-		</StyledPepemonCard>
-    )
-}
+      balances &&
+      parseFloat(balances.totalSupply) < parseFloat(balances.maxSupply)
+    );
+  };
+  const isAffordable = () => {
+    if (price.isEqualTo(ppdexBalance)) {
+      return true;
+    }
+    return price.comparedTo(ppdexBalance) === -1;
+  };
+  const isAllowedSpending = () => {
+    // No allowance needed for native BNB payments
+    if (providerChainId === 56) {
+      return true;
+    }
+    return price.comparedTo(allowance) === -1;
+  };
+
+  const isReleasingSoon = useCallback(() => {
+    const birthdayMetaData = metadata.attributes.find(
+      (attribute) => attribute.trait_type === "birthday"
+    );
+    if (parseFloat(birthdayMetaData.value) === 0) {
+      return true;
+    }
+    return parseFloat(birthdayMetaData.value) > Date.now() / 1000;
+  }, [metadata.attributes]);
+
+  const isForSale = () => {
+    const birthdayMetaData = metadata.attributes.find(
+      (attribute) => attribute.trait_type === "birthday"
+    );
+    if (parseFloat(birthdayMetaData.value) === 0) {
+      return false;
+    }
+    return (
+      parseFloat(birthdayMetaData.value) + daysForSale() * 24 * 60 * 60 >
+      Date.now() / 1000
+    );
+  };
+  const isSoldOut = () => {
+    return (
+      (!isMintable() && !isReleasingSoon()) ||
+      (!isForSale() && !isReleasingSoon())
+    );
+  };
+  const isNoLongerForSale = () => {
+    return !isReleasingSoon() && !isForSale();
+  };
+
+  // const calculateTimeLeft = useCallback(() => {
+  //     const birthdayMetaData = metadata.attributes.find(attribute => attribute.trait_type === 'birthday');
+  //     if (parseFloat(birthdayMetaData.value) === 0) {
+  //         return 0;
+  //     }
+  //
+  //     if (isReleasingSoon()) {
+  //         return parseFloat(birthdayMetaData.value) - (Date.now() / 1000);
+  //     }
+  //
+  //     if ((parseFloat(birthdayMetaData.value) + (daysForSale() * 60 * 60 * 24)) - (Date.now() / 1000) <= 0) {
+  //         return 0;
+  //     }
+  //     return (parseFloat(birthdayMetaData.value) + (daysForSale() * 60 * 60 * 24)) - (Date.now() / 1000);
+  // }, [metadata.attributes, isReleasingSoon, daysForSale])
+
+  // const [timeLeft, setTimeLeft] = useState(calculateTimeLeft());
+  // useEffect(() => {
+  //     const timer = setInterval(() => {
+  //         setTimeLeft(calculateTimeLeft());
+  //     }, 60000)
+  //
+  //     return () => {
+  //         clearInterval(timer)
+  //     }
+  // }, [calculateTimeLeft]);
+
+  // const countdown = (pre: string = ' ', after: string = '', fontSize?: number) => {
+  //     const days = timeLeft / (60 * 60 * 24);
+  //
+  //     if (days > 1) {
+  //         return (<span>
+  //             {Math.ceil(days).toFixed(0)}{pre} {Math.ceil(days).toFixed(0) === '1' ? 'day' : 'days'} {after}
+  //         </span>);
+  //     }
+  //
+  //     const hours = timeLeft / (60 * 60);
+  //     if (hours > 1) {
+  //         return (<span style={{fontSize: fontSize ? `${fontSize}px` : '55px'}}>
+  //             {Math.ceil(hours).toFixed(0)}{pre} {Math.ceil(hours).toFixed(0) === '1' ? 'hour' : 'hours'} {after}
+  //         </span>);
+  //     }
+  //
+  //     const minutes = timeLeft / 60;
+  //
+  //     if (minutes <= 0) {
+  //         return null;
+  //     }
+  //     return (<span style={{fontSize: fontSize ? `${fontSize}px` : '50px'}}>
+  //         {minutes.toFixed(0)}{pre} {minutes.toFixed(0) === '1' ? 'minute' : 'minutes'} {after}
+  //     </span>);
+  // }
+  const isRedeemingThisCard =
+    isRedeemingCard && isRedeemingCard[0] === tokenId && isRedeemingCard[1];
+  const priceOfCard = parseFloat(
+    getDisplayBalance(price, token ? token.decimals : 18)
+  ).toFixed(2);
+
+  return (
+    <StyledPepemonCard style={{ opacity: isSoldOut() ? "50%" : "100%" }}>
+      <StyledPepemonCardPrice>
+        {parseFloat(priceOfCard) === 0 ? (
+          "Unavailable"
+        ) : (
+          <>
+            <img loading="lazy" src={coin} alt="coin" />
+            {priceOfCard} PPDEX
+          </>
+        )}
+      </StyledPepemonCardPrice>
+      <div>
+        <StyledPepemonCardImage
+          loading="lazy"
+          active={active}
+          src={isReleasingSoon() ? getCardInfo(0).img : metadata.image}
+          alt={isReleasingSoon() ? "Coming soon" : metadata.name}
+          onClick={() =>
+            setSelectedCard({
+              tokenId: tokenId,
+              token: token,
+              priceOfCard: priceOfCard,
+              title: metadata.name,
+              description: metadata.description,
+              image: metadata.image,
+              rarity: metadata.attributes[1],
+              type: metadata.attributes[4],
+              set: metadata.attributes[0],
+              artist: metadata.attributes[3],
+              isSoldOut: isSoldOut,
+              isAllowedSpending: isAllowedSpending,
+              isRedeemingCard: isRedeemingCard,
+              isRedeemingThisCard: isRedeemingThisCard,
+              isAffordable: isAffordable,
+              isReleasingSoon: isReleasingSoon,
+              isMintable: isMintable,
+              isNoLongerForSale: isNoLongerForSale,
+              setDelayApprove: setDelayApprove,
+              onRedeemCard: onRedeemCard,
+              setTransactions: setTransactions,
+            })
+          }
+        />
+        <Title as="h4" size="xxs" font={theme.font.neometric}>
+          {isReleasingSoon() ? "Coming soon" : metadata.name}
+        </Title>
+        <StyledSpacer bg={theme.color.gray[100]} size={2} />
+        <Spacer size="sm" />
+        <StyledPepemonCardMeta>
+          <dt>Minted</dt>
+          <dd>
+            {isReleasingSoon()
+              ? "0 / 0"
+              : `${balances.totalSupply} / ${
+                  parseFloat(balances.maxSupply) > 10000
+                    ? "∞"
+                    : balances.maxSupply
+                }`}
+          </dd>
+        </StyledPepemonCardMeta>
+        <StyledPepemonCardMeta>
+          <dt>Time</dt>
+          <dd>24 hours</dd>
+        </StyledPepemonCardMeta>
+      </div>
+    </StyledPepemonCard>
+  );
+};
 
 // NEW
 const StyledPepemonCard = styled.div`
-	display: flex;
-	justify-content: center;
-	flex-direction: column;
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
 
-	&:hover {
-		cursor: pointer;
-	}
-`
+  &:hover {
+    cursor: pointer;
+  }
+`;
 
-export const StyledPepemonCardPrice = styled.span<{styling?: string}>`
-	& {
-		background-color: ${props => props.styling === 'alt' ? props.theme.color.white : props.theme.color.black};
-		color: ${props => props.styling === 'alt' ? props.theme.color.black : props.theme.color.white};
-		font-family: ${props => props.theme.font.spaceMace};
-		border-radius: 6px;
-		display: inline-flex;
-		margin-left: auto;
-		margin-right: auto;
-		align-items: center;
-		padding: ${props => props.styling === 'alt' ? '' : '2px 8px'};
-		font-size: ${props => props.styling === 'alt' ? '1rem' : '.8rem'};
-		transform: ${props => props.styling === 'alt' ? '' : 'translateY(40%)'};
-		position: relative;
-		z-index: 1;
-	}
+export const StyledPepemonCardPrice = styled.span<{ styling?: string }>`
+  & {
+    background-color: ${(props) =>
+      props.styling === "alt"
+        ? props.theme.color.white
+        : props.theme.color.black};
+    color: ${(props) =>
+      props.styling === "alt"
+        ? props.theme.color.black
+        : props.theme.color.white};
+    font-family: ${(props) => props.theme.font.spaceMace};
+    border-radius: 6px;
+    display: inline-flex;
+    margin-left: auto;
+    margin-right: auto;
+    align-items: center;
+    padding: ${(props) => (props.styling === "alt" ? "" : "2px 8px")};
+    font-size: ${(props) => (props.styling === "alt" ? "1rem" : ".8rem")};
+    transform: ${(props) => (props.styling === "alt" ? "" : "translateY(40%)")};
+    position: relative;
+    z-index: 1;
+  }
 
-	& img {
-		width: 1.8em;
-	}
-`
+  & img {
+    width: 1.8em;
+  }
+`;
 
-export const StyledPepemonCardImage = styled.img<{active?: boolean}>`
-	filter: drop-shadow(0 4px 8px rgba(0, 0, 0, 0.12));
-	height: auto;
-	max-width: 25em;
-	position: relative;
-	width: 100%;
-	z-index: 0;
+export const StyledPepemonCardImage = styled.img<{ active?: boolean }>`
+  filter: drop-shadow(0 4px 8px rgba(0, 0, 0, 0.12));
+  height: auto;
+  max-width: 25em;
+  position: relative;
+  width: 100%;
+  z-index: 0;
 
-	&:hover {
-		cusror: pointer;
-	}
+  &:hover {
+    cusror: pointer;
+  }
 
-	${({ active }) => active && `
+  ${({ active }) =>
+    active &&
+    `
 		&{
 			filter: drop-shadow(0 0 50px #894fbe);
 		}
 	`}
-`
+`;
 
 export const StyledPepemonCardMeta = styled.dl`
-	&{
-		display: flex;
-		font-family: ${props => props.theme.font.inter};
-		justify-content: space-between;
-		margin-bottom: 0;
-		margin-top: 0;
-	}
+  & {
+    display: flex;
+    font-family: ${(props) => props.theme.font.inter};
+    justify-content: space-between;
+    margin-bottom: 0;
+    margin-top: 0;
+  }
 
-	& dt, dd {
-		font-size: .8rem;
-		margin-top: .5em;
-	}
+  & dt,
+  dd {
+    font-size: 0.8rem;
+    margin-top: 0.5em;
+  }
 
-	& dt {
-		color: ${props => props.theme.color.gray[300]};
-		text-transform: uppercase;
-		letter-spacing: 1.2px;
-	}
+  & dt {
+    color: ${(props) => props.theme.color.gray[300]};
+    text-transform: uppercase;
+    letter-spacing: 1.2px;
+  }
 
-	& dd {
-		color: ${props => props.theme.color.gray[600]};
-		font-weight: bold
-	}
-`
+  & dd {
+    color: ${(props) => props.theme.color.gray[600]};
+    font-weight: bold;
+  }
+`;
 
 export default PepemonCard;

--- a/packages/app/src/components/PepemonCard/index.ts
+++ b/packages/app/src/components/PepemonCard/index.ts
@@ -1,1 +1,6 @@
-export { default, StyledPepemonCardImage, StyledPepemonCardMeta, StyledPepemonCardPrice } from './PepemonCard';
+export {
+  default,
+  StyledPepemonCardImage,
+  StyledPepemonCardMeta,
+  StyledPepemonCardPrice,
+} from "./PepemonCard";

--- a/packages/app/src/components/ProgressBar/ProgressBar.tsx
+++ b/packages/app/src/components/ProgressBar/ProgressBar.tsx
@@ -2,17 +2,17 @@ import React from "react";
 import styled from "styled-components";
 
 interface ProgressBarProps {
-	percent: number
+  percent: number;
 }
 
 const ProgressBar: React.FC<ProgressBarProps> = ({ percent }) => {
-	return (
-		<Container>
-			<Background/>
-			<Progress percent={percent}/>
-		</Container>
-	)
-}
+  return (
+    <Container>
+      <Background />
+      <Progress percent={percent} />
+    </Container>
+  );
+};
 
 const Container = styled.div`
   height: 8px;
@@ -30,13 +30,13 @@ const BaseBox = styled.div`
 `;
 
 const Background = styled(BaseBox)`
-  background: ${props => props.theme.color.gray[100]};
+  background: ${(props) => props.theme.color.gray[100]};
   width: 100%;
 `;
 
 const Progress = styled(BaseBox)<ProgressBarProps>`
-	background: ${props => props.theme.color.green[200]};
-	width: ${({ percent }) => percent}%;
+  background: ${(props) => props.theme.color.green[200]};
+  width: ${({ percent }) => percent}%;
 `;
 
 export default ProgressBar;

--- a/packages/app/src/components/ProgressBar/index.ts
+++ b/packages/app/src/components/ProgressBar/index.ts
@@ -1,1 +1,1 @@
-export { default } from './ProgressBar';
+export { default } from "./ProgressBar";

--- a/packages/app/src/components/ScrollToTop/ScrollToTop.tsx
+++ b/packages/app/src/components/ScrollToTop/ScrollToTop.tsx
@@ -1,44 +1,53 @@
-import React, { useState } from 'react';
-import styled, { css, keyframes } from 'styled-components';
-import { arrowUp } from '../../assets';
+import React, { useState } from "react";
+import styled, { css, keyframes } from "styled-components";
+import { arrowUp } from "../../assets";
 import { theme } from "../../theme";
 
 const ScrollToTop = () => {
-	const [showScroll, setShowScroll] = useState(false);
-	const [bottom, setBottom] = useState(1);
+  const [showScroll, setShowScroll] = useState(false);
+  const [bottom, setBottom] = useState(1);
 
-	const checkScrollOffset = () => {
-		// show or hide
-		if (!showScroll && window.pageYOffset > 400){
-			setShowScroll(true)
-		} else if (showScroll && window.pageYOffset <= 400){
-			setShowScroll(false)
-		}
+  const checkScrollOffset = () => {
+    // show or hide
+    if (!showScroll && window.pageYOffset > 400) {
+      setShowScroll(true);
+    } else if (showScroll && window.pageYOffset <= 400) {
+      setShowScroll(false);
+    }
 
-		// set bottom offset
-		if (document.body.scrollHeight - (window.pageYOffset + window.innerHeight) < 68.5) {
-			setBottom(7);
-		} else if (bottom !== 1) {
-			setBottom(1);
-		}
-	};
+    // set bottom offset
+    if (
+      document.body.scrollHeight - (window.pageYOffset + window.innerHeight) <
+      68.5
+    ) {
+      setBottom(7);
+    } else if (bottom !== 1) {
+      setBottom(1);
+    }
+  };
 
-	const scrollTop = () =>{
-		window.scrollTo({top: 0, behavior: 'smooth'});
-	};
+  const scrollTop = () => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
 
-	window.addEventListener('scroll', checkScrollOffset);
+  window.addEventListener("scroll", checkScrollOffset);
 
-	return (
-		<StyledScrollToTop onClick={scrollTop}
-			style={{display: !showScroll && 'none'}}
-			aria-label='Scroll to top'
-			bottom={bottom}
-		>
-			<img loading='lazy' src={arrowUp} alt='Scroll to top' title='Scroll to top'/>
-		</StyledScrollToTop>
-	)
-}
+  return (
+    <StyledScrollToTop
+      onClick={scrollTop}
+      style={{ display: !showScroll && "none" }}
+      aria-label="Scroll to top"
+      bottom={bottom}
+    >
+      <img
+        loading="lazy"
+        src={arrowUp}
+        alt="Scroll to top"
+        title="Scroll to top"
+      />
+    </StyledScrollToTop>
+  );
+};
 
 const fadeIn = keyframes`
 	0% {
@@ -47,41 +56,45 @@ const fadeIn = keyframes`
 	100% {
 		opacity: 0.5;
 	}
-`
+`;
 
 const fadeInCss = css`
-	animation: ${fadeIn} .3s;
-`
+  animation: ${fadeIn} 0.3s;
+`;
 
-const StyledScrollToTop = styled.button<{bottom: number}>`
-	${fadeInCss};
-	align-items: center;
-	background-color: transparent;
-	background-image: linear-gradient(to bottom, #aa6cd6 -100%, ${theme.color.purple[600]});
-	border-width: 0;
-	border-radius: 50%;
-	bottom: ${({bottom}) => bottom}em;
-	box-shadow: 0 4px 10px 0 ${theme.color.colorsLayoutShadows};
-	cursor: pointer;
-	justify-content: center;
-	opacity: 1;
-	padding: 1em;
-	position: fixed;
-	right: .6em;
-	transition: all .4s;
-	z-index: 40;
+const StyledScrollToTop = styled.button<{ bottom: number }>`
+  ${fadeInCss};
+  align-items: center;
+  background-color: transparent;
+  background-image: linear-gradient(
+    to bottom,
+    #aa6cd6 -100%,
+    ${theme.color.purple[600]}
+  );
+  border-width: 0;
+  border-radius: 50%;
+  bottom: ${({ bottom }) => bottom}em;
+  box-shadow: 0 4px 10px 0 ${theme.color.colorsLayoutShadows};
+  cursor: pointer;
+  justify-content: center;
+  opacity: 1;
+  padding: 1em;
+  position: fixed;
+  right: 0.6em;
+  transition: all 0.4s;
+  z-index: 40;
 
-	&:hover{
-		opacity: .5;
-	}
+  &:hover {
+    opacity: 0.5;
+  }
 
-	@media (min-width: ${theme.breakpoints.desktop}) {
-		right: 2.5em;
-	}
+  @media (min-width: ${theme.breakpoints.desktop}) {
+    right: 2.5em;
+  }
 
-	@media (min-width: ${theme.breakpoints.wide}) {
-		bottom: 2em;
-	}
-`
+  @media (min-width: ${theme.breakpoints.wide}) {
+    bottom: 2em;
+  }
+`;
 
 export default ScrollToTop;

--- a/packages/app/src/components/ScrollToTop/index.ts
+++ b/packages/app/src/components/ScrollToTop/index.ts
@@ -1,1 +1,1 @@
-export { default } from './ScrollToTop';
+export { default } from "./ScrollToTop";

--- a/packages/app/src/components/SocialBoxes/SocialBoxes.tsx
+++ b/packages/app/src/components/SocialBoxes/SocialBoxes.tsx
@@ -1,76 +1,158 @@
 import React from "react";
 import styled from "styled-components";
 import { theme } from "../../theme";
-import { ContentBox, ContentBoxGrid, ContentCentered, Title, Text, Spacer } from "../../components";
+import {
+  ContentBox,
+  ContentBoxGrid,
+  ContentCentered,
+  Title,
+  Text,
+  Spacer,
+} from "../../components";
 import { discord, telegram, twitter, medium } from "../../assets";
 
 const SocialBoxes: React.FC<any> = () => {
-	return (
-		<ContentCentered>
-			<Title as="h1" font={theme.font.neometric} size='xxl' lineHeight={1.04} weight={900} align="center">
-				Say hi and meet all the Pepetrainers
-			</Title>
-			<Spacer size="md"/>
-			<Text as="p" font={theme.font.spaceMace} align="center" underline>Our socials</Text>
-			<Spacer size="lg"/>
-			<div>
-				<CustomContentBoxGrid>
-					<ContentBoxLink as="a" href="https://twitter.com/pepemonfinance" target="_blank" rel="noopener noreferrer"
-					bgColor={theme.color.purple[300]} gridArea="socialBox1">
-						<StyledSocialIcon loading="lazy" src={twitter} alt="twitter"/>
-						<Spacer size="sm"/>
-						<Text as="p" size='xl' font={theme.font.neometric} weight={900} align="center">Twitter</Text>
-						<Spacer size="sm"/>
-						<Text as="p" align="center" lineHeight={1.5}>Follow us on Twitter for all updates and anouncements.</Text>
-					</ContentBoxLink>
-					<ContentBoxLink as="a" href="https://t.me/pepemonfinance" target="_blank" rel="noopener noreferrer"
-					bgColor={theme.color.purple[300]} gridArea="socialBox2">
-						<StyledSocialIcon loading="lazy" src={telegram} alt="telegram"/>
-						<Spacer size="sm"/>
-						<Text as="p" size='xl' font={theme.font.neometric} weight={900} align="center">Telegram</Text>
-						<Spacer size="sm"/>
-						<Text as="p" align="center" lineHeight={1.5}>Join us on Telegram to ask us questions and talk with your fellow Pepetrainers.</Text>
-					</ContentBoxLink>
-					<ContentBoxLink as="a" href="https://discord.com/invite/R8sZwMv" target="_blank" rel="noopener noreferrer"
-					bgColor={theme.color.purple[300]} gridArea="socialBox3">
-						<StyledSocialIcon loading="lazy" src={discord} alt="discord"/>
-						<Spacer size="sm"/>
-						<Text as="p" size='xl' font={theme.font.neometric} weight={900} align="center">Discord</Text>
-						<Spacer size="sm"/>
-						<Text as="p" align="center" lineHeight={1.5}>Come hang out with us and all the Pepetrainers on Discord.</Text>
-					</ContentBoxLink>
-					<ContentBoxLink as="a" href="https://pepemonfinance.medium.com/" target="_blank" rel="noopener noreferrer"
-					bgColor={theme.color.purple[300]} gridArea="socialBox4">
-						<StyledSocialIcon loading="lazy" src={medium} alt="medium"/>
-						<Spacer size="sm"/>
-						<Text as="p" size='xl' font={theme.font.neometric} weight={900} align="center">Medium</Text>
-						<Spacer size="sm"/>
-						<Text as="p" align="center" lineHeight={1.5}>Find more detailed articles on Medium about Pepemon and the ecosystem.</Text>
-					</ContentBoxLink>
-				</CustomContentBoxGrid>
-			</div>
-		</ContentCentered>
-	)
-}
+  return (
+    <ContentCentered>
+      <Title
+        as="h1"
+        font={theme.font.neometric}
+        size="xxl"
+        lineHeight={1.04}
+        weight={900}
+        align="center"
+      >
+        Say hi and meet all the Pepetrainers
+      </Title>
+      <Spacer size="md" />
+      <Text as="p" font={theme.font.spaceMace} align="center" underline>
+        Our socials
+      </Text>
+      <Spacer size="lg" />
+      <div>
+        <CustomContentBoxGrid>
+          <ContentBoxLink
+            as="a"
+            href="https://twitter.com/pepemonfinance"
+            target="_blank"
+            rel="noopener noreferrer"
+            bgColor={theme.color.purple[300]}
+            gridArea="socialBox1"
+          >
+            <StyledSocialIcon loading="lazy" src={twitter} alt="twitter" />
+            <Spacer size="sm" />
+            <Text
+              as="p"
+              size="xl"
+              font={theme.font.neometric}
+              weight={900}
+              align="center"
+            >
+              Twitter
+            </Text>
+            <Spacer size="sm" />
+            <Text as="p" align="center" lineHeight={1.5}>
+              Follow us on Twitter for all updates and anouncements.
+            </Text>
+          </ContentBoxLink>
+          <ContentBoxLink
+            as="a"
+            href="https://t.me/pepemonfinance"
+            target="_blank"
+            rel="noopener noreferrer"
+            bgColor={theme.color.purple[300]}
+            gridArea="socialBox2"
+          >
+            <StyledSocialIcon loading="lazy" src={telegram} alt="telegram" />
+            <Spacer size="sm" />
+            <Text
+              as="p"
+              size="xl"
+              font={theme.font.neometric}
+              weight={900}
+              align="center"
+            >
+              Telegram
+            </Text>
+            <Spacer size="sm" />
+            <Text as="p" align="center" lineHeight={1.5}>
+              Join us on Telegram to ask us questions and talk with your fellow
+              Pepetrainers.
+            </Text>
+          </ContentBoxLink>
+          <ContentBoxLink
+            as="a"
+            href="https://discord.com/invite/R8sZwMv"
+            target="_blank"
+            rel="noopener noreferrer"
+            bgColor={theme.color.purple[300]}
+            gridArea="socialBox3"
+          >
+            <StyledSocialIcon loading="lazy" src={discord} alt="discord" />
+            <Spacer size="sm" />
+            <Text
+              as="p"
+              size="xl"
+              font={theme.font.neometric}
+              weight={900}
+              align="center"
+            >
+              Discord
+            </Text>
+            <Spacer size="sm" />
+            <Text as="p" align="center" lineHeight={1.5}>
+              Come hang out with us and all the Pepetrainers on Discord.
+            </Text>
+          </ContentBoxLink>
+          <ContentBoxLink
+            as="a"
+            href="https://pepemonfinance.medium.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            bgColor={theme.color.purple[300]}
+            gridArea="socialBox4"
+          >
+            <StyledSocialIcon loading="lazy" src={medium} alt="medium" />
+            <Spacer size="sm" />
+            <Text
+              as="p"
+              size="xl"
+              font={theme.font.neometric}
+              weight={900}
+              align="center"
+            >
+              Medium
+            </Text>
+            <Spacer size="sm" />
+            <Text as="p" align="center" lineHeight={1.5}>
+              Find more detailed articles on Medium about Pepemon and the
+              ecosystem.
+            </Text>
+          </ContentBoxLink>
+        </CustomContentBoxGrid>
+      </div>
+    </ContentCentered>
+  );
+};
 
 const StyledSocialIcon = styled.img`
-	margin-left: auto;
-	margin-right: auto;
-	width: 3.75em;
-`
+  margin-left: auto;
+  margin-right: auto;
+  width: 3.75em;
+`;
 
 const CustomContentBoxGrid = styled(ContentBoxGrid)`
-	grid-template-areas: 'socialBox1' 'socialBox2' 'socialBox3' 'socialBox4';
+  grid-template-areas: "socialBox1" "socialBox2" "socialBox3" "socialBox4";
 
-	@media (min-width: ${theme.breakpoints.tabletL}) {
-		grid-template-areas: 'socialBox1 socialBox2 socialBox3 socialBox4';
-	}
-`
+  @media (min-width: ${theme.breakpoints.tabletL}) {
+    grid-template-areas: "socialBox1 socialBox2 socialBox3 socialBox4";
+  }
+`;
 
-const ContentBoxLink = styled(ContentBox)<{gridArea: string}>`
-	box-shadow: 0 18.7px 14.2px 0 rgba(0, 0, 0, 0.1);
-	grid-area: ${props => props.gridArea};
-	text-decoration: none;
-`
+const ContentBoxLink = styled(ContentBox)<{ gridArea: string }>`
+  box-shadow: 0 18.7px 14.2px 0 rgba(0, 0, 0, 0.1);
+  grid-area: ${(props) => props.gridArea};
+  text-decoration: none;
+`;
 
 export default SocialBoxes;

--- a/packages/app/src/components/SocialBoxes/index.ts
+++ b/packages/app/src/components/SocialBoxes/index.ts
@@ -1,1 +1,1 @@
-export { default } from './SocialBoxes';
+export { default } from "./SocialBoxes";

--- a/packages/app/src/components/Spacer/Spacer.tsx
+++ b/packages/app/src/components/Spacer/Spacer.tsx
@@ -26,13 +26,14 @@ const Spacer: React.FC<SpacerProps> = ({ size = "md" }) => {
 
 interface StyledSpacerProps {
   size?: number;
-  bg?: string
+  bg?: string;
 }
 
 export const StyledSpacer = styled.div<StyledSpacerProps>`
-  height: ${props => props.size ? props.size : 0}px;
-  width: ${props => props.size ? props.size : 0}px;
-  background-color: ${props => props.bg ? props.bg : props.theme.color.transparent};
+  height: ${(props) => (props.size ? props.size : 0)}px;
+  width: ${(props) => (props.size ? props.size : 0)}px;
+  background-color: ${(props) =>
+    props.bg ? props.bg : props.theme.color.transparent};
 `;
 
 export default Spacer;

--- a/packages/app/src/components/Spacer/index.ts
+++ b/packages/app/src/components/Spacer/index.ts
@@ -1,1 +1,1 @@
-export { default, StyledSpacer } from './Spacer'
+export { default, StyledSpacer } from "./Spacer";

--- a/packages/app/src/components/Stats/Stats.tsx
+++ b/packages/app/src/components/Stats/Stats.tsx
@@ -1,82 +1,118 @@
-import React from 'react';
-import styled from 'styled-components';
-import { ContentBoxGrid, ContentCentered, ContentColumn, ContentColumns, ExternalLink, Spacer, Title, Text } from '../../components';
-import { theme } from '../../theme';
-import { dummyGraph, fudizardPng } from '../../assets';
-import { LazyLoadImage } from 'react-lazy-load-image-component';
-import 'react-lazy-load-image-component/src/effects/blur.css';
+import React from "react";
+import styled from "styled-components";
+import {
+  ContentBoxGrid,
+  ContentCentered,
+  ContentColumn,
+  ContentColumns,
+  ExternalLink,
+  Spacer,
+  Title,
+  Text,
+} from "../../components";
+import { theme } from "../../theme";
+import { dummyGraph, fudizardPng } from "../../assets";
+import { LazyLoadImage } from "react-lazy-load-image-component";
+import "react-lazy-load-image-component/src/effects/blur.css";
 
 const Stats: React.FC<any> = () => {
-	return (
-		<ContentColumns
-			mobileStyle={{marginTop: "5em", marginBottom: "5em"}}
-			desktopStyle={{marginTop: "17em", marginBottom: "4em"}}>
-			<ContentColumn width="50%">
-				<Title as="h2" align='left' font={theme.font.neometric} size='xxl' weight={900} lineHeight={1.04}>Get yours before it's gone!</Title>
-				<Spacer size="md"/>
-				<ContentColumns justify="space-between">
-					<ContentColumn>
-						<Text as="p" align='left' font={theme.font.spaceMace} underline>Golden Fudizard</Text>
-					</ContentColumn>
-					<ContentColumn tabletLStyle={{ maxWidth: '250px' }}>
-						<StyledContentBoxGrid gridTemplate='"meta1 meta2 meta3"'>
-							<div style={{ gridArea: "meta1" }}>
-								<Text as="p">owners</Text>
-								<Text as="p" size='xl' font={theme.font.neometric} weight={900}>28</Text>
-							</div>
-							<div style={{ gridArea: "meta2" }}>
-								<Text as="p">total</Text>
-								<Text as="p" size='xl' font={theme.font.neometric} weight={900}>30</Text>
-							</div>
-							<div style={{ gridArea: "meta3" }}>
-								<Text as="p">last sold</Text>
-								<Text as="p" size='xl' font={theme.font.neometric} weight={900}>2.8ETH</Text>
-							</div>
-						</StyledContentBoxGrid>
-					</ContentColumn>
-				</ContentColumns>
-				<LazyLoadImage effect="blur" src={dummyGraph} alt="graph" width="880"/>
-				<StyledExternalLink styling="button" style={{display: "inline-block", width: "100%"}} href="https://opensea.io/collection/pepemonfactory">
-					Buy now
-				</StyledExternalLink>
-			</ContentColumn>
-			<ContentColumn width="50%">
-				<StyledImgContainer>
-					<StyledImgContainerInner>
-						<LazyLoadImage effect="blur" loading="lazy" src={fudizardPng} alt="fudizard"/>
-					</StyledImgContainerInner>
-				</StyledImgContainer>
-			</ContentColumn>
-		</ContentColumns>
-	)
-}
+  return (
+    <ContentColumns
+      mobileStyle={{ marginTop: "5em", marginBottom: "5em" }}
+      desktopStyle={{ marginTop: "17em", marginBottom: "4em" }}
+    >
+      <ContentColumn width="50%">
+        <Title
+          as="h2"
+          align="left"
+          font={theme.font.neometric}
+          size="xxl"
+          weight={900}
+          lineHeight={1.04}
+        >
+          Get yours before it's gone!
+        </Title>
+        <Spacer size="md" />
+        <ContentColumns justify="space-between">
+          <ContentColumn>
+            <Text as="p" align="left" font={theme.font.spaceMace} underline>
+              Golden Fudizard
+            </Text>
+          </ContentColumn>
+          <ContentColumn tabletLStyle={{ maxWidth: "250px" }}>
+            <StyledContentBoxGrid gridTemplate='"meta1 meta2 meta3"'>
+              <div style={{ gridArea: "meta1" }}>
+                <Text as="p">owners</Text>
+                <Text as="p" size="xl" font={theme.font.neometric} weight={900}>
+                  28
+                </Text>
+              </div>
+              <div style={{ gridArea: "meta2" }}>
+                <Text as="p">total</Text>
+                <Text as="p" size="xl" font={theme.font.neometric} weight={900}>
+                  30
+                </Text>
+              </div>
+              <div style={{ gridArea: "meta3" }}>
+                <Text as="p">last sold</Text>
+                <Text as="p" size="xl" font={theme.font.neometric} weight={900}>
+                  2.8ETH
+                </Text>
+              </div>
+            </StyledContentBoxGrid>
+          </ContentColumn>
+        </ContentColumns>
+        <LazyLoadImage effect="blur" src={dummyGraph} alt="graph" width="880" />
+        <StyledExternalLink
+          styling="button"
+          style={{ display: "inline-block", width: "100%" }}
+          href="https://opensea.io/collection/pepemonfactory"
+        >
+          Buy now
+        </StyledExternalLink>
+      </ContentColumn>
+      <ContentColumn width="50%">
+        <StyledImgContainer>
+          <StyledImgContainerInner>
+            <LazyLoadImage
+              effect="blur"
+              loading="lazy"
+              src={fudizardPng}
+              alt="fudizard"
+            />
+          </StyledImgContainerInner>
+        </StyledImgContainer>
+      </ContentColumn>
+    </ContentColumns>
+  );
+};
 
 const StyledExternalLink = styled(ExternalLink)`
-	@media (max-width: ${theme.breakpoints.tabletL}) {
-		max-width: 60%;
-	}
-`
+  @media (max-width: ${theme.breakpoints.tabletL}) {
+    max-width: 60%;
+  }
+`;
 
 const StyledContentBoxGrid = styled(ContentBoxGrid)`
-	text-align: left;
-	@media (min-width: ${theme.breakpoints.tabletL}) {
-		text-align: center;
-	}
-`
+  text-align: left;
+  @media (min-width: ${theme.breakpoints.tabletL}) {
+    text-align: center;
+  }
+`;
 
 const StyledImgContainer = styled.div`
-	height: 100%;
-	position: relative;
-	width: 100%
-`
+  height: 100%;
+  position: relative;
+  width: 100%;
+`;
 
 const StyledImgContainerInner = styled(ContentCentered)`
-	@media (max-width: ${theme.breakpoints.tabletL}) {
-		max-width: 40%;
-		position: absolute;
-		right: 0;
-		transform: translateY(-60%);
-	}
-`
+  @media (max-width: ${theme.breakpoints.tabletL}) {
+    max-width: 40%;
+    position: absolute;
+    right: 0;
+    transform: translateY(-60%);
+  }
+`;
 
 export default Stats;

--- a/packages/app/src/components/Stats/index.ts
+++ b/packages/app/src/components/Stats/index.ts
@@ -1,1 +1,1 @@
-export { default } from './Stats';
+export { default } from "./Stats";

--- a/packages/app/src/components/Text/Text.tsx
+++ b/packages/app/src/components/Text/Text.tsx
@@ -1,54 +1,56 @@
-import styled from 'styled-components';
-import { theme } from '../../theme';
+import styled from "styled-components";
+import { theme } from "../../theme";
 
-type Size = 'xs' | 's' | 'm' | 'l' | 'xl' | 'xxl' | 'inherit';
+type Size = "xs" | "s" | "m" | "l" | "xl" | "xxl" | "inherit";
 
 interface StyledTextProps {
-	as?: 'div' | 'p' | 'span' | 'b' | 'strong' | 'mark';
-	align?: string;
-	color?: string;
-	font?: string;
-	lineHeight?: number;
-	size?: Size;
-	spacing?: number;
-	txtTransform?: string;
-	underline?: boolean;
-	weight?: number | string;
+  as?: "div" | "p" | "span" | "b" | "strong" | "mark";
+  align?: string;
+  color?: string;
+  font?: string;
+  lineHeight?: number;
+  size?: Size;
+  spacing?: number;
+  txtTransform?: string;
+  underline?: boolean;
+  weight?: number | string;
 }
 
-const getSize = (size) : string => {
-	switch (size) {
-		case 'xs':
-			return 'clamp(.7rem, 1vw, .75rem)';
-		case 's':
-			return 'clamp(.75rem, 1.1vw, .875rem)';
-		case 'l':
-			return 'clamp(1.1rem, 1.8vw, 1.375rem)';
-		case 'xl':
-			return 'clamp(1.8rem, 3rem, 2rem)';
-		case 'xxl':
-			return 'clamp(2rem, 4vw, 2.5rem)';
-		case 'inherit':
-			return 'inherit';
-		case 'm':
-		default:
-			return 'clamp(.9rem, 1vw, 1rem)';
-	}
-}
+const getSize = (size): string => {
+  switch (size) {
+    case "xs":
+      return "clamp(.7rem, 1vw, .75rem)";
+    case "s":
+      return "clamp(.75rem, 1.1vw, .875rem)";
+    case "l":
+      return "clamp(1.1rem, 1.8vw, 1.375rem)";
+    case "xl":
+      return "clamp(1.8rem, 3rem, 2rem)";
+    case "xxl":
+      return "clamp(2rem, 4vw, 2.5rem)";
+    case "inherit":
+      return "inherit";
+    case "m":
+    default:
+      return "clamp(.9rem, 1vw, 1rem)";
+  }
+};
 
 const Text = styled.div<StyledTextProps>`
-	color: ${props => props.color ? props.color : props.theme.color.headers};
-	font-family: ${props => props.font && props.font};
-	font-size: ${props => props.size && getSize(props.size)};
-	font-weight: ${props => props.weight ? props.weight : "normal"};
-	text-align: ${props => props.align && props.align};
-	text-transform: ${props => props.txtTransform && props.txtTransform};
-	letter-spacing: ${props => props.spacing && props.spacing + "px"};
-	line-height: ${props => props.lineHeight ? props.lineHeight : 1.5};
-	margin-top: 0;
-	margin-bottom: 0;
+  color: ${(props) => (props.color ? props.color : props.theme.color.headers)};
+  font-family: ${(props) => props.font && props.font};
+  font-size: ${(props) => props.size && getSize(props.size)};
+  font-weight: ${(props) => (props.weight ? props.weight : "normal")};
+  text-align: ${(props) => props.align && props.align};
+  text-transform: ${(props) => props.txtTransform && props.txtTransform};
+  letter-spacing: ${(props) => props.spacing && props.spacing + "px"};
+  line-height: ${(props) => (props.lineHeight ? props.lineHeight : 1.5)};
+  margin-top: 0;
+  margin-bottom: 0;
 
-	${({underline, color}) => underline && `
+  ${({ underline, color }) =>
+    underline &&
+    `
 		display: inline-flex;
 		flex-direction: column;
 
@@ -61,10 +63,10 @@ const Text = styled.div<StyledTextProps>`
 			width: 100%;
 		}
 	`}
-`
+`;
 
 Text.defaultProps = {
-	as: 'p'
-}
+  as: "p",
+};
 
 export default Text;

--- a/packages/app/src/components/Text/Title.tsx
+++ b/packages/app/src/components/Text/Title.tsx
@@ -1,80 +1,93 @@
-import styled from 'styled-components';
-import { theme } from '../../theme';
+import styled from "styled-components";
+import { theme } from "../../theme";
 
-type Size = 'xxxs' | 'xxs' | 'xs' | 's' | 'm' | 'l' | 'xl' | 'xxl' | 'xxxl' | 'inherit';
+type Size =
+  | "xxxs"
+  | "xxs"
+  | "xs"
+  | "s"
+  | "m"
+  | "l"
+  | "xl"
+  | "xxl"
+  | "xxxl"
+  | "inherit";
 
 interface TitleProps {
-	as: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
-	align?: string;
-	font?: string;
-	isInactive?: boolean;
-	lineHeight?: number;
-	size?: Size;
-	weight?: number | string;
+  as: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+  align?: string;
+  font?: string;
+  isInactive?: boolean;
+  lineHeight?: number;
+  size?: Size;
+  weight?: number | string;
 }
 
-const getSize = (size) : string => {
-	switch (size) {
-		case 'xxxs':
-			return '.8rem';
-		case 'xxs':
-			return 'clamp(1.1rem, 1.1vw, 1.125rem)';
-		case 'xs':
-			return 'clamp(1.125rem, 1.2vw, 1.2rem)';
-		case 's':
-			return '1.3rem';
-		case 'l':
-			return 'clamp(1.4rem, 2.65vw, 2rem)';
-		case 'xl':
-			return '2.5rem';
-		case 'xxl':
-			return '3rem';
-		case 'xxxl':
-			return 'clamp(2.5rem, 6vw, 4.5rem)';
-		case 'inherit':
-			return 'inherit';
-		case 'm':
-		default:
-			return 'clamp(.9rem, 1vw, 1rem)';
-	}
-}
+const getSize = (size): string => {
+  switch (size) {
+    case "xxxs":
+      return ".8rem";
+    case "xxs":
+      return "clamp(1.1rem, 1.1vw, 1.125rem)";
+    case "xs":
+      return "clamp(1.125rem, 1.2vw, 1.2rem)";
+    case "s":
+      return "1.3rem";
+    case "l":
+      return "clamp(1.4rem, 2.65vw, 2rem)";
+    case "xl":
+      return "2.5rem";
+    case "xxl":
+      return "3rem";
+    case "xxxl":
+      return "clamp(2.5rem, 6vw, 4.5rem)";
+    case "inherit":
+      return "inherit";
+    case "m":
+    default:
+      return "clamp(.9rem, 1vw, 1rem)";
+  }
+};
 
 const Title = styled.div<TitleProps>`
-	&{
-		color: ${props => props.color ? props.color : props.theme.color.black};
-		font-family: ${props => props.font ? props.font : props.theme.font.spaceMace};
-		font-size: ${props => props.size && getSize(props.size)};
-		font-weight: ${props => props.weight ? props.weight : 500};
-		hyphens: none;
-		line-height: ${props => props.lineHeight && props.lineHeight};
-		margin: 0;
-		text-align: ${props => props.align && props.align};
-	}
-`
+  & {
+    color: ${(props) => (props.color ? props.color : props.theme.color.black)};
+    font-family: ${(props) =>
+      props.font ? props.font : props.theme.font.spaceMace};
+    font-size: ${(props) => props.size && getSize(props.size)};
+    font-weight: ${(props) => (props.weight ? props.weight : 500)};
+    hyphens: none;
+    line-height: ${(props) => props.lineHeight && props.lineHeight};
+    margin: 0;
+    text-align: ${(props) => props.align && props.align};
+  }
+`;
 
 export const StyledPageTitle = styled(Title)`
-	font-size: 2.5rem;
-	margin-bottom: .5em;
-`
+  font-size: 2.5rem;
+  margin-bottom: 0.5em;
+`;
 
-export const StyledLinkTitle = styled.h2<{isInactive?: boolean}>`
-	font-size: 1.2rem;
-	font-family: ${theme.font.neometric};
-	font-weight: 500;
-	margin-bottom: 0;
-	margin-top: 0;
-	position: relative;
+export const StyledLinkTitle = styled.h2<{ isInactive?: boolean }>`
+  font-size: 1.2rem;
+  font-family: ${theme.font.neometric};
+  font-weight: 500;
+  margin-bottom: 0;
+  margin-top: 0;
+  position: relative;
 
-	&:not(:last-child) {
-		margin-right: 1em;
-	}
+  &:not(:last-child) {
+    margin-right: 1em;
+  }
 
-	a {
-		color: ${theme.color.white};
-		text-decoration: none;
-	}
+  a {
+    color: ${theme.color.white};
+    text-decoration: none;
+  }
 
-	${({ isInactive }) => isInactive !== true ? (`
+  ${({ isInactive }) =>
+    isInactive !== true
+      ? `
 		&{
 			font-weight: 900;
 		}
@@ -92,9 +105,10 @@ export const StyledLinkTitle = styled.h2<{isInactive?: boolean}>`
 			width: 100%;
 			bottom: -.1em;
 			left: 0;
-		}`): (`
+		}`
+      : `
 		opacity: .7;
-	`)}
-`
+	`}
+`;
 
 export default Title;

--- a/packages/app/src/components/Text/index.ts
+++ b/packages/app/src/components/Text/index.ts
@@ -1,2 +1,2 @@
-export { default as Title, StyledLinkTitle, StyledPageTitle } from './Title'
-export { default as Text } from './Text'
+export { default as Title, StyledLinkTitle, StyledPageTitle } from "./Title";
+export { default as Text } from "./Text";

--- a/packages/app/src/components/TopBar/components/NetworkSwitch.tsx
+++ b/packages/app/src/components/TopBar/components/NetworkSwitch.tsx
@@ -1,159 +1,177 @@
-import React, { useState, useRef, useContext } from 'react';
-import styled from 'styled-components';
-import { useLocation } from 'react-router-dom';
-import { up_down_arrows_dark } from '../../../assets';
-import { chains } from '../../../constants';
-import { PepemonProviderContext } from '../../../contexts';
-import { isSupportedChain } from '../../../utils';
-import { UnhandledError } from '../../../components';
-import { theme } from '../../../theme';
-import { useOutsideClick } from '../../../hooks';
+import React, { useState, useRef, useContext } from "react";
+import styled from "styled-components";
+import { useLocation } from "react-router-dom";
+import { up_down_arrows_dark } from "../../../assets";
+import { chains } from "../../../constants";
+import { PepemonProviderContext } from "../../../contexts";
+import { isSupportedChain } from "../../../utils";
+import { UnhandledError } from "../../../components";
+import { theme } from "../../../theme";
+import { useOutsideClick } from "../../../hooks";
 
 const NetworkSwitch: React.FC<any> = () => {
-	const [chainsListActive, setChainsListActive] = useState(false);
-	const [unhandledError, setUnhandledError] = useState<{errCode?: number, errMsg: string}>({errCode: null, errMsg: ''})
-	const networkSwitchRef = useRef(null);
-	useOutsideClick(networkSwitchRef, () => {
-		if (chainsListActive) {
-			setChainsListActive(false);
-		}
-	})
+  const [chainsListActive, setChainsListActive] = useState(false);
+  const [unhandledError, setUnhandledError] = useState<{
+    errCode?: number;
+    errMsg: string;
+  }>({ errCode: null, errMsg: "" });
+  const networkSwitchRef = useRef(null);
+  useOutsideClick(networkSwitchRef, () => {
+    if (chainsListActive) {
+      setChainsListActive(false);
+    }
+  });
 
-	const { pathname } = useLocation();
+  const { pathname } = useLocation();
 
-	const [pepemon] = useContext(PepemonProviderContext);
-	const { chainId } = pepemon;
+  const [pepemon] = useContext(PepemonProviderContext);
+  const { chainId } = pepemon;
 
-	const handleChainSwitch = async (chain) => {
-		try {
-			await window.ethereum.request({
-				method: 'wallet_switchEthereumChain',
-				params: [{ chainId: chain.chainId }],
-			});
-		} catch (switchError: any) {
-			// This error code indicates that the chain has not been added to MetaMask.
-			if (switchError.code === 4902) {
-				try {
-					await window.ethereum.request({
-						method: 'wallet_addEthereumChain',
-						params: [{
-							chainId: chain.chainId,
-							chainName: chain.chainName,
-							nativeCurrency: chain.nativeCurrency,
-							rpcUrls: chain.rpcUrls,
-							blockExplorerUrls: chain.blockExplorerUrls,
-						}]
-					});
-				} catch (addError: any) {
-					// handle 'add' error
-					setUnhandledError({
-						errCode: addError.code,
-						errMsg: addError.message
-					})
-				}
-			}
-			// handle other 'switch' errors
-			else {
-				setUnhandledError({
-					errMsg: 'Your provider either does not support switching chains or does not allow dynamically adding new chains. If you are connected with another device, please switch your chain there and reload this page or try adding the chain manually first before switching.'
-				})
-			}
-		}
-		setChainsListActive(false);
-	}
+  const handleChainSwitch = async (chain) => {
+    try {
+      await window.ethereum.request({
+        method: "wallet_switchEthereumChain",
+        params: [{ chainId: chain.chainId }],
+      });
+    } catch (switchError: any) {
+      // This error code indicates that the chain has not been added to MetaMask.
+      if (switchError.code === 4902) {
+        try {
+          await window.ethereum.request({
+            method: "wallet_addEthereumChain",
+            params: [
+              {
+                chainId: chain.chainId,
+                chainName: chain.chainName,
+                nativeCurrency: chain.nativeCurrency,
+                rpcUrls: chain.rpcUrls,
+                blockExplorerUrls: chain.blockExplorerUrls,
+              },
+            ],
+          });
+        } catch (addError: any) {
+          // handle 'add' error
+          setUnhandledError({
+            errCode: addError.code,
+            errMsg: addError.message,
+          });
+        }
+      }
+      // handle other 'switch' errors
+      else {
+        setUnhandledError({
+          errMsg:
+            "Your provider either does not support switching chains or does not allow dynamically adding new chains. If you are connected with another device, please switch your chain there and reload this page or try adding the chain manually first before switching.",
+        });
+      }
+    }
+    setChainsListActive(false);
+  };
 
-	const supportedChains = chains.filter(chain => isSupportedChain(parseInt(chain.chainId), pathname));
-	const [currentChain] = chains.filter(chain => (parseInt(chain.chainId) === chainId) && chain.chainName);
+  const supportedChains = chains.filter((chain) =>
+    isSupportedChain(parseInt(chain.chainId), pathname)
+  );
+  const [currentChain] = chains.filter(
+    (chain) => parseInt(chain.chainId) === chainId && chain.chainName
+  );
 
-	return (
-		<NetworkSwitchWrapper>
-			<ChainsListButton onClick={() => setChainsListActive(!chainsListActive)}>
-				{ currentChain ? currentChain.name : 'Not connected' }
-				<img alt='change network' src={up_down_arrows_dark} style={{ width: '.5em', marginLeft: '.8em' }}/>
-			</ChainsListButton>
-			<ChainsList isOpen={chainsListActive} ref={networkSwitchRef}>
-				{ supportedChains.map((chain, key) => {
-					return (
-						<li key={key}>
-							<ChainsListButton disabled={parseInt(chain.chainId) === chainId} aria-label={`change to ${chain.name}`}
-								onClick={() => handleChainSwitch(chain)}>
-								{chain.name}
-							</ChainsListButton>
-						</li>
-					)
-				})}
-			</ChainsList>
-			{ (unhandledError.errCode || unhandledError.errMsg) &&
-				<UnhandledError
-					errCode={unhandledError.errCode}
-					errMsg={unhandledError.errMsg}
-					onDismiss={() => setUnhandledError({errCode: null, errMsg: ''})}/>
-			}
-		</NetworkSwitchWrapper>
-	)
-}
+  return (
+    <NetworkSwitchWrapper>
+      <ChainsListButton onClick={() => setChainsListActive(!chainsListActive)}>
+        {currentChain ? currentChain.name : "Not connected"}
+        <img
+          alt="change network"
+          src={up_down_arrows_dark}
+          style={{ width: ".5em", marginLeft: ".8em" }}
+        />
+      </ChainsListButton>
+      <ChainsList isOpen={chainsListActive} ref={networkSwitchRef}>
+        {supportedChains.map((chain, key) => {
+          return (
+            <li key={key}>
+              <ChainsListButton
+                disabled={parseInt(chain.chainId) === chainId}
+                aria-label={`change to ${chain.name}`}
+                onClick={() => handleChainSwitch(chain)}
+              >
+                {chain.name}
+              </ChainsListButton>
+            </li>
+          );
+        })}
+      </ChainsList>
+      {(unhandledError.errCode || unhandledError.errMsg) && (
+        <UnhandledError
+          errCode={unhandledError.errCode}
+          errMsg={unhandledError.errMsg}
+          onDismiss={() => setUnhandledError({ errCode: null, errMsg: "" })}
+        />
+      )}
+    </NetworkSwitchWrapper>
+  );
+};
 
 const ChainsListButton = styled.button`
-	background-color: transparent;
-	border: none;
-	color: currentColor;
-	cursor: pointer;
-	font-size: inherit;
-	font-weight: inherit;
+  background-color: transparent;
+  border: none;
+  color: currentColor;
+  cursor: pointer;
+  font-size: inherit;
+  font-weight: inherit;
 
-	&:focus-visible {
-		outline: none;
-		box-shadow: 0px 0px 10px 5px ${theme.color.purple[600]};
-	}
-`
+  &:focus-visible {
+    outline: none;
+    box-shadow: 0px 0px 10px 5px ${theme.color.purple[600]};
+  }
+`;
 
 const NetworkSwitchWrapper = styled.div`
-	position: relative;
+  position: relative;
 
-	> ${ChainsListButton} {
-		@media (max-width: ${theme.breakpoints.mobile}) {
-			border-radius: 10px;
-			border: 1px solid ${theme.color.purple[800]};
-			padding: .4em .9em;
-		}
-	}
-`
+  > ${ChainsListButton} {
+    @media (max-width: ${theme.breakpoints.mobile}) {
+      border-radius: 10px;
+      border: 1px solid ${theme.color.purple[800]};
+      padding: 0.4em 0.9em;
+    }
+  }
+`;
 
-const ChainsList = styled.ul<{isOpen?: boolean}>`
-	background-color: ${theme.color.white};
-	border-radius: 10px;
-	border: 1px solid ${theme.color.purple[800]};
-	display: ${props => !props.isOpen && 'none'};
-	left: 0;
-	list-style-type: none;
-	margin-top: .5em;
-	overflow: hidden;
-	padding: .25em;
-	position: absolute;
+const ChainsList = styled.ul<{ isOpen?: boolean }>`
+  background-color: ${theme.color.white};
+  border-radius: 10px;
+  border: 1px solid ${theme.color.purple[800]};
+  display: ${(props) => !props.isOpen && "none"};
+  left: 0;
+  list-style-type: none;
+  margin-top: 0.5em;
+  overflow: hidden;
+  padding: 0.25em;
+  position: absolute;
 
-	@media (min-width: ${theme.breakpoints.mobile}) {
-		background-color: rgba(255, 255, 255, .6);
-		margin-top: 1em;
-	}
+  @media (min-width: ${theme.breakpoints.mobile}) {
+    background-color: rgba(255, 255, 255, 0.6);
+    margin-top: 1em;
+  }
 
-	li {
-		&:not(:last-child) {
-			margin-bottom: .1em;
-		}
-	}
+  li {
+    &:not(:last-child) {
+      margin-bottom: 0.1em;
+    }
+  }
 
-	${ChainsListButton} {
-		border-radius: 10px;
-		padding: .4em .9em;
-		text-align: left;
-		transition: all .4s;
-		width: 100%;
+  ${ChainsListButton} {
+    border-radius: 10px;
+    padding: 0.4em 0.9em;
+    text-align: left;
+    transition: all 0.4s;
+    width: 100%;
 
-		&:hover {
-			background-image: linear-gradient(to bottom,#aa6cd6 -100%,#713aac);
-			color: ${theme.color.white};
-		}
-	}
-`
+    &:hover {
+      background-image: linear-gradient(to bottom, #aa6cd6 -100%, #713aac);
+      color: ${theme.color.white};
+    }
+  }
+`;
 
 export default NetworkSwitch;

--- a/packages/app/src/components/TopBar/components/WalletModal.tsx
+++ b/packages/app/src/components/TopBar/components/WalletModal.tsx
@@ -1,80 +1,108 @@
-import React, { useContext } from 'react';
-import styled from 'styled-components';
-import { isMobile } from 'web3modal';
-import { ExternalLink, ModalProps, NetworkSwitch, Text } from '../../../components';
-import { PepemonProviderContext } from '../../../contexts';
-import { theme } from '../../../theme';
-import { chains } from '../../../constants';
+import React, { useContext } from "react";
+import styled from "styled-components";
+import { isMobile } from "web3modal";
+import {
+  ExternalLink,
+  ModalProps,
+  NetworkSwitch,
+  Text,
+} from "../../../components";
+import { PepemonProviderContext } from "../../../contexts";
+import { theme } from "../../../theme";
+import { chains } from "../../../constants";
 
 interface WalletModal extends ModalProps {
-	account: string,
-	setChainId?: () => void,
-	ppblzBalance?: any,
-	nativeBalance?: string,
-	totalPpblz?: string,
-	totalPpdex?: string
-	ppmnCardsOwned?: number
+  account: string;
+  setChainId?: () => void;
+  ppblzBalance?: any;
+  nativeBalance?: string;
+  totalPpblz?: string;
+  totalPpdex?: string;
+  ppmnCardsOwned?: number;
 }
 
-const WalletModal: React.FC<WalletModal> = ({account, setChainId, ppblzBalance, nativeBalance, totalPpblz, totalPpdex, ppmnCardsOwned}) => {
-	const [{chainId}] = useContext(PepemonProviderContext);
+const WalletModal: React.FC<WalletModal> = ({
+  account,
+  setChainId,
+  ppblzBalance,
+  nativeBalance,
+  totalPpblz,
+  totalPpdex,
+  ppmnCardsOwned,
+}) => {
+  const [{ chainId }] = useContext(PepemonProviderContext);
 
-	const [currentChain] = chains.filter(chain => (parseInt(chain.chainId) === chainId) && chain.chainName);
+  const [currentChain] = chains.filter(
+    (chain) => parseInt(chain.chainId) === chainId && chain.chainName
+  );
 
-    return (
-		<>
-			{ ppblzBalance &&
-				<StyledTextInfos>
-					{ isMobile() &&
-						<>
-							<dt>Change network:</dt>
-							<dd><NetworkSwitch {...{appChainId: chainId, providerChainId: chainId}}/></dd>
-						</>
-					}
-					<dt>Native balance</dt>
-					<dd>{nativeBalance}</dd>
-					<dt>In Wallet + Staked PPBLZ</dt>
-					<dd>{totalPpblz}</dd>
-					<dt>In Wallet + Not Claimed PPDEX</dt>
-					<dd>{totalPpdex}</dd>
-					<dt>Unique card{ppmnCardsOwned !== 1 && 's'}</dt>
-					<dd>{ppmnCardsOwned}</dd>
-				</StyledTextInfos>
-			}
-			<CustomText font={theme.font.inter} size='s' color={theme.color.gray[600]}>
-				View your account on <ExternalLink href={`${currentChain?.blockExplorerUrls}/address/${account}`}>{currentChain?.blockExplorerTitle}</ExternalLink>
-			</CustomText>
-		</>
-    )
-}
+  return (
+    <>
+      {ppblzBalance && (
+        <StyledTextInfos>
+          {isMobile() && (
+            <>
+              <dt>Change network:</dt>
+              <dd>
+                <NetworkSwitch
+                  {...{ appChainId: chainId, providerChainId: chainId }}
+                />
+              </dd>
+            </>
+          )}
+          <dt>Native balance</dt>
+          <dd>{nativeBalance}</dd>
+          <dt>In Wallet + Staked PPBLZ</dt>
+          <dd>{totalPpblz}</dd>
+          <dt>In Wallet + Not Claimed PPDEX</dt>
+          <dd>{totalPpdex}</dd>
+          <dt>Unique card{ppmnCardsOwned !== 1 && "s"}</dt>
+          <dd>{ppmnCardsOwned}</dd>
+        </StyledTextInfos>
+      )}
+      <CustomText
+        font={theme.font.inter}
+        size="s"
+        color={theme.color.gray[600]}
+      >
+        View your account on{" "}
+        <ExternalLink
+          href={`${currentChain?.blockExplorerUrls}/address/${account}`}
+        >
+          {currentChain?.blockExplorerTitle}
+        </ExternalLink>
+      </CustomText>
+    </>
+  );
+};
 
 export const StyledTextInfos = styled.dl`
-	&{
-		font-family: ${theme.font.inter};
-		margin-bottom: 0;
-	}
+  & {
+    font-family: ${theme.font.inter};
+    margin-bottom: 0;
+  }
 
-	& dt {
-		color: ${theme.color.gray[300]};
-		font-size: .8rem;
-		text-transform: uppercase;
-		letter-spacing: 1.2px;
-	}
+  & dt {
+    color: ${theme.color.gray[300]};
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 1.2px;
+  }
 
-	& dd {
-		color: ${theme.color.gray[600]};
-		font-size: 1.2rem;
-		font-weight: bold;
-		margin-bottom: 1em;
-		margin-left: 0;
-		margin-top: .2em;
-	}
-`
+  & dd {
+    color: ${theme.color.gray[600]};
+    font-size: 1.2rem;
+    font-weight: bold;
+    margin-bottom: 1em;
+    margin-left: 0;
+    margin-top: 0.2em;
+  }
+`;
 
 const CustomText = styled(Text)`
-	@media (min-width: ${theme.breakpoints.tabletL}) {
-		text-align: center;
-	}
-`
+  @media (min-width: ${theme.breakpoints.tabletL}) {
+    text-align: center;
+  }
+`;
 
-export default WalletModal
+export default WalletModal;

--- a/packages/app/src/components/TopBar/components/index.ts
+++ b/packages/app/src/components/TopBar/components/index.ts
@@ -1,2 +1,2 @@
-export { default as NetworkSwitch } from './NetworkSwitch';
-export { default as WalletModal } from './WalletModal';
+export { default as NetworkSwitch } from "./NetworkSwitch";
+export { default as WalletModal } from "./WalletModal";

--- a/packages/app/src/components/TopBar/index.ts
+++ b/packages/app/src/components/TopBar/index.ts
@@ -1,2 +1,2 @@
-export { default } from './TopBar'
-export { NetworkSwitch } from './components';
+export { default } from "./TopBar";
+export { NetworkSwitch } from "./components";

--- a/packages/app/src/components/UnhandledError/UnhandledError.tsx
+++ b/packages/app/src/components/UnhandledError/UnhandledError.tsx
@@ -1,42 +1,61 @@
-import React from 'react';
-import { ModalProps, Modal, ModalTitle, ModalContent, ModalActions, Text, Spacer } from '../../components';
-import { theme } from '../../theme';
+import React from "react";
+import {
+  ModalProps,
+  Modal,
+  ModalTitle,
+  ModalContent,
+  ModalActions,
+  Text,
+  Spacer,
+} from "../../components";
+import { theme } from "../../theme";
 
 interface UnhandledErrorProps extends ModalProps {
-	errCode?: number,
-	errMsg: string
+  errCode?: number;
+  errMsg: string;
 }
 
-const UnhandledError: React.FC<UnhandledErrorProps> = ({errCode, errMsg, onDismiss}) => {
-	const title = errCode ? `Error ${errCode}` : 'Unknown error';
+const UnhandledError: React.FC<UnhandledErrorProps> = ({
+  errCode,
+  errMsg,
+  onDismiss,
+}) => {
+  const title = errCode ? `Error ${errCode}` : "Unknown error";
 
-	return (
-		<Modal onDismiss={onDismiss}>
-			<ModalTitle text={title}/>
-			<ModalContent>
-				<Text align='center' font={theme.font.inter} size='s' color={theme.color.gray[600]}>
-					{errMsg}
-				</Text>
-			</ModalContent>
-			<Spacer size='md'/>
-			<ModalActions modalActions={[
-				{
-					text: 'Report on GitHub',
-					href: `https://github.com/pepem00n/pepemon-frontend/issues/new?title=Error:%20${title}:%20${errMsg}&body=%0A%0A%0A---%0AI%27m+a+human.+Please+be+nice.`,
-					buttonProps: {
-						styling: 'button',
-					}
-				},
-				{
-					text: 'Reload',
-					buttonProps: {
-						styling: 'white',
-						onClick: () => window.location.reload()
-					}
-				}
-			]}/>
-		</Modal>
-	)
-}
+  return (
+    <Modal onDismiss={onDismiss}>
+      <ModalTitle text={title} />
+      <ModalContent>
+        <Text
+          align="center"
+          font={theme.font.inter}
+          size="s"
+          color={theme.color.gray[600]}
+        >
+          {errMsg}
+        </Text>
+      </ModalContent>
+      <Spacer size="md" />
+      <ModalActions
+        modalActions={[
+          {
+            text: "Report on GitHub",
+            href: `https://github.com/pepem00n/pepemon-frontend/issues/new?title=Error:%20${title}:%20${errMsg}&body=%0A%0A%0A---%0AI%27m+a+human.+Please+be+nice.`,
+            buttonProps: {
+              styling: "button",
+            },
+          },
+          {
+            text: "Reload",
+            buttonProps: {
+              styling: "white",
+              onClick: () => window.location.reload(),
+            },
+          },
+        ]}
+      />
+    </Modal>
+  );
+};
 
 export default UnhandledError;

--- a/packages/app/src/components/UnhandledError/index.ts
+++ b/packages/app/src/components/UnhandledError/index.ts
@@ -1,1 +1,1 @@
-export { default } from './UnhandledError';
+export { default } from "./UnhandledError";

--- a/packages/app/src/components/Value/Value.tsx
+++ b/packages/app/src/components/Value/Value.tsx
@@ -1,29 +1,27 @@
-import React, { useState, useEffect } from 'react'
-import CountUp from 'react-countup'
-import styled from 'styled-components'
+import React, { useState, useEffect } from "react";
+import CountUp from "react-countup";
+import styled from "styled-components";
 
 interface ValueProps {
-  value: string | number
-  decimals?: number
-  size?: 'small' | 'medium'
+  value: string | number;
+  decimals?: number;
+  size?: "small" | "medium";
 }
 
 const Value: React.FC<ValueProps> = ({ value, decimals, size }) => {
-  const [start, updateStart] = useState(0)
-  const [end, updateEnd] = useState(0)
+  const [start, updateStart] = useState(0);
+  const [end, updateEnd] = useState(0);
 
   useEffect(() => {
-    if (typeof value === 'number') {
-      updateStart(end)
-      updateEnd(value)
+    if (typeof value === "number") {
+      updateStart(end);
+      updateEnd(value);
     }
-  }, [value, end])
+  }, [value, end]);
 
   return (
-    <StyledValue
-        size={size || 'default'}
-    >
-      {typeof value == 'string' ? (
+    <StyledValue size={size || "default"}>
+      {typeof value == "string" ? (
         value
       ) : (
         <CountUp
@@ -38,16 +36,17 @@ const Value: React.FC<ValueProps> = ({ value, decimals, size }) => {
         />
       )}
     </StyledValue>
-  )
-}
+  );
+};
 
 interface StyledValueProps {
-	size?: 'small' | 'medium' | 'default',
+  size?: "small" | "medium" | "default";
 }
 
 const StyledValue = styled.span<StyledValueProps>`
-  font-size: ${(props) => props.size === 'small' ? 14 : props.size === 'medium' ? 26 : 36}px;
-  font-weight: ${(props) => props.size === 'small' ? 400 : 700};
-`
+  font-size: ${(props) =>
+    props.size === "small" ? 14 : props.size === "medium" ? 26 : 36}px;
+  font-weight: ${(props) => (props.size === "small" ? 400 : 700)};
+`;
 
-export default Value
+export default Value;

--- a/packages/app/src/components/Value/index.ts
+++ b/packages/app/src/components/Value/index.ts
@@ -1,1 +1,1 @@
-export { default } from './Value'
+export { default } from "./Value";

--- a/packages/app/src/components/WalletButton/WalletButton.tsx
+++ b/packages/app/src/components/WalletButton/WalletButton.tsx
@@ -2,19 +2,20 @@ import React from "react";
 import { Button } from "../index";
 import { useWeb3Modal } from "../../hooks";
 
-const WalletButton: React.FC<any> = ({setConnecting}) => {
-	const [provider, loadWeb3Modal] = useWeb3Modal();
+const WalletButton: React.FC<any> = ({ setConnecting }) => {
+  const [provider, loadWeb3Modal] = useWeb3Modal();
 
-	const handleClick = async () => {
-		if (!provider) {
-			await loadWeb3Modal();
-		}
-	}
+  const handleClick = async () => {
+    if (!provider) {
+      await loadWeb3Modal();
+    }
+  };
 
   return (
-    <Button styling="purple"
+    <Button
+      styling="purple"
       onClick={handleClick}
-	  {...(provider && {disabled: true})}
+      {...(provider && { disabled: true })}
     >
       {!provider ? "Connect wallet" : "Connecting wallet..."}
     </Button>

--- a/packages/app/src/components/WalletButton/index.ts
+++ b/packages/app/src/components/WalletButton/index.ts
@@ -1,1 +1,1 @@
-export { default } from './WalletButton';
+export { default } from "./WalletButton";

--- a/packages/app/src/components/index.ts
+++ b/packages/app/src/components/index.ts
@@ -1,47 +1,73 @@
-export { default as Accordion, AccordionGroup, AccordionWrapper, AccordionHeader, AccordionHeaderTitle, AccordionHeaderButton, AccordionBody, AccordionBodyContent } from './Accordion'
-export { default as AnimatedImg } from './AnimatedImg';
-export { default as Button, ButtonLink } from './Button';
-export type { ButtonProps } from './Button';
-export { default as Badge } from './Badge';
-export { default as Card } from './Card';
-export { default as CardContent } from './CardContent';
-export { default as CardIcon } from './CardIcon';
-export { default as CardTitle } from './CardTitle';
-export { default as Container } from './Container';
-export { ContentBox, ContentBoxNumber, ContentBoxGrid, ContentCentered, ContentColumn, ContentColumns } from './Content';
-export { default as DropdownMenu } from './DropdownMenu';
-export { default as Evolve } from './Evolve';
-export { default as Footer } from './Footer';
-export { default as Hero } from './Hero';
-export { default as IButtonPopover } from './IButtonPopover';
-export type { IButtonPopoverProps } from './IButtonPopover';
-export { default as Head } from './Head';
-export { default as Label } from './Label';
-export { default as ExternalLink } from './Link';
-export type { ExternalLinkProps } from './Link';
-export { default as Loader } from './Loader';
-export { default as Loading } from './Loading';
-export { default as Logo } from './Logo';
-export { default as MobileMenu } from './MobileMenu';
-export { default as Modal } from './Modal';
-export type { ModalProps } from './Modal';
-export { default as ModalActions } from './ModalActions';
-export type { ModalActionsProps } from './ModalActions';
-export { default as ModalContent } from './ModalContent';
-export { default as ModalTitle } from './ModalTitle';
-export { default as Navigation } from './Navigation';
-export { default as Newsletter } from './Newsletter';
-export { default as NotSupportedModal } from './NotSupportedModal';
-export { default as Page, StyledPageWrapper, StyledPageWrapperMain, StyledPageWrapperMainInner } from './Page';
-export { DefaultPage, PlainText } from './Pages';
-export { default as PepemonCard, StyledPepemonCardImage, StyledPepemonCardMeta, StyledPepemonCardPrice } from './PepemonCard';
-export { default as ProgressBar } from './ProgressBar';
-export { default as ScrollToTop } from './ScrollToTop';
-export { default as SocialBoxes } from './SocialBoxes';
-export { default as Spacer, StyledSpacer } from './Spacer';
-export { default as Stats } from './Stats';
-export { Title, StyledPageTitle, StyledLinkTitle, Text } from './Text';
-export { default as TopBar, NetworkSwitch } from './TopBar';
-export { default as UnhandledError } from './UnhandledError';
-export { default as Value } from './Value';
-export { default as WalletButton } from './WalletButton';
+export {
+  default as Accordion,
+  AccordionGroup,
+  AccordionWrapper,
+  AccordionHeader,
+  AccordionHeaderTitle,
+  AccordionHeaderButton,
+  AccordionBody,
+  AccordionBodyContent,
+} from "./Accordion";
+export { default as AnimatedImg } from "./AnimatedImg";
+export { default as Button, ButtonLink } from "./Button";
+export type { ButtonProps } from "./Button";
+export { default as Badge } from "./Badge";
+export { default as Card } from "./Card";
+export { default as CardContent } from "./CardContent";
+export { default as CardIcon } from "./CardIcon";
+export { default as CardTitle } from "./CardTitle";
+export { default as Container } from "./Container";
+export {
+  ContentBox,
+  ContentBoxNumber,
+  ContentBoxGrid,
+  ContentCentered,
+  ContentColumn,
+  ContentColumns,
+} from "./Content";
+export { default as DropdownMenu } from "./DropdownMenu";
+export { default as Evolve } from "./Evolve";
+export { default as Footer } from "./Footer";
+export { default as Hero } from "./Hero";
+export { default as IButtonPopover } from "./IButtonPopover";
+export type { IButtonPopoverProps } from "./IButtonPopover";
+export { default as Head } from "./Head";
+export { default as Label } from "./Label";
+export { default as ExternalLink } from "./Link";
+export type { ExternalLinkProps } from "./Link";
+export { default as Loader } from "./Loader";
+export { default as Loading } from "./Loading";
+export { default as Logo } from "./Logo";
+export { default as MobileMenu } from "./MobileMenu";
+export { default as Modal } from "./Modal";
+export type { ModalProps } from "./Modal";
+export { default as ModalActions } from "./ModalActions";
+export type { ModalActionsProps } from "./ModalActions";
+export { default as ModalContent } from "./ModalContent";
+export { default as ModalTitle } from "./ModalTitle";
+export { default as Navigation } from "./Navigation";
+export { default as Newsletter } from "./Newsletter";
+export { default as NotSupportedModal } from "./NotSupportedModal";
+export {
+  default as Page,
+  StyledPageWrapper,
+  StyledPageWrapperMain,
+  StyledPageWrapperMainInner,
+} from "./Page";
+export { DefaultPage, PlainText } from "./Pages";
+export {
+  default as PepemonCard,
+  StyledPepemonCardImage,
+  StyledPepemonCardMeta,
+  StyledPepemonCardPrice,
+} from "./PepemonCard";
+export { default as ProgressBar } from "./ProgressBar";
+export { default as ScrollToTop } from "./ScrollToTop";
+export { default as SocialBoxes } from "./SocialBoxes";
+export { default as Spacer, StyledSpacer } from "./Spacer";
+export { default as Stats } from "./Stats";
+export { Title, StyledPageTitle, StyledLinkTitle, Text } from "./Text";
+export { default as TopBar, NetworkSwitch } from "./TopBar";
+export { default as UnhandledError } from "./UnhandledError";
+export { default as Value } from "./Value";
+export { default as WalletButton } from "./WalletButton";

--- a/packages/app/src/constants/api.ts
+++ b/packages/app/src/constants/api.ts
@@ -1,10 +1,10 @@
 const api = {
-	lambdaApi: {
-		endpoint: '/.netlify/functions/', // endpoint is always root
-		functions: {
-			subsNewsletter: 'subsNewsletter'
-		}
-	}
-}
+  lambdaApi: {
+    endpoint: "/.netlify/functions/", // endpoint is always root
+    functions: {
+      subsNewsletter: "subsNewsletter",
+    },
+  },
+};
 
 export default api;

--- a/packages/app/src/constants/cards.ts
+++ b/packages/app/src/constants/cards.ts
@@ -1,82 +1,114 @@
 // STORE CONSTANTS
 type SeriesType = {
-	title: string,
-	title_formatted: string,
-	cards: number[],
-}
+  title: string;
+  title_formatted: string;
+  cards: number[];
+};
 
 // ETH SERIES
 const ORIGIN_SERIES: SeriesType = {
-	title: 'Origin Series',
-	title_formatted: 'ORIGIN_SERIES',
-	cards: [1, 2, 3, 4, 5, 6, 7, 8],
-}
+  title: "Origin Series",
+  title_formatted: "ORIGIN_SERIES",
+  cards: [1, 2, 3, 4, 5, 6, 7, 8],
+};
 
 const CHARACTER_SERIES_CARDS: SeriesType = {
-	title: 'Character Series',
-	title_formatted: 'CHARACTER_SERIES_CARDS',
-	cards: [9, 10, 11, 12],
-}
+  title: "Character Series",
+  title_formatted: "CHARACTER_SERIES_CARDS",
+  cards: [9, 10, 11, 12],
+};
 
 const FRIENDS_SERIES_CARDS: SeriesType = {
-	title: 'Buddy Series',
-	title_formatted: 'FRIENDS_SERIES_CARDS',
-	cards: [13, 14, 15, 16],
-}
+  title: "Buddy Series",
+  title_formatted: "FRIENDS_SERIES_CARDS",
+  cards: [13, 14, 15, 16],
+};
 
 const EVENT_ITEM_CARDS: SeriesType = {
-	title: 'Event Items',
-	title_formatted: 'EVENT_ITEM_CARDS',
-	cards: process.env.NODE_ENV === 'test' ? [17] : [17, 18, 19],
-}
+  title: "Event Items",
+  title_formatted: "EVENT_ITEM_CARDS",
+  cards: process.env.NODE_ENV === "test" ? [17] : [17, 18, 19],
+};
 
 const NEW_BEGINNING_CARDS: SeriesType = {
-	title: 'New Beginning Series',
-	title_formatted: 'NEW_BEGINNING_CARDS',
-	cards: [25, 26, 27, 28, 29, 30, 47, 62, 63, 64],
-}
+  title: "New Beginning Series",
+  title_formatted: "NEW_BEGINNING_CARDS",
+  cards: [25, 26, 27, 28, 29, 30, 47, 62, 63, 64],
+};
 
 const DUNGEONS_AND_DRAGONS: SeriesType = {
-	title: 'Dungeons & Dragons Series',
-	title_formatted: 'DUNGEONS_AND_DRAGONS',
-	cards: [38, 39, 40, 41, 42, 43],
-}
+  title: "Dungeons & Dragons Series",
+  title_formatted: "DUNGEONS_AND_DRAGONS",
+  cards: [38, 39, 40, 41, 42, 43],
+};
 
 const NEW_BEGINNING_PIXEL_CARDS: SeriesType = {
-	title: 'New Beginning Pixel Series',
-	title_formatted: 'NEW_BEGINNING_PIXEL_CARDS',
-	cards: [54, 53, 52, 51, 58, 68],
-}
+  title: "New Beginning Pixel Series",
+  title_formatted: "NEW_BEGINNING_PIXEL_CARDS",
+  cards: [54, 53, 52, 51, 58, 68],
+};
 
 // MATIC SERIES
 const MATIC_SERIES: SeriesType = {
-	title: 'Matic Test Series',
-	title_formatted: 'MATIC_SERIES',
-	cards: [1, 2],
-}
+  title: "Matic Test Series",
+  title_formatted: "MATIC_SERIES",
+  cards: [1, 2],
+};
 
 // BSC SERIES
 const CARTOONIZED_SERIES: SeriesType = {
-	title: 'Cartoonized Series',
-	title_formatted: 'CARTOONIZED_SERIES',
-	cards: [3, 4, 5, 6, 7, 8, 10, 11, 12],
-}
+  title: "Cartoonized Series",
+  title_formatted: "CARTOONIZED_SERIES",
+  cards: [3, 4, 5, 6, 7, 8, 10, 11, 12],
+};
 
 // PepemonOneAnniversarySet
 export const PPMNONE_ANNIVERSARY_SET = {
-	cards: [75, 76, 77, 78],
-}
+  cards: [75, 76, 77, 78],
+};
 
 // All cards ID's
-export const ALL_CARDS = [...ORIGIN_SERIES.cards, ...CHARACTER_SERIES_CARDS.cards, ...FRIENDS_SERIES_CARDS.cards, ...NEW_BEGINNING_CARDS.cards, ...DUNGEONS_AND_DRAGONS.cards, ...NEW_BEGINNING_PIXEL_CARDS.cards, ...PPMNONE_ANNIVERSARY_SET.cards];
-
+export const ALL_CARDS = [
+  ...ORIGIN_SERIES.cards,
+  ...CHARACTER_SERIES_CARDS.cards,
+  ...FRIENDS_SERIES_CARDS.cards,
+  ...NEW_BEGINNING_CARDS.cards,
+  ...DUNGEONS_AND_DRAGONS.cards,
+  ...NEW_BEGINNING_PIXEL_CARDS.cards,
+  ...PPMNONE_ANNIVERSARY_SET.cards,
+];
 
 // series per chainId
 const ALL_SERIES = new Map([
-	[1, process.env.NODE_ENV === 'test' ? [EVENT_ITEM_CARDS] : [EVENT_ITEM_CARDS, NEW_BEGINNING_PIXEL_CARDS, NEW_BEGINNING_CARDS, DUNGEONS_AND_DRAGONS, FRIENDS_SERIES_CARDS, CHARACTER_SERIES_CARDS, ORIGIN_SERIES]],
-	[4, process.env.NODE_ENV === 'test' ? [EVENT_ITEM_CARDS, NEW_BEGINNING_CARDS, DUNGEONS_AND_DRAGONS] : [EVENT_ITEM_CARDS, NEW_BEGINNING_CARDS, DUNGEONS_AND_DRAGONS, FRIENDS_SERIES_CARDS, CHARACTER_SERIES_CARDS, ORIGIN_SERIES]],
-	[56, [CARTOONIZED_SERIES]],
-	[137, [MATIC_SERIES]],
+  [
+    1,
+    process.env.NODE_ENV === "test"
+      ? [EVENT_ITEM_CARDS]
+      : [
+          EVENT_ITEM_CARDS,
+          NEW_BEGINNING_PIXEL_CARDS,
+          NEW_BEGINNING_CARDS,
+          DUNGEONS_AND_DRAGONS,
+          FRIENDS_SERIES_CARDS,
+          CHARACTER_SERIES_CARDS,
+          ORIGIN_SERIES,
+        ],
+  ],
+  [
+    4,
+    process.env.NODE_ENV === "test"
+      ? [EVENT_ITEM_CARDS, NEW_BEGINNING_CARDS, DUNGEONS_AND_DRAGONS]
+      : [
+          EVENT_ITEM_CARDS,
+          NEW_BEGINNING_CARDS,
+          DUNGEONS_AND_DRAGONS,
+          FRIENDS_SERIES_CARDS,
+          CHARACTER_SERIES_CARDS,
+          ORIGIN_SERIES,
+        ],
+  ],
+  [56, [CARTOONIZED_SERIES]],
+  [137, [MATIC_SERIES]],
 ]);
 
 export default ALL_SERIES;

--- a/packages/app/src/constants/index.ts
+++ b/packages/app/src/constants/index.ts
@@ -1,5 +1,5 @@
-export { default as api } from './api';
-export { default as cards } from './cards';
-export { default as chains } from './chains';
-export { getOpenSeaUri } from './openSeaUri';
-export { default as packs } from './packs';
+export { default as api } from "./api";
+export { default as cards } from "./cards";
+export { default as chains } from "./chains";
+export { getOpenSeaUri } from "./openSeaUri";
+export { default as packs } from "./packs";

--- a/packages/app/src/constants/openSeaUri.ts
+++ b/packages/app/src/constants/openSeaUri.ts
@@ -1,13 +1,18 @@
 type GetOpenSeaUriProps = {
-	chainId: number,
-	account?: string
+  chainId: number;
+  account?: string;
 };
 
-export const getOpenSeaUri = (fn: GetOpenSeaUriProps) : string => {
-	const { chainId, account } = fn;
-	const openSeaUri = (chainId === 1) ? `https://opensea.io/accounts/${account}` :
-		chainId === 4 ? `https://rinkeby.opensea.io/accounts/${account}` :
-			chainId === 56 ? `https://treasureland.market/#/nft-market/pepemon` : `https://matic.opensea.io/accounts/${account}`;
+export const getOpenSeaUri = (fn: GetOpenSeaUriProps): string => {
+  const { chainId, account } = fn;
+  const openSeaUri =
+    chainId === 1
+      ? `https://opensea.io/accounts/${account}`
+      : chainId === 4
+      ? `https://rinkeby.opensea.io/accounts/${account}`
+      : chainId === 56
+      ? `https://treasureland.market/#/nft-market/pepemon`
+      : `https://matic.opensea.io/accounts/${account}`;
 
-	return openSeaUri;
-}
+  return openSeaUri;
+};

--- a/packages/app/src/constants/packs.ts
+++ b/packages/app/src/constants/packs.ts
@@ -1,43 +1,116 @@
-import { Boosterpack_3_cards_Battle_Monsters, Boosterpack_3_cards_Battle_Support, Boosterpack_3_cards_Gen_1, Boosterpack_6_cards_Battle_Monsters, Boosterpack_6_cards_Battle_Support, Boosterpack_6_cards_Gen_1, Boosterpack_9_cards_Battle_Monsters, Boosterpack_9_cards_Battle_Support, Boosterpack_9_cards_Gen_1 } from '../assets';
-import { BATTLE_MONSTERS_3_CARD_BASE_SEPOLIA } from './boosterpacks';
+import {
+  Boosterpack_3_cards_Battle_Monsters,
+  Boosterpack_3_cards_Battle_Support,
+  Boosterpack_3_cards_Gen_1,
+  Boosterpack_6_cards_Battle_Monsters,
+  Boosterpack_6_cards_Battle_Support,
+  Boosterpack_6_cards_Gen_1,
+  Boosterpack_9_cards_Battle_Monsters,
+  Boosterpack_9_cards_Battle_Support,
+  Boosterpack_9_cards_Gen_1,
+} from "../assets";
+import { BATTLE_MONSTERS_3_CARD_BASE_SEPOLIA } from "./boosterpacks";
 
 const BATTLE_MONSTERS_EDITION = {
-	title: 'Battle Monsters edition',
-	title_formatted: 'BATTLE_MONSTERS_EDITION',
-	packs: [
-		{ name: "Battle Monsters edition - 3 cards", cardsPerPack: 3, url: Boosterpack_3_cards_Battle_Monsters, minted: "10/20", time: "20 hours", price: "75", onchainConfig: BATTLE_MONSTERS_3_CARD_BASE_SEPOLIA },
-		{ name: "Battle Monsters edition - 6 cards", cardsPerPack: 6, url: Boosterpack_6_cards_Battle_Monsters, minted: "10/20", time: "20 hours", price: "175" },
-		{ name: "Battle Monsters edition - 9 cards", cardsPerPack: 9, url: Boosterpack_9_cards_Battle_Monsters, minted: "10/20", time: "20 hours", price: "1000" },
-	]
-}
+  title: "Battle Monsters edition",
+  title_formatted: "BATTLE_MONSTERS_EDITION",
+  packs: [
+    {
+      name: "Battle Monsters edition - 3 cards",
+      cardsPerPack: 3,
+      url: Boosterpack_3_cards_Battle_Monsters,
+      minted: "10/20",
+      time: "20 hours",
+      price: "75",
+      onchainConfig: BATTLE_MONSTERS_3_CARD_BASE_SEPOLIA,
+    },
+    {
+      name: "Battle Monsters edition - 6 cards",
+      cardsPerPack: 6,
+      url: Boosterpack_6_cards_Battle_Monsters,
+      minted: "10/20",
+      time: "20 hours",
+      price: "175",
+    },
+    {
+      name: "Battle Monsters edition - 9 cards",
+      cardsPerPack: 9,
+      url: Boosterpack_9_cards_Battle_Monsters,
+      minted: "10/20",
+      time: "20 hours",
+      price: "1000",
+    },
+  ],
+};
 
 const GEN_1_EDITION = {
-	title: 'Gen 1 edition',
-	title_formatted: 'GEN_1_EDITION',
-	packs: [
-		{ name: "Gen 1 edition - 3 cards", cardsPerPack: 3, url: Boosterpack_3_cards_Gen_1, minted: "10/20", time: "20 hours", price: "75" },
-		{ name: "Gen 1 edition - 6 cards", cardsPerPack: 6, url: Boosterpack_6_cards_Gen_1, minted: "10/20", time: "20 hours", price: "175" },
-		{ name: "Gen 1 edition - 9 cards", cardsPerPack: 9, url: Boosterpack_9_cards_Gen_1, minted: "10/20", time: "20 hours", price: "1000" },
-	]
-}
+  title: "Gen 1 edition",
+  title_formatted: "GEN_1_EDITION",
+  packs: [
+    {
+      name: "Gen 1 edition - 3 cards",
+      cardsPerPack: 3,
+      url: Boosterpack_3_cards_Gen_1,
+      minted: "10/20",
+      time: "20 hours",
+      price: "75",
+    },
+    {
+      name: "Gen 1 edition - 6 cards",
+      cardsPerPack: 6,
+      url: Boosterpack_6_cards_Gen_1,
+      minted: "10/20",
+      time: "20 hours",
+      price: "175",
+    },
+    {
+      name: "Gen 1 edition - 9 cards",
+      cardsPerPack: 9,
+      url: Boosterpack_9_cards_Gen_1,
+      minted: "10/20",
+      time: "20 hours",
+      price: "1000",
+    },
+  ],
+};
 const BATTLE_SUPPORT_EDITION = {
-	title: 'Battle Support edition',
-	title_formatted: 'BATTLE_SUPPORT_EDITION',
-	packs: [
-		{ name: "Battle Support edition - 3 cards", cardsPerPack: 3, url: Boosterpack_3_cards_Battle_Support, minted: "10/20", time: "20 hours", price: "75" },
-		{ name: "Battle Support edition - 6 cards", cardsPerPack: 6, url: Boosterpack_6_cards_Battle_Support, minted: "10/20", time: "20 hours", price: "175" },
-		{ name: "Battle Support edition - 9 cards", cardsPerPack: 9, url: Boosterpack_9_cards_Battle_Support, minted: "10/20", time: "20 hours", price: "1000" },
-	]
-}
-
+  title: "Battle Support edition",
+  title_formatted: "BATTLE_SUPPORT_EDITION",
+  packs: [
+    {
+      name: "Battle Support edition - 3 cards",
+      cardsPerPack: 3,
+      url: Boosterpack_3_cards_Battle_Support,
+      minted: "10/20",
+      time: "20 hours",
+      price: "75",
+    },
+    {
+      name: "Battle Support edition - 6 cards",
+      cardsPerPack: 6,
+      url: Boosterpack_6_cards_Battle_Support,
+      minted: "10/20",
+      time: "20 hours",
+      price: "175",
+    },
+    {
+      name: "Battle Support edition - 9 cards",
+      cardsPerPack: 9,
+      url: Boosterpack_9_cards_Battle_Support,
+      minted: "10/20",
+      time: "20 hours",
+      price: "1000",
+    },
+  ],
+};
 
 // series per chainId
 const ALL_BOOSTERPACKS = new Map([
-	[1, [BATTLE_MONSTERS_EDITION, GEN_1_EDITION, BATTLE_SUPPORT_EDITION]],
-	[4, [BATTLE_MONSTERS_EDITION, GEN_1_EDITION, BATTLE_SUPPORT_EDITION]],
-	[56, [BATTLE_MONSTERS_EDITION, GEN_1_EDITION, BATTLE_SUPPORT_EDITION]],
-	[137, [BATTLE_MONSTERS_EDITION, GEN_1_EDITION, BATTLE_SUPPORT_EDITION]],
-	[84532, [BATTLE_MONSTERS_EDITION]],
+  [1, [BATTLE_MONSTERS_EDITION, GEN_1_EDITION, BATTLE_SUPPORT_EDITION]],
+  [4, [BATTLE_MONSTERS_EDITION, GEN_1_EDITION, BATTLE_SUPPORT_EDITION]],
+  [56, [BATTLE_MONSTERS_EDITION, GEN_1_EDITION, BATTLE_SUPPORT_EDITION]],
+  [137, [BATTLE_MONSTERS_EDITION, GEN_1_EDITION, BATTLE_SUPPORT_EDITION]],
+  [84532, [BATTLE_MONSTERS_EDITION]],
 ]);
 
 export default ALL_BOOSTERPACKS;

--- a/packages/app/src/contexts/ModalsProvider/ModalsProvider.tsx
+++ b/packages/app/src/contexts/ModalsProvider/ModalsProvider.tsx
@@ -1,79 +1,90 @@
-import React, { createContext, useCallback, useState, useRef } from 'react';
-import styled, { keyframes } from 'styled-components';
-import { useOutsideClick } from '../../hooks';
-import { theme } from '../../theme';
-import { ActionClose } from '../../assets';
-import { ModalActions,
-	//ModalActionsProps
-} from '../../components';
+import React, { createContext, useCallback, useState, useRef } from "react";
+import styled, { keyframes } from "styled-components";
+import { useOutsideClick } from "../../hooks";
+import { theme } from "../../theme";
+import { ActionClose } from "../../assets";
+import {
+  ModalActions,
+  //ModalActionsProps
+} from "../../components";
 
 interface ModalProps {
-	maxWidth?: number;
+  maxWidth?: number;
 }
 
 export interface ModalData extends ModalProps {
-	title?: React.ReactNode|string,
-	content?: React.ReactNode,
-	modalActions?: any
+  title?: React.ReactNode | string;
+  content?: React.ReactNode;
+  modalActions?: any;
 }
 
 interface ModalsContext {
-	data?: ModalData,
-	isOpen?: boolean,
-	onPresent: (content: React.ReactNode, key?: string) => void,
-	onDismiss: () => void
+  data?: ModalData;
+  isOpen?: boolean;
+  onPresent: (content: React.ReactNode, key?: string) => void;
+  onDismiss: () => void;
 }
 
 export const Context = createContext<ModalsContext>({
-	data: {},
-	onPresent: () => {},
-	onDismiss: () => {},
-})
+  data: {},
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  onPresent: () => {},
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  onDismiss: () => {},
+});
 
 const ModalsProvider: React.FC = ({ children }) => {
-	const [isOpen, setIsOpen] = useState(false);
-	const [data, setData] = useState<ModalData>();
-	const [, setModalKey] = useState<string>();
+  const [isOpen, setIsOpen] = useState(false);
+  const [data, setData] = useState<ModalData>();
+  const [, setModalKey] = useState<string>();
 
-	const handlePresent = useCallback((modalData: any, key?: string) => {
-		setModalKey(key)
-		setData(modalData)
-		setIsOpen(true)
-	}, [setData, setIsOpen, setModalKey])
+  const handlePresent = useCallback(
+    (modalData: any, key?: string) => {
+      setModalKey(key);
+      setData(modalData);
+      setIsOpen(true);
+    },
+    [setData, setIsOpen, setModalKey]
+  );
 
-	const handleDismiss = useCallback(() => {
-		setData(undefined)
-		setIsOpen(false)
-	}, [setData, setIsOpen])
+  const handleDismiss = useCallback(() => {
+    setData(undefined);
+    setIsOpen(false);
+  }, [setData, setIsOpen]);
 
-	const modalRef = useRef(null);
-	useOutsideClick(modalRef, () => isOpen && handleDismiss());
+  const modalRef = useRef(null);
+  useOutsideClick(modalRef, () => isOpen && handleDismiss());
 
-	return (
-		<Context.Provider value={{
-			data,
-			isOpen,
-			onPresent: handlePresent,
-			onDismiss: handleDismiss,
-		}}>
-			{children}
-			{(data && isOpen) && (
-				<ResponsiveWrapper>
-					<Modal ref={modalRef} maxWidth={data.maxWidth}>
-						<ActionClose onClick={handleDismiss} />
-						{ data.title && <ModalTitle>{data.title}</ModalTitle> }
-						<ModalContent>
-							{React.isValidElement(data.content) && React.cloneElement(data.content, {
-								onDismiss: handleDismiss,
-							})}
-						</ModalContent>
-						{ data.modalActions && <ModalActions modalActions={data.modalActions}/> }
-					</Modal>
-				</ResponsiveWrapper>
-			)}
-		</Context.Provider>
-	)
-}
+  return (
+    <Context.Provider
+      value={{
+        data,
+        isOpen,
+        onPresent: handlePresent,
+        onDismiss: handleDismiss,
+      }}
+    >
+      {children}
+      {data && isOpen && (
+        <ResponsiveWrapper>
+          <Modal ref={modalRef} maxWidth={data.maxWidth}>
+            <ActionClose onClick={handleDismiss} />
+            {data.title && <ModalTitle>{data.title}</ModalTitle>}
+            <ModalContent>
+              {React.isValidElement(data.content) &&
+                React.cloneElement(data.content, {
+                  onDismiss: handleDismiss,
+                })}
+            </ModalContent>
+            {data.modalActions && (
+              <ModalActions modalActions={data.modalActions} />
+            )}
+          </Modal>
+        </ResponsiveWrapper>
+      )}
+    </Context.Provider>
+  );
+};
 
 const mobileKeyframes = keyframes`
 	0% {
@@ -85,50 +96,50 @@ const mobileKeyframes = keyframes`
 `;
 
 const ResponsiveWrapper = styled.div`
-	align-items: center;
-	animation: ${mobileKeyframes} 0.3s forwards ease-in;
-	background: rgba(0, 0, 0, 0.4);
-	display: flex;
-	flex-direction: column;
-	height: 100vh;
-	justify-content: center;
-	left: 0;
-	padding: 1em;
-	position: fixed;
-	top: 0;
-	width: 100vw;
-	z-index: 10;
+  align-items: center;
+  animation: ${mobileKeyframes} 0.3s forwards ease-in;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  justify-content: center;
+  left: 0;
+  padding: 1em;
+  position: fixed;
+  top: 0;
+  width: 100vw;
+  z-index: 10;
 
-	@media (max-width: ${(props) => props.theme.breakpoints.tablet}px) {
-		flex: 1;
-		position: absolute;
-		top: 100%;
-		right: 0;
-		left: 0;
-		animation: ${mobileKeyframes} 0.3s forwards ease-out;
-		max-width: 100vw;
-	}
+  @media (max-width: ${(props) => props.theme.breakpoints.tablet}px) {
+    flex: 1;
+    position: absolute;
+    top: 100%;
+    right: 0;
+    left: 0;
+    animation: ${mobileKeyframes} 0.3s forwards ease-out;
+    max-width: 100vw;
+  }
 
-	& svg:first-child {
-		position: absolute;
-		top: 1em;
-		right: 1em;
-		z-index: 10;
-	}
+  & svg:first-child {
+    position: absolute;
+    top: 1em;
+    right: 1em;
+    z-index: 10;
+  }
 `;
 
 const Modal = styled.div<ModalProps>`
-	padding: 1.5em;
-	background-color: ${props => props.theme.color.white};
-	border-radius: 32px;
-	box-shadow: 0 5px 10px 0px ${theme.color.colorsLayoutShadows};
-	display: flex;
-	flex-direction: column;
-	max-width: ${(props) => props.maxWidth ? props.maxWidth : 800}px;
-	align-items: center;
-	position: relative;
-	width: 100%;
-	min-height: 0;
+  padding: 1.5em;
+  background-color: ${(props) => props.theme.color.white};
+  border-radius: 32px;
+  box-shadow: 0 5px 10px 0px ${theme.color.colorsLayoutShadows};
+  display: flex;
+  flex-direction: column;
+  max-width: ${(props) => (props.maxWidth ? props.maxWidth : 800)}px;
+  align-items: center;
+  position: relative;
+  width: 100%;
+  min-height: 0;
 `;
 
 const ModalTitle = styled.div`
@@ -137,10 +148,10 @@ const ModalTitle = styled.div`
   font-size: 1.375rem;
   font-weight: 700;
   justify-content: center;
-`
+`;
 
 const ModalContent = styled.div`
-	padding: ${(props) => props.theme.spacing[2]}px;
-`
+  padding: ${(props) => props.theme.spacing[2]}px;
+`;
 
 export default ModalsProvider;

--- a/packages/app/src/contexts/ModalsProvider/index.ts
+++ b/packages/app/src/contexts/ModalsProvider/index.ts
@@ -1,2 +1,2 @@
-export { Context, default } from './ModalsProvider';
-export type { ModalData } from './ModalsProvider';
+export { Context, default } from "./ModalsProvider";
+export type { ModalData } from "./ModalsProvider";

--- a/packages/app/src/contexts/PepemonProvider/PepemonProvider.tsx
+++ b/packages/app/src/contexts/PepemonProvider/PepemonProvider.tsx
@@ -1,110 +1,94 @@
-import React, { createContext, useReducer } from 'react';
-import { contractAddresses } from '../../pepemon/lib/constants';
+import React, { createContext, useReducer } from "react";
+import { contractAddresses } from "../../pepemon/lib/constants";
 
 declare global {
   interface Window {
-    pepesauce: any
+    pepesauce: any;
   }
 }
 
-const initial: any = ({
-    account: null,
-    chainId: null,
-    contracts: new Map([]),
-    provider: null,
-    // web3: null,
-})
+const initial: any = {
+  account: null,
+  chainId: null,
+  contracts: new Map([]),
+  provider: null,
+  // web3: null,
+};
 export const Context = createContext<any>({
   pepemon: undefined,
-})
+});
 
 export const PepemonProvider: React.FC<any> = ({ children }) => {
-  const setContractAddresses = (networkId: any): any => ({
-    // @ts-ignore
-    ppblzAddress: contractAddresses.ppblz[networkId],
-    // @ts-ignore
-    ppdexAddress: contractAddresses.ppdex[networkId],
-    // @ts-ignore
-    wethAddress: contractAddresses.weth[networkId],
-    // @ts-ignore
-    uniV2Address: contractAddresses.uniV2_ppblz[networkId],
-    // @ts-ignore
-    pepemonFactoryAddress: contractAddresses.pepemonFactory[networkId],
-    // @ts-ignore
-    pepemonStoreAddress: contractAddresses.pepemonStore[networkId],
-    // @ts-ignore
-    pepemonStakeAddress: contractAddresses.pepemonStake[networkId],
-    // @ts-ignore
-    merkleAddress: contractAddresses.merkle[networkId],
-    // @ts-ignore
-    merkleAddressPpblz: contractAddresses.merklePpblz[networkId],
-    // @ts-ignore
-    merkleAddressPpdex: contractAddresses.merklePpdex[networkId],
-    // @ts-ignore
-    merkleAddressUniV2: contractAddresses.merkleUniV2[networkId],
-	// @ts-ignore
-	merkleDistributor: contractAddresses.merkleDistributor[networkId],
-    // @ts-ignore
-    pepemonLottery: contractAddresses.pepemonLottery[networkId],
-    // @ts-ignore
-    uniV2PpdexAddress: contractAddresses.uniV2_ppdex[networkId],
-    // @ts-ignore
-    pepemonPromoStoreAddress: contractAddresses.pepemonPromoStore[networkId],
-    // @ts-ignore
-    pepemonPromoTokenAddress: contractAddresses.pepemonPromoToken[networkId],
-  } as any)
+  const setContractAddresses = (networkId: any): any =>
+    ({
+      ppblzAddress: contractAddresses.ppblz[networkId],
+      ppdexAddress: contractAddresses.ppdex[networkId],
+      wethAddress: contractAddresses.weth[networkId],
+      uniV2Address: contractAddresses.uniV2_ppblz[networkId],
+      pepemonFactoryAddress: contractAddresses.pepemonFactory[networkId],
+      pepemonStoreAddress: contractAddresses.pepemonStore[networkId],
+      pepemonStakeAddress: contractAddresses.pepemonStake[networkId],
+      merkleAddress: contractAddresses.merkle[networkId],
+      merkleAddressPpblz: contractAddresses.merklePpblz[networkId],
+      merkleAddressPpdex: contractAddresses.merklePpdex[networkId],
+      merkleAddressUniV2: contractAddresses.merkleUniV2[networkId],
+      merkleDistributor: contractAddresses.merkleDistributor[networkId],
+      pepemonLottery: contractAddresses.pepemonLottery[networkId],
+      uniV2PpdexAddress: contractAddresses.uniV2_ppdex[networkId],
+      pepemonPromoStoreAddress: contractAddresses.pepemonPromoStore[networkId],
+      pepemonPromoTokenAddress: contractAddresses.pepemonPromoToken[networkId],
+    } as any);
 
   const pepemonReducer = (state: any, action: any) => {
     switch (action.type) {
-      case 'all':
+      case "all":
         const allState = {
-            account: action.account,
-            chainId: action.chainId,
-            contracts: action.contracts,
-            provider: action.provider,
-            // web3: new Web3(action.provider),
-            ...setContractAddresses(action.chainId),
-        }
-        // @ts-ignore
-        window.pepemon = allState
-        return {...allState};
-      case 'chainChanged':
+          account: action.account,
+          chainId: action.chainId,
+          contracts: action.contracts,
+          provider: action.provider,
+          // web3: new Web3(action.provider),
+          ...setContractAddresses(action.chainId),
+        };
+        // @ts-expect-error -- web3/ethers type mismatch
+        window.pepemon = allState;
+        return { ...allState };
+      case "chainChanged":
         const chainChangedState = {
-            ...state,
-            chainId: action.chainId,
-            contracts: action.contracts,
-            provider: action.provider,
-            // web3: new Web3(action.provider),
-            ...setContractAddresses(action.chainId),
-        }
-        // @ts-ignore
+          ...state,
+          chainId: action.chainId,
+          contracts: action.contracts,
+          provider: action.provider,
+          // web3: new Web3(action.provider),
+          ...setContractAddresses(action.chainId),
+        };
+        // @ts-expect-error -- web3/ethers type mismatch
         window.pepemon = chainChangedState;
-        return {...chainChangedState};
-      case 'accountChanged':
+        return { ...chainChangedState };
+      case "accountChanged":
         const accountChangedState = {
-            ...state,
-            account: action.account,
-            contracts: action.contracts,
-            provider: action.provider,
-            // web3: new Web3(action.provider),
-            ...setContractAddresses(action.chainId),
-        }
-        // @ts-ignore
+          ...state,
+          account: action.account,
+          contracts: action.contracts,
+          provider: action.provider,
+          // web3: new Web3(action.provider),
+          ...setContractAddresses(action.chainId),
+        };
+        // @ts-expect-error -- web3/ethers type mismatch
         window.pepemon = chainChangedState;
-        return {...accountChangedState};
-      case 'reset': return {...initial}
+        return { ...accountChangedState };
+      case "reset":
+        return { ...initial };
       default:
-        return {...state};
+        return { ...state };
     }
-  }
+  };
 
-  const [state, dispatch] = useReducer(pepemonReducer, initial)
+  const [state, dispatch] = useReducer(pepemonReducer, initial);
 
   return (
-      <Context.Provider value={[state, dispatch]}>
-        {children}
-      </Context.Provider>
-  )
-}
+    <Context.Provider value={[state, dispatch]}>{children}</Context.Provider>
+  );
+};
 
 export default PepemonProvider;

--- a/packages/app/src/contexts/PepemonProvider/index.ts
+++ b/packages/app/src/contexts/PepemonProvider/index.ts
@@ -1,1 +1,1 @@
-export { Context, default } from './PepemonProvider'
+export { Context, default } from "./PepemonProvider";

--- a/packages/app/src/contexts/index.ts
+++ b/packages/app/src/contexts/index.ts
@@ -1,3 +1,9 @@
-export { default as ModalsProvider, Context as ModalsProviderContext } from './ModalsProvider';
-export type { ModalData } from './ModalsProvider';
-export { default as PepemonProvider, Context as PepemonProviderContext } from './PepemonProvider';
+export {
+  default as ModalsProvider,
+  Context as ModalsProviderContext,
+} from "./ModalsProvider";
+export type { ModalData } from "./ModalsProvider";
+export {
+  default as PepemonProvider,
+  Context as PepemonProviderContext,
+} from "./PepemonProvider";

--- a/packages/app/src/contracts/src/abis/factory.json
+++ b/packages/app/src/contracts/src/abis/factory.json
@@ -1,6 +1,8 @@
 [
   {
-    "inputs": [{ "internalType": "address", "name": "_feeToSetter", "type": "address" }],
+    "inputs": [
+      { "internalType": "address", "name": "_feeToSetter", "type": "address" }
+    ],
     "payable": false,
     "stateMutability": "nonpayable",
     "type": "constructor"
@@ -8,10 +10,30 @@
   {
     "anonymous": false,
     "inputs": [
-      { "indexed": true, "internalType": "address", "name": "token0", "type": "address" },
-      { "indexed": true, "internalType": "address", "name": "token1", "type": "address" },
-      { "indexed": false, "internalType": "address", "name": "pair", "type": "address" },
-      { "indexed": false, "internalType": "uint256", "name": "", "type": "uint256" }
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token0",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token1",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "pair",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
     ],
     "name": "PairCreated",
     "type": "event"
@@ -41,7 +63,9 @@
       { "internalType": "address", "name": "tokenB", "type": "address" }
     ],
     "name": "createPair",
-    "outputs": [{ "internalType": "address", "name": "pair", "type": "address" }],
+    "outputs": [
+      { "internalType": "address", "name": "pair", "type": "address" }
+    ],
     "payable": false,
     "stateMutability": "nonpayable",
     "type": "function"
@@ -78,7 +102,9 @@
   },
   {
     "constant": false,
-    "inputs": [{ "internalType": "address", "name": "_feeTo", "type": "address" }],
+    "inputs": [
+      { "internalType": "address", "name": "_feeTo", "type": "address" }
+    ],
     "name": "setFeeTo",
     "outputs": [],
     "payable": false,
@@ -87,7 +113,9 @@
   },
   {
     "constant": false,
-    "inputs": [{ "internalType": "address", "name": "_feeToSetter", "type": "address" }],
+    "inputs": [
+      { "internalType": "address", "name": "_feeToSetter", "type": "address" }
+    ],
     "name": "setFeeToSetter",
     "outputs": [],
     "payable": false,

--- a/packages/app/src/contracts/src/abis/pair.json
+++ b/packages/app/src/contracts/src/abis/pair.json
@@ -1,11 +1,31 @@
 [
-  { "inputs": [], "payable": false, "stateMutability": "nonpayable", "type": "constructor" },
+  {
+    "inputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
   {
     "anonymous": false,
     "inputs": [
-      { "indexed": true, "internalType": "address", "name": "owner", "type": "address" },
-      { "indexed": true, "internalType": "address", "name": "spender", "type": "address" },
-      { "indexed": false, "internalType": "uint256", "name": "value", "type": "uint256" }
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
     ],
     "name": "Approval",
     "type": "event"
@@ -13,10 +33,30 @@
   {
     "anonymous": false,
     "inputs": [
-      { "indexed": true, "internalType": "address", "name": "sender", "type": "address" },
-      { "indexed": false, "internalType": "uint256", "name": "amount0", "type": "uint256" },
-      { "indexed": false, "internalType": "uint256", "name": "amount1", "type": "uint256" },
-      { "indexed": true, "internalType": "address", "name": "to", "type": "address" }
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
     ],
     "name": "Burn",
     "type": "event"
@@ -24,9 +64,24 @@
   {
     "anonymous": false,
     "inputs": [
-      { "indexed": true, "internalType": "address", "name": "sender", "type": "address" },
-      { "indexed": false, "internalType": "uint256", "name": "amount0", "type": "uint256" },
-      { "indexed": false, "internalType": "uint256", "name": "amount1", "type": "uint256" }
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      }
     ],
     "name": "Mint",
     "type": "event"
@@ -34,12 +89,42 @@
   {
     "anonymous": false,
     "inputs": [
-      { "indexed": true, "internalType": "address", "name": "sender", "type": "address" },
-      { "indexed": false, "internalType": "uint256", "name": "amount0In", "type": "uint256" },
-      { "indexed": false, "internalType": "uint256", "name": "amount1In", "type": "uint256" },
-      { "indexed": false, "internalType": "uint256", "name": "amount0Out", "type": "uint256" },
-      { "indexed": false, "internalType": "uint256", "name": "amount1Out", "type": "uint256" },
-      { "indexed": true, "internalType": "address", "name": "to", "type": "address" }
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0In",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1In",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0Out",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1Out",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
     ],
     "name": "Swap",
     "type": "event"
@@ -47,8 +132,18 @@
   {
     "anonymous": false,
     "inputs": [
-      { "indexed": false, "internalType": "uint112", "name": "reserve0", "type": "uint112" },
-      { "indexed": false, "internalType": "uint112", "name": "reserve1", "type": "uint112" }
+      {
+        "indexed": false,
+        "internalType": "uint112",
+        "name": "reserve0",
+        "type": "uint112"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint112",
+        "name": "reserve1",
+        "type": "uint112"
+      }
     ],
     "name": "Sync",
     "type": "event"
@@ -56,9 +151,24 @@
   {
     "anonymous": false,
     "inputs": [
-      { "indexed": true, "internalType": "address", "name": "from", "type": "address" },
-      { "indexed": true, "internalType": "address", "name": "to", "type": "address" },
-      { "indexed": false, "internalType": "uint256", "name": "value", "type": "uint256" }
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
     ],
     "name": "Transfer",
     "type": "event"
@@ -160,7 +270,11 @@
     "outputs": [
       { "internalType": "uint112", "name": "_reserve0", "type": "uint112" },
       { "internalType": "uint112", "name": "_reserve1", "type": "uint112" },
-      { "internalType": "uint32", "name": "_blockTimestampLast", "type": "uint32" }
+      {
+        "internalType": "uint32",
+        "name": "_blockTimestampLast",
+        "type": "uint32"
+      }
     ],
     "payable": false,
     "stateMutability": "view",
@@ -191,7 +305,9 @@
     "constant": false,
     "inputs": [{ "internalType": "address", "name": "to", "type": "address" }],
     "name": "mint",
-    "outputs": [{ "internalType": "uint256", "name": "liquidity", "type": "uint256" }],
+    "outputs": [
+      { "internalType": "uint256", "name": "liquidity", "type": "uint256" }
+    ],
     "payable": false,
     "stateMutability": "nonpayable",
     "type": "function"

--- a/packages/app/src/contracts/src/abis/pepemon_factory.json
+++ b/packages/app/src/contracts/src/abis/pepemon_factory.json
@@ -1,893 +1,893 @@
 [
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_proxyRegistryAddress",
-                "type": "address"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "constructor"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "_owner",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "_operator",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "bool",
-                "name": "_approved",
-                "type": "bool"
-            }
-        ],
-        "name": "ApprovalForAll",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
-        ],
-        "name": "MinterAdded",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
-        ],
-        "name": "MinterRemoved",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "previousOwner",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "newOwner",
-                "type": "address"
-            }
-        ],
-        "name": "OwnershipTransferred",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "_operator",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "_from",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "_to",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256[]",
-                "name": "_ids",
-                "type": "uint256[]"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256[]",
-                "name": "_amounts",
-                "type": "uint256[]"
-            }
-        ],
-        "name": "TransferBatch",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "_operator",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "_from",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "_to",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "_id",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "_amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "TransferSingle",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": false,
-                "internalType": "string",
-                "name": "_uri",
-                "type": "string"
-            },
-            {
-                "indexed": true,
-                "internalType": "uint256",
-                "name": "_id",
-                "type": "uint256"
-            }
-        ],
-        "name": "URI",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
-        ],
-        "name": "WhitelistAdminAdded",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
-        ],
-        "name": "WhitelistAdminRemoved",
-        "type": "event"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
-        ],
-        "name": "addMinter",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
-        ],
-        "name": "addWhitelistAdmin",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_owner",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_id",
-                "type": "uint256"
-            }
-        ],
-        "name": "balanceOf",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [
-            {
-                "internalType": "address[]",
-                "name": "_owners",
-                "type": "address[]"
-            },
-            {
-                "internalType": "uint256[]",
-                "name": "_ids",
-                "type": "uint256[]"
-            }
-        ],
-        "name": "balanceOfBatch",
-        "outputs": [
-            {
-                "internalType": "uint256[]",
-                "name": "",
-                "type": "uint256[]"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_maxSupply",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_initialSupply",
-                "type": "uint256"
-            },
-            {
-                "internalType": "string",
-                "name": "_uri",
-                "type": "string"
-            },
-            {
-                "internalType": "bytes",
-                "name": "_data",
-                "type": "bytes"
-            }
-        ],
-        "name": "create",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "tokenId",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "name": "creators",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_owner",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "_operator",
-                "type": "address"
-            }
-        ],
-        "name": "isApprovedForAll",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "isOperator",
-                "type": "bool"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
-        ],
-        "name": "isMinter",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "isOwner",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
-        ],
-        "name": "isWhitelistAdmin",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_id",
-                "type": "uint256"
-            }
-        ],
-        "name": "maxSupply",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_to",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_id",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_quantity",
-                "type": "uint256"
-            },
-            {
-                "internalType": "bytes",
-                "name": "_data",
-                "type": "bytes"
-            }
-        ],
-        "name": "mint",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "name",
-        "outputs": [
-            {
-                "internalType": "string",
-                "name": "",
-                "type": "string"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "owner",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
-        ],
-        "name": "removeMinter",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
-        ],
-        "name": "removeWhitelistAdmin",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [],
-        "name": "renounceMinter",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [],
-        "name": "renounceOwnership",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [],
-        "name": "renounceWhitelistAdmin",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_from",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "_to",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256[]",
-                "name": "_ids",
-                "type": "uint256[]"
-            },
-            {
-                "internalType": "uint256[]",
-                "name": "_amounts",
-                "type": "uint256[]"
-            },
-            {
-                "internalType": "bytes",
-                "name": "_data",
-                "type": "bytes"
-            }
-        ],
-        "name": "safeBatchTransferFrom",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_from",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "_to",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_id",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_amount",
-                "type": "uint256"
-            },
-            {
-                "internalType": "bytes",
-                "name": "_data",
-                "type": "bytes"
-            }
-        ],
-        "name": "safeTransferFrom",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_operator",
-                "type": "address"
-            },
-            {
-                "internalType": "bool",
-                "name": "_approved",
-                "type": "bool"
-            }
-        ],
-        "name": "setApprovalForAll",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [
-            {
-                "internalType": "bytes4",
-                "name": "_interfaceID",
-                "type": "bytes4"
-            }
-        ],
-        "name": "supportsInterface",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "symbol",
-        "outputs": [
-            {
-                "internalType": "string",
-                "name": "",
-                "type": "string"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "name": "tokenMaxSupply",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "name": "tokenSupply",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_id",
-                "type": "uint256"
-            }
-        ],
-        "name": "totalSupply",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "newOwner",
-                "type": "address"
-            }
-        ],
-        "name": "transferOwnership",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_id",
-                "type": "uint256"
-            }
-        ],
-        "name": "uri",
-        "outputs": [
-            {
-                "internalType": "string",
-                "name": "",
-                "type": "string"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "string",
-                "name": "newURI",
-                "type": "string"
-            }
-        ],
-        "name": "setBaseMetadataURI",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "string",
-                "name": "newURI",
-                "type": "string"
-            }
-        ],
-        "name": "setContractURI",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "contractURI",
-        "outputs": [
-            {
-                "internalType": "string",
-                "name": "",
-                "type": "string"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_id",
-                "type": "uint256"
-            }
-        ],
-        "name": "endMinting",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_account",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_id",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "burn",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_id",
-                "type": "uint256"
-            },
-            {
-                "internalType": "address[]",
-                "name": "_addresses",
-                "type": "address[]"
-            }
-        ],
-        "name": "airdrop",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    }
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_proxyRegistryAddress",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_operator",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "_approved",
+        "type": "bool"
+      }
+    ],
+    "name": "ApprovalForAll",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "MinterAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "MinterRemoved",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_operator",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "_ids",
+        "type": "uint256[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "_amounts",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "TransferBatch",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_operator",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_id",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "TransferSingle",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "_uri",
+        "type": "string"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "_id",
+        "type": "uint256"
+      }
+    ],
+    "name": "URI",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "WhitelistAdminAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "WhitelistAdminRemoved",
+    "type": "event"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "addMinter",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "addWhitelistAdmin",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_owner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_id",
+        "type": "uint256"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "_owners",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "_ids",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "balanceOfBatch",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_maxSupply",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_initialSupply",
+        "type": "uint256"
+      },
+      {
+        "internalType": "string",
+        "name": "_uri",
+        "type": "string"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_data",
+        "type": "bytes"
+      }
+    ],
+    "name": "create",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "creators",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_operator",
+        "type": "address"
+      }
+    ],
+    "name": "isApprovedForAll",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "isOperator",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "isMinter",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "isOwner",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "isWhitelistAdmin",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_id",
+        "type": "uint256"
+      }
+    ],
+    "name": "maxSupply",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_id",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_quantity",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_data",
+        "type": "bytes"
+      }
+    ],
+    "name": "mint",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "removeMinter",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "removeWhitelistAdmin",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "renounceMinter",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "renounceWhitelistAdmin",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "_ids",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "_amounts",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_data",
+        "type": "bytes"
+      }
+    ],
+    "name": "safeBatchTransferFrom",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_id",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_data",
+        "type": "bytes"
+      }
+    ],
+    "name": "safeTransferFrom",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_operator",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_approved",
+        "type": "bool"
+      }
+    ],
+    "name": "setApprovalForAll",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "bytes4",
+        "name": "_interfaceID",
+        "type": "bytes4"
+      }
+    ],
+    "name": "supportsInterface",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "tokenMaxSupply",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "tokenSupply",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_id",
+        "type": "uint256"
+      }
+    ],
+    "name": "totalSupply",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_id",
+        "type": "uint256"
+      }
+    ],
+    "name": "uri",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "newURI",
+        "type": "string"
+      }
+    ],
+    "name": "setBaseMetadataURI",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "newURI",
+        "type": "string"
+      }
+    ],
+    "name": "setContractURI",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "contractURI",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_id",
+        "type": "uint256"
+      }
+    ],
+    "name": "endMinting",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_id",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "burn",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_id",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address[]",
+        "name": "_addresses",
+        "type": "address[]"
+      }
+    ],
+    "name": "airdrop",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
 ]

--- a/packages/app/src/contracts/src/abis/pepemon_lottery.json
+++ b/packages/app/src/contracts/src/abis/pepemon_lottery.json
@@ -1,528 +1,528 @@
 [
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_UniV2Address",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "_PPDEX",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "_pepemonFactory",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_blockTime",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "nonpayable",
-        "type": "constructor"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "previousOwner",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "newOwner",
-                "type": "address"
-            }
-        ],
-        "name": "OwnershipTransferred",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "user",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "id",
-                "type": "uint256"
-            }
-        ],
-        "name": "Redeemed",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "user",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "Staked",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "user",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "Unstaked",
-        "type": "event"
-    },
-    {
-        "inputs": [],
-        "name": "PPDEX",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function",
-        "constant": true
-    },
-    {
-        "inputs": [],
-        "name": "UniV2Address",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function",
-        "constant": true
-    },
-    {
-        "inputs": [],
-        "name": "blockTime",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function",
-        "constant": true
-    },
-    {
-        "inputs": [],
-        "name": "goldenID",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function",
-        "constant": true
-    },
-    {
-        "inputs": [],
-        "name": "minPPDEX",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function",
-        "constant": true
-    },
-    {
-        "inputs": [],
-        "name": "minPPDEXGolden",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function",
-        "constant": true
-    },
-    {
-        "inputs": [],
-        "name": "normalID",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function",
-        "constant": true
-    },
-    {
-        "inputs": [],
-        "name": "owner",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function",
-        "constant": true
-    },
-    {
-        "inputs": [],
-        "name": "pepemonFactory",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function",
-        "constant": true
-    },
-    {
-        "inputs": [],
-        "name": "renounceOwnership",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "stakingDeadline",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function",
-        "constant": true
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "newOwner",
-                "type": "address"
-            }
-        ],
-        "name": "transferOwnership",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "addr",
-                "type": "address"
-            }
-        ],
-        "name": "setUniV2Address",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_PPDEX",
-                "type": "address"
-            }
-        ],
-        "name": "setPPDEX",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_pepemonFactory",
-                "type": "address"
-            }
-        ],
-        "name": "setPepemonFactory",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_minPPDEXGolden",
-                "type": "uint256"
-            }
-        ],
-        "name": "setminPPDEXGolden",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_minPPDEX",
-                "type": "uint256"
-            }
-        ],
-        "name": "setminPPDEX",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_normalID",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_goldenID",
-                "type": "uint256"
-            }
-        ],
-        "name": "updateNFT",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "MinLPTokens",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function",
-        "constant": true
-    },
-    {
-        "inputs": [],
-        "name": "MinLPTokensGolden",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function",
-        "constant": true
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "lp",
-                "type": "uint256"
-            }
-        ],
-        "name": "LPToPPDEX",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function",
-        "constant": true
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "addr",
-                "type": "address"
-            }
-        ],
-        "name": "getStakingStart",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function",
-        "constant": true
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "addr",
-                "type": "address"
-            }
-        ],
-        "name": "getLPBalance",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function",
-        "constant": true
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "addr",
-                "type": "address"
-            }
-        ],
-        "name": "isUserStaking",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function",
-        "constant": true
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "addr",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "id",
-                "type": "uint256"
-            }
-        ],
-        "name": "hasUserMinted",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function",
-        "constant": true
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "addr",
-                "type": "address"
-            }
-        ],
-        "name": "isUserStakingNormalNFT",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function",
-        "constant": true
-    },
-    {
-        "inputs": [],
-        "name": "stakeForNormalNFT",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "stakeForGoldenNFT",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "withdrawLP",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "mintNFT",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    }
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_UniV2Address",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_PPDEX",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_pepemonFactory",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_blockTime",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "Redeemed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Staked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Unstaked",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "PPDEX",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "constant": true
+  },
+  {
+    "inputs": [],
+    "name": "UniV2Address",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "constant": true
+  },
+  {
+    "inputs": [],
+    "name": "blockTime",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "constant": true
+  },
+  {
+    "inputs": [],
+    "name": "goldenID",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "constant": true
+  },
+  {
+    "inputs": [],
+    "name": "minPPDEX",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "constant": true
+  },
+  {
+    "inputs": [],
+    "name": "minPPDEXGolden",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "constant": true
+  },
+  {
+    "inputs": [],
+    "name": "normalID",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "constant": true
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "constant": true
+  },
+  {
+    "inputs": [],
+    "name": "pepemonFactory",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "constant": true
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "stakingDeadline",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "constant": true
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "addr",
+        "type": "address"
+      }
+    ],
+    "name": "setUniV2Address",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_PPDEX",
+        "type": "address"
+      }
+    ],
+    "name": "setPPDEX",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_pepemonFactory",
+        "type": "address"
+      }
+    ],
+    "name": "setPepemonFactory",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_minPPDEXGolden",
+        "type": "uint256"
+      }
+    ],
+    "name": "setminPPDEXGolden",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_minPPDEX",
+        "type": "uint256"
+      }
+    ],
+    "name": "setminPPDEX",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_normalID",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_goldenID",
+        "type": "uint256"
+      }
+    ],
+    "name": "updateNFT",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MinLPTokens",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "constant": true
+  },
+  {
+    "inputs": [],
+    "name": "MinLPTokensGolden",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "constant": true
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "lp",
+        "type": "uint256"
+      }
+    ],
+    "name": "LPToPPDEX",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "constant": true
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "addr",
+        "type": "address"
+      }
+    ],
+    "name": "getStakingStart",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "constant": true
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "addr",
+        "type": "address"
+      }
+    ],
+    "name": "getLPBalance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "constant": true
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "addr",
+        "type": "address"
+      }
+    ],
+    "name": "isUserStaking",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "constant": true
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "addr",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "hasUserMinted",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "constant": true
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "addr",
+        "type": "address"
+      }
+    ],
+    "name": "isUserStakingNormalNFT",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "constant": true
+  },
+  {
+    "inputs": [],
+    "name": "stakeForNormalNFT",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "stakeForGoldenNFT",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "withdrawLP",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "mintNFT",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
 ]

--- a/packages/app/src/contracts/src/abis/pepemon_stake.json
+++ b/packages/app/src/contracts/src/abis/pepemon_stake.json
@@ -1,630 +1,629 @@
 [
-    {
-        "inputs": [
-            {
-                "internalType": "contract IPepemonFactory",
-                "name": "_pepemonFactoryAddress",
-                "type": "address"
-            }
+  {
+    "inputs": [
+      {
+        "internalType": "contract IPepemonFactory",
+        "name": "_pepemonFactoryAddress",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "eventId",
+        "type": "uint256"
+      }
+    ],
+    "name": "StakingEventCancelled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "eventId",
+        "type": "uint256"
+      }
+    ],
+    "name": "StakingEventCompleted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "eventId",
+        "type": "uint256"
+      }
+    ],
+    "name": "StakingEventCreated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "eventId",
+        "type": "uint256"
+      }
+    ],
+    "name": "StakingEventEntered",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "cardsStaked",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isOwner",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pepemonFactory",
+    "outputs": [
+      {
+        "internalType": "contract IPepemonFactory",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "stakingEvents",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "cardAmountAny",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "cardRewardId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "blockStakeLength",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "blockEventClose",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "userInfo",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "isCompleted",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "blockEnd",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getStakingEventsLength",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getAllEvents",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256[]",
+            "name": "cardIdList",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256",
+            "name": "cardAmountAny",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "cardAmountList",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256",
+            "name": "cardRewardId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "blockStakeLength",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "blockEventClose",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "toBurnIdList",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "toBurnAmountList",
+            "type": "uint256[]"
+          }
         ],
-        "stateMutability": "nonpayable",
-        "type": "constructor"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "previousOwner",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "newOwner",
-                "type": "address"
-            }
-        ],
-        "name": "OwnershipTransferred",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "user",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "eventId",
-                "type": "uint256"
-            }
-        ],
-        "name": "StakingEventCancelled",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "user",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "eventId",
-                "type": "uint256"
-            }
-        ],
-        "name": "StakingEventCompleted",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "eventId",
-                "type": "uint256"
-            }
-        ],
-        "name": "StakingEventCreated",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "user",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "eventId",
-                "type": "uint256"
-            }
-        ],
-        "name": "StakingEventEntered",
-        "type": "event"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "name": "cardsStaked",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "isOwner",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "owner",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "pepemonFactory",
-        "outputs": [
-            {
-                "internalType": "contract IPepemonFactory",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "renounceOwnership",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "name": "stakingEvents",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "cardAmountAny",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "cardRewardId",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "blockStakeLength",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "blockEventClose",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "newOwner",
-                "type": "address"
-            }
-        ],
-        "name": "transferOwnership",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "name": "userInfo",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "isCompleted",
-                "type": "bool"
-            },
-            {
-                "internalType": "uint256",
-                "name": "blockEnd",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "getStakingEventsLength",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "getAllEvents",
-        "outputs": [
-            {
-                "components": [
-                    {
-                        "internalType": "uint256[]",
-                        "name": "cardIdList",
-                        "type": "uint256[]"
-                    },
-                    {
-                        "internalType": "uint256",
-                        "name": "cardAmountAny",
-                        "type": "uint256"
-                    },
-                    {
-                        "internalType": "uint256[]",
-                        "name": "cardAmountList",
-                        "type": "uint256[]"
-                    },
-                    {
-                        "internalType": "uint256",
-                        "name": "cardRewardId",
-                        "type": "uint256"
-                    },
-                    {
-                        "internalType": "uint256",
-                        "name": "blockStakeLength",
-                        "type": "uint256"
-                    },
-                    {
-                        "internalType": "uint256",
-                        "name": "blockEventClose",
-                        "type": "uint256"
-                    },
-                    {
-                        "internalType": "uint256[]",
-                        "name": "toBurnIdList",
-                        "type": "uint256[]"
-                    },
-                    {
-                        "internalType": "uint256[]",
-                        "name": "toBurnAmountList",
-                        "type": "uint256[]"
-                    }
-                ],
-                "internalType": "struct PepemonStake.StakingEvent[]",
-                "name": "",
-                "type": "tuple[]"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "getActiveEvents",
-        "outputs": [
-            {
-                "internalType": "uint256[]",
-                "name": "",
-                "type": "uint256[]"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "getClosedEvents",
-        "outputs": [
-            {
-                "internalType": "uint256[]",
-                "name": "",
-                "type": "uint256[]"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_eventId",
-                "type": "uint256"
-            }
-        ],
-        "name": "getCardIdListOfEvent",
-        "outputs": [
-            {
-                "internalType": "uint256[]",
-                "name": "",
-                "type": "uint256[]"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_eventId",
-                "type": "uint256"
-            }
-        ],
-        "name": "getCardAmountListOfEvent",
-        "outputs": [
-            {
-                "internalType": "uint256[]",
-                "name": "",
-                "type": "uint256[]"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_user",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_eventId",
-                "type": "uint256"
-            }
-        ],
-        "name": "getUserProgress",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256[]",
-                "name": "_cardIdList",
-                "type": "uint256[]"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_cardAmountAny",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256[]",
-                "name": "_cardAmountList",
-                "type": "uint256[]"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_cardRewardId",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_blockStakeLength",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_blockEventClose",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256[]",
-                "name": "_toBurnIdList",
-                "type": "uint256[]"
-            },
-            {
-                "internalType": "uint256[]",
-                "name": "_toBurnAmountList",
-                "type": "uint256[]"
-            }
-        ],
-        "name": "createStakingEvent",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_eventId",
-                "type": "uint256"
-            }
-        ],
-        "name": "closeStakingEvent",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_eventId",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256[]",
-                "name": "_cardIdList",
-                "type": "uint256[]"
-            },
-            {
-                "internalType": "uint256[]",
-                "name": "_cardAmountList",
-                "type": "uint256[]"
-            }
-        ],
-        "name": "stakeAny",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_eventId",
-                "type": "uint256"
-            }
-        ],
-        "name": "stake",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_eventId",
-                "type": "uint256"
-            }
-        ],
-        "name": "claim",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_eventId",
-                "type": "uint256"
-            }
-        ],
-        "name": "cancel",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_operator",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "_from",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_id",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_amount",
-                "type": "uint256"
-            },
-            {
-                "internalType": "bytes",
-                "name": "_data",
-                "type": "bytes"
-            }
-        ],
-        "name": "onERC1155Received",
-        "outputs": [
-            {
-                "internalType": "bytes4",
-                "name": "",
-                "type": "bytes4"
-            }
-        ],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_operator",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "_from",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256[]",
-                "name": "_ids",
-                "type": "uint256[]"
-            },
-            {
-                "internalType": "uint256[]",
-                "name": "_amounts",
-                "type": "uint256[]"
-            },
-            {
-                "internalType": "bytes",
-                "name": "_data",
-                "type": "bytes"
-            }
-        ],
-        "name": "onERC1155BatchReceived",
-        "outputs": [
-            {
-                "internalType": "bytes4",
-                "name": "",
-                "type": "bytes4"
-            }
-        ],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "bytes4",
-                "name": "interfaceID",
-                "type": "bytes4"
-            }
-        ],
-        "name": "supportsInterface",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    }
+        "internalType": "struct PepemonStake.StakingEvent[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getActiveEvents",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getClosedEvents",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_eventId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getCardIdListOfEvent",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_eventId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getCardAmountListOfEvent",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_user",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_eventId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getUserProgress",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "_cardIdList",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_cardAmountAny",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "_cardAmountList",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_cardRewardId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_blockStakeLength",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_blockEventClose",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "_toBurnIdList",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "_toBurnAmountList",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "createStakingEvent",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_eventId",
+        "type": "uint256"
+      }
+    ],
+    "name": "closeStakingEvent",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_eventId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "_cardIdList",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "_cardAmountList",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "stakeAny",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_eventId",
+        "type": "uint256"
+      }
+    ],
+    "name": "stake",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_eventId",
+        "type": "uint256"
+      }
+    ],
+    "name": "claim",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_eventId",
+        "type": "uint256"
+      }
+    ],
+    "name": "cancel",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_operator",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_from",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_id",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_data",
+        "type": "bytes"
+      }
+    ],
+    "name": "onERC1155Received",
+    "outputs": [
+      {
+        "internalType": "bytes4",
+        "name": "",
+        "type": "bytes4"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_operator",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_from",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "_ids",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "_amounts",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_data",
+        "type": "bytes"
+      }
+    ],
+    "name": "onERC1155BatchReceived",
+    "outputs": [
+      {
+        "internalType": "bytes4",
+        "name": "",
+        "type": "bytes4"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes4",
+        "name": "interfaceID",
+        "type": "bytes4"
+      }
+    ],
+    "name": "supportsInterface",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
 ]
-

--- a/packages/app/src/contracts/src/abis/pepemon_store_native.json
+++ b/packages/app/src/contracts/src/abis/pepemon_store_native.json
@@ -1,1 +1,191 @@
-[{"inputs":[{"internalType":"contract ERC1155Tradable","name":"_PepemonFactoryAddress","type":"address"}],"payable":false,"stateMutability":"nonpayable","type":"constructor"},{"anonymous":false,"inputs":[{"indexed":false,"internalType":"uint256","name":"card","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"points","type":"uint256"}],"name":"CardAdded","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"previousOwner","type":"address"},{"indexed":true,"internalType":"address","name":"newOwner","type":"address"}],"name":"OwnershipTransferred","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"user","type":"address"},{"indexed":false,"internalType":"uint256","name":"amount","type":"uint256"}],"name":"Redeemed","type":"event"},{"constant":true,"inputs":[],"name":"PepemonFactory","outputs":[{"internalType":"contract ERC1155Tradable","name":"","type":"address"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"internalType":"uint256","name":"cardId","type":"uint256"},{"internalType":"uint256","name":"amount","type":"uint256"}],"name":"addCard","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[{"internalType":"uint256","name":"","type":"uint256"}],"name":"cardCosts","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[],"name":"fundAddress","outputs":[{"internalType":"address payable","name":"","type":"address"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[],"name":"isOwner","outputs":[{"internalType":"bool","name":"","type":"bool"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[],"name":"owner","outputs":[{"internalType":"address","name":"","type":"address"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"internalType":"uint256","name":"card","type":"uint256"}],"name":"redeem","outputs":[],"payable":true,"stateMutability":"payable","type":"function"},{"constant":false,"inputs":[],"name":"renounceOwnership","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[{"internalType":"address payable","name":"_fundAddress","type":"address"}],"name":"setFundAddress","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"totalBNBspend","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"internalType":"address","name":"newOwner","type":"address"}],"name":"transferOwnership","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}]
+[
+  {
+    "inputs": [
+      {
+        "internalType": "contract ERC1155Tradable",
+        "name": "_PepemonFactoryAddress",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "card",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "points",
+        "type": "uint256"
+      }
+    ],
+    "name": "CardAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Redeemed",
+    "type": "event"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "PepemonFactory",
+    "outputs": [
+      {
+        "internalType": "contract ERC1155Tradable",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "uint256", "name": "cardId", "type": "uint256" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "addCard",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "name": "cardCosts",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "fundAddress",
+    "outputs": [
+      { "internalType": "address payable", "name": "", "type": "address" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "isOwner",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "owner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "uint256", "name": "card", "type": "uint256" }
+    ],
+    "name": "redeem",
+    "outputs": [],
+    "payable": true,
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address payable",
+        "name": "_fundAddress",
+        "type": "address"
+      }
+    ],
+    "name": "setFundAddress",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "totalBNBspend",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "newOwner", "type": "address" }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/packages/app/src/contracts/src/abis/ppblz.json
+++ b/packages/app/src/contracts/src/abis/ppblz.json
@@ -1,1 +1,542 @@
-[{"inputs":[{"internalType":"string","name":"name","type":"string"},{"internalType":"string","name":"symbol","type":"string"},{"internalType":"uint8","name":"decimals","type":"uint8"},{"internalType":"uint256","name":"cap","type":"uint256"},{"internalType":"uint256","name":"initialSupply","type":"uint256"},{"internalType":"bool","name":"transferEnabled","type":"bool"},{"internalType":"bool","name":"mintingFinished","type":"bool"}],"stateMutability":"nonpayable","type":"constructor"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"owner","type":"address"},{"indexed":true,"internalType":"address","name":"spender","type":"address"},{"indexed":false,"internalType":"uint256","name":"value","type":"uint256"}],"name":"Approval","type":"event"},{"anonymous":false,"inputs":[],"name":"MintFinished","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"previousOwner","type":"address"},{"indexed":true,"internalType":"address","name":"newOwner","type":"address"}],"name":"OwnershipTransferred","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"bytes32","name":"role","type":"bytes32"},{"indexed":true,"internalType":"bytes32","name":"previousAdminRole","type":"bytes32"},{"indexed":true,"internalType":"bytes32","name":"newAdminRole","type":"bytes32"}],"name":"RoleAdminChanged","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"bytes32","name":"role","type":"bytes32"},{"indexed":true,"internalType":"address","name":"account","type":"address"},{"indexed":true,"internalType":"address","name":"sender","type":"address"}],"name":"RoleGranted","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"bytes32","name":"role","type":"bytes32"},{"indexed":true,"internalType":"address","name":"account","type":"address"},{"indexed":true,"internalType":"address","name":"sender","type":"address"}],"name":"RoleRevoked","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"from","type":"address"},{"indexed":true,"internalType":"address","name":"to","type":"address"},{"indexed":false,"internalType":"uint256","name":"value","type":"uint256"}],"name":"Transfer","type":"event"},{"anonymous":false,"inputs":[],"name":"TransferEnabled","type":"event"},{"inputs":[],"name":"DEFAULT_ADMIN_ROLE","outputs":[{"internalType":"bytes32","name":"","type":"bytes32"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"MINTER_ROLE","outputs":[{"internalType":"bytes32","name":"","type":"bytes32"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"OPERATOR_ROLE","outputs":[{"internalType":"bytes32","name":"","type":"bytes32"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"owner","type":"address"},{"internalType":"address","name":"spender","type":"address"}],"name":"allowance","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"spender","type":"address"},{"internalType":"uint256","name":"amount","type":"uint256"}],"name":"approve","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"spender","type":"address"},{"internalType":"uint256","name":"value","type":"uint256"}],"name":"approveAndCall","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"spender","type":"address"},{"internalType":"uint256","name":"value","type":"uint256"},{"internalType":"bytes","name":"data","type":"bytes"}],"name":"approveAndCall","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"account","type":"address"}],"name":"balanceOf","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"uint256","name":"amount","type":"uint256"}],"name":"burn","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"account","type":"address"},{"internalType":"uint256","name":"amount","type":"uint256"}],"name":"burnFrom","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[],"name":"cap","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"decimals","outputs":[{"internalType":"uint8","name":"","type":"uint8"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"spender","type":"address"},{"internalType":"uint256","name":"subtractedValue","type":"uint256"}],"name":"decreaseAllowance","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"nonpayable","type":"function"},{"inputs":[],"name":"enableTransfer","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[],"name":"finishMinting","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[],"name":"generator","outputs":[{"internalType":"string","name":"","type":"string"}],"stateMutability":"pure","type":"function"},{"inputs":[{"internalType":"bytes32","name":"role","type":"bytes32"}],"name":"getRoleAdmin","outputs":[{"internalType":"bytes32","name":"","type":"bytes32"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"bytes32","name":"role","type":"bytes32"},{"internalType":"uint256","name":"index","type":"uint256"}],"name":"getRoleMember","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"bytes32","name":"role","type":"bytes32"}],"name":"getRoleMemberCount","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"bytes32","name":"role","type":"bytes32"},{"internalType":"address","name":"account","type":"address"}],"name":"grantRole","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"bytes32","name":"role","type":"bytes32"},{"internalType":"address","name":"account","type":"address"}],"name":"hasRole","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"spender","type":"address"},{"internalType":"uint256","name":"addedValue","type":"uint256"}],"name":"increaseAllowance","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"to","type":"address"},{"internalType":"uint256","name":"value","type":"uint256"}],"name":"mint","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[],"name":"mintingFinished","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"name","outputs":[{"internalType":"string","name":"","type":"string"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"owner","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"tokenAddress","type":"address"},{"internalType":"uint256","name":"tokenAmount","type":"uint256"}],"name":"recoverERC20","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[],"name":"renounceOwnership","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"bytes32","name":"role","type":"bytes32"},{"internalType":"address","name":"account","type":"address"}],"name":"renounceRole","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"bytes32","name":"role","type":"bytes32"},{"internalType":"address","name":"account","type":"address"}],"name":"revokeRole","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"bytes4","name":"interfaceId","type":"bytes4"}],"name":"supportsInterface","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"symbol","outputs":[{"internalType":"string","name":"","type":"string"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"totalSupply","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"to","type":"address"},{"internalType":"uint256","name":"value","type":"uint256"}],"name":"transfer","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"to","type":"address"},{"internalType":"uint256","name":"value","type":"uint256"}],"name":"transferAndCall","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"to","type":"address"},{"internalType":"uint256","name":"value","type":"uint256"},{"internalType":"bytes","name":"data","type":"bytes"}],"name":"transferAndCall","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"nonpayable","type":"function"},{"inputs":[],"name":"transferEnabled","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"from","type":"address"},{"internalType":"address","name":"to","type":"address"},{"internalType":"uint256","name":"value","type":"uint256"}],"name":"transferFrom","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"from","type":"address"},{"internalType":"address","name":"to","type":"address"},{"internalType":"uint256","name":"value","type":"uint256"},{"internalType":"bytes","name":"data","type":"bytes"}],"name":"transferFromAndCall","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"from","type":"address"},{"internalType":"address","name":"to","type":"address"},{"internalType":"uint256","name":"value","type":"uint256"}],"name":"transferFromAndCall","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"newOwner","type":"address"}],"name":"transferOwnership","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[],"name":"version","outputs":[{"internalType":"string","name":"","type":"string"}],"stateMutability":"pure","type":"function"}]
+[
+  {
+    "inputs": [
+      { "internalType": "string", "name": "name", "type": "string" },
+      { "internalType": "string", "name": "symbol", "type": "string" },
+      { "internalType": "uint8", "name": "decimals", "type": "uint8" },
+      { "internalType": "uint256", "name": "cap", "type": "uint256" },
+      { "internalType": "uint256", "name": "initialSupply", "type": "uint256" },
+      { "internalType": "bool", "name": "transferEnabled", "type": "bool" },
+      { "internalType": "bool", "name": "mintingFinished", "type": "bool" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  { "anonymous": false, "inputs": [], "name": "MintFinished", "type": "event" },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "previousAdminRole",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "newAdminRole",
+        "type": "bytes32"
+      }
+    ],
+    "name": "RoleAdminChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleGranted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleRevoked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [],
+    "name": "TransferEnabled",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "DEFAULT_ADMIN_ROLE",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MINTER_ROLE",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "OPERATOR_ROLE",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "owner", "type": "address" },
+      { "internalType": "address", "name": "spender", "type": "address" }
+    ],
+    "name": "allowance",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "approve",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "value", "type": "uint256" }
+    ],
+    "name": "approveAndCall",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "value", "type": "uint256" },
+      { "internalType": "bytes", "name": "data", "type": "bytes" }
+    ],
+    "name": "approveAndCall",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "balanceOf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "burn",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "account", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "burnFrom",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "cap",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [{ "internalType": "uint8", "name": "", "type": "uint8" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      {
+        "internalType": "uint256",
+        "name": "subtractedValue",
+        "type": "uint256"
+      }
+    ],
+    "name": "decreaseAllowance",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "enableTransfer",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "finishMinting",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "generator",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" }
+    ],
+    "name": "getRoleAdmin",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "uint256", "name": "index", "type": "uint256" }
+    ],
+    "name": "getRoleMember",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" }
+    ],
+    "name": "getRoleMemberCount",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "grantRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "hasRole",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "addedValue", "type": "uint256" }
+    ],
+    "name": "increaseAllowance",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "value", "type": "uint256" }
+    ],
+    "name": "mint",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "mintingFinished",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "tokenAddress", "type": "address" },
+      { "internalType": "uint256", "name": "tokenAmount", "type": "uint256" }
+    ],
+    "name": "recoverERC20",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "renounceRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "revokeRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes4", "name": "interfaceId", "type": "bytes4" }
+    ],
+    "name": "supportsInterface",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "value", "type": "uint256" }
+    ],
+    "name": "transfer",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "value", "type": "uint256" }
+    ],
+    "name": "transferAndCall",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "value", "type": "uint256" },
+      { "internalType": "bytes", "name": "data", "type": "bytes" }
+    ],
+    "name": "transferAndCall",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "transferEnabled",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "from", "type": "address" },
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "value", "type": "uint256" }
+    ],
+    "name": "transferFrom",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "from", "type": "address" },
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "value", "type": "uint256" },
+      { "internalType": "bytes", "name": "data", "type": "bytes" }
+    ],
+    "name": "transferFromAndCall",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "from", "type": "address" },
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "value", "type": "uint256" }
+    ],
+    "name": "transferFromAndCall",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "newOwner", "type": "address" }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "version",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "pure",
+    "type": "function"
+  }
+]

--- a/packages/app/src/contracts/src/abis/ppdex.json
+++ b/packages/app/src/contracts/src/abis/ppdex.json
@@ -1,680 +1,680 @@
 [
-    {
-        "inputs": [],
-        "stateMutability": "nonpayable",
-        "type": "constructor"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "owner",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "spender",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "value",
-                "type": "uint256"
-            }
-        ],
-        "name": "Approval",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "user",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "totalPpblzStaked",
-                "type": "uint256"
-            }
-        ],
-        "name": "PpblzStaked",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "user",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "PpblzWithdrawn",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "user",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "reward",
-                "type": "uint256"
-            }
-        ],
-        "name": "Rewards",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "from",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "to",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "value",
-                "type": "uint256"
-            }
-        ],
-        "name": "Transfer",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "user",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "totalUniV2Staked",
-                "type": "uint256"
-            }
-        ],
-        "name": "UniV2Staked",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "user",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "UniV2Withdrawn",
-        "type": "event"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "owner",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "spender",
-                "type": "address"
-            }
-        ],
-        "name": "allowance",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "spender",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "approve",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
-        ],
-        "name": "balanceOf",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "decimals",
-        "outputs": [
-            {
-                "internalType": "uint8",
-                "name": "",
-                "type": "uint8"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "spender",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "subtractedValue",
-                "type": "uint256"
-            }
-        ],
-        "name": "decreaseAllowance",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "spender",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "addedValue",
-                "type": "uint256"
-            }
-        ],
-        "name": "increaseAllowance",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "name",
-        "outputs": [
-            {
-                "internalType": "string",
-                "name": "",
-                "type": "string"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "symbol",
-        "outputs": [
-            {
-                "internalType": "string",
-                "name": "",
-                "type": "string"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "totalSupply",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "recipient",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "transfer",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "sender",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "recipient",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "transferFrom",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "uniV2PairAddress",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_ppblzAddress",
-                "type": "address"
-            }
-        ],
-        "name": "setPpblzAddress",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_uniV2PairAddress",
-                "type": "address"
-            }
-        ],
-        "name": "setUniV2PairAddress",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_fundAddress",
-                "type": "address"
-            }
-        ],
-        "name": "setFundAddress",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "setRewardsVar",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "setLiquidityMultiplier",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "getLiquidityMultiplier",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "getBlockNum",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_account",
-                "type": "address"
-            }
-        ],
-        "name": "getLastBlockCheckedNum",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_account",
-                "type": "address"
-            }
-        ],
-        "name": "getAddressPpblzStakeAmount",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_account",
-                "type": "address"
-            }
-        ],
-        "name": "getAddressUniV2StakeAmount",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "totalStakedSupply",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "totalStakedPpblz",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "totalStakedUniV2",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
-        ],
-        "name": "myRewardsBalance",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "stakePpblz",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "stakeUniV2",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "withdrawPpblz",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "withdrawUniV2",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "getReward",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    }
+  {
+    "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalPpblzStaked",
+        "type": "uint256"
+      }
+    ],
+    "name": "PpblzStaked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "PpblzWithdrawn",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "reward",
+        "type": "uint256"
+      }
+    ],
+    "name": "Rewards",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalUniV2Staked",
+        "type": "uint256"
+      }
+    ],
+    "name": "UniV2Staked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "UniV2Withdrawn",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      }
+    ],
+    "name": "allowance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "approve",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "subtractedValue",
+        "type": "uint256"
+      }
+    ],
+    "name": "decreaseAllowance",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "addedValue",
+        "type": "uint256"
+      }
+    ],
+    "name": "increaseAllowance",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "transfer",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferFrom",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "uniV2PairAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_ppblzAddress",
+        "type": "address"
+      }
+    ],
+    "name": "setPpblzAddress",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_uniV2PairAddress",
+        "type": "address"
+      }
+    ],
+    "name": "setUniV2PairAddress",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_fundAddress",
+        "type": "address"
+      }
+    ],
+    "name": "setFundAddress",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "setRewardsVar",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "setLiquidityMultiplier",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getLiquidityMultiplier",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getBlockNum",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      }
+    ],
+    "name": "getLastBlockCheckedNum",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      }
+    ],
+    "name": "getAddressPpblzStakeAmount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      }
+    ],
+    "name": "getAddressUniV2StakeAmount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalStakedSupply",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalStakedPpblz",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalStakedUniV2",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "myRewardsBalance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "stakePpblz",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "stakeUniV2",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "withdrawPpblz",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "withdrawUniV2",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getReward",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
 ]

--- a/packages/app/src/contracts/src/abis/router01.json
+++ b/packages/app/src/contracts/src/abis/router01.json
@@ -18,8 +18,16 @@
     "inputs": [
       { "internalType": "address", "name": "tokenA", "type": "address" },
       { "internalType": "address", "name": "tokenB", "type": "address" },
-      { "internalType": "uint256", "name": "amountADesired", "type": "uint256" },
-      { "internalType": "uint256", "name": "amountBDesired", "type": "uint256" },
+      {
+        "internalType": "uint256",
+        "name": "amountADesired",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountBDesired",
+        "type": "uint256"
+      },
       { "internalType": "uint256", "name": "amountAMin", "type": "uint256" },
       { "internalType": "uint256", "name": "amountBMin", "type": "uint256" },
       { "internalType": "address", "name": "to", "type": "address" },
@@ -37,8 +45,16 @@
   {
     "inputs": [
       { "internalType": "address", "name": "token", "type": "address" },
-      { "internalType": "uint256", "name": "amountTokenDesired", "type": "uint256" },
-      { "internalType": "uint256", "name": "amountTokenMin", "type": "uint256" },
+      {
+        "internalType": "uint256",
+        "name": "amountTokenDesired",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountTokenMin",
+        "type": "uint256"
+      },
       { "internalType": "uint256", "name": "amountETHMin", "type": "uint256" },
       { "internalType": "address", "name": "to", "type": "address" },
       { "internalType": "uint256", "name": "deadline", "type": "uint256" }
@@ -66,7 +82,9 @@
       { "internalType": "uint256", "name": "reserveOut", "type": "uint256" }
     ],
     "name": "getAmountIn",
-    "outputs": [{ "internalType": "uint256", "name": "amountIn", "type": "uint256" }],
+    "outputs": [
+      { "internalType": "uint256", "name": "amountIn", "type": "uint256" }
+    ],
     "stateMutability": "pure",
     "type": "function"
   },
@@ -77,7 +95,9 @@
       { "internalType": "uint256", "name": "reserveOut", "type": "uint256" }
     ],
     "name": "getAmountOut",
-    "outputs": [{ "internalType": "uint256", "name": "amountOut", "type": "uint256" }],
+    "outputs": [
+      { "internalType": "uint256", "name": "amountOut", "type": "uint256" }
+    ],
     "stateMutability": "pure",
     "type": "function"
   },
@@ -87,7 +107,9 @@
       { "internalType": "address[]", "name": "path", "type": "address[]" }
     ],
     "name": "getAmountsIn",
-    "outputs": [{ "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" }],
+    "outputs": [
+      { "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
@@ -97,7 +119,9 @@
       { "internalType": "address[]", "name": "path", "type": "address[]" }
     ],
     "name": "getAmountsOut",
-    "outputs": [{ "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" }],
+    "outputs": [
+      { "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
@@ -108,7 +132,9 @@
       { "internalType": "uint256", "name": "reserveB", "type": "uint256" }
     ],
     "name": "quote",
-    "outputs": [{ "internalType": "uint256", "name": "amountB", "type": "uint256" }],
+    "outputs": [
+      { "internalType": "uint256", "name": "amountB", "type": "uint256" }
+    ],
     "stateMutability": "pure",
     "type": "function"
   },
@@ -134,7 +160,11 @@
     "inputs": [
       { "internalType": "address", "name": "token", "type": "address" },
       { "internalType": "uint256", "name": "liquidity", "type": "uint256" },
-      { "internalType": "uint256", "name": "amountTokenMin", "type": "uint256" },
+      {
+        "internalType": "uint256",
+        "name": "amountTokenMin",
+        "type": "uint256"
+      },
       { "internalType": "uint256", "name": "amountETHMin", "type": "uint256" },
       { "internalType": "address", "name": "to", "type": "address" },
       { "internalType": "uint256", "name": "deadline", "type": "uint256" }
@@ -151,7 +181,11 @@
     "inputs": [
       { "internalType": "address", "name": "token", "type": "address" },
       { "internalType": "uint256", "name": "liquidity", "type": "uint256" },
-      { "internalType": "uint256", "name": "amountTokenMin", "type": "uint256" },
+      {
+        "internalType": "uint256",
+        "name": "amountTokenMin",
+        "type": "uint256"
+      },
       { "internalType": "uint256", "name": "amountETHMin", "type": "uint256" },
       { "internalType": "address", "name": "to", "type": "address" },
       { "internalType": "uint256", "name": "deadline", "type": "uint256" },
@@ -198,7 +232,9 @@
       { "internalType": "uint256", "name": "deadline", "type": "uint256" }
     ],
     "name": "swapETHForExactTokens",
-    "outputs": [{ "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" }],
+    "outputs": [
+      { "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" }
+    ],
     "stateMutability": "payable",
     "type": "function"
   },
@@ -210,7 +246,9 @@
       { "internalType": "uint256", "name": "deadline", "type": "uint256" }
     ],
     "name": "swapExactETHForTokens",
-    "outputs": [{ "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" }],
+    "outputs": [
+      { "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" }
+    ],
     "stateMutability": "payable",
     "type": "function"
   },
@@ -223,7 +261,9 @@
       { "internalType": "uint256", "name": "deadline", "type": "uint256" }
     ],
     "name": "swapExactTokensForETH",
-    "outputs": [{ "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" }],
+    "outputs": [
+      { "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" }
+    ],
     "stateMutability": "nonpayable",
     "type": "function"
   },
@@ -236,7 +276,9 @@
       { "internalType": "uint256", "name": "deadline", "type": "uint256" }
     ],
     "name": "swapExactTokensForTokens",
-    "outputs": [{ "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" }],
+    "outputs": [
+      { "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" }
+    ],
     "stateMutability": "nonpayable",
     "type": "function"
   },
@@ -249,7 +291,9 @@
       { "internalType": "uint256", "name": "deadline", "type": "uint256" }
     ],
     "name": "swapTokensForExactETH",
-    "outputs": [{ "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" }],
+    "outputs": [
+      { "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" }
+    ],
     "stateMutability": "nonpayable",
     "type": "function"
   },
@@ -262,7 +306,9 @@
       { "internalType": "uint256", "name": "deadline", "type": "uint256" }
     ],
     "name": "swapTokensForExactTokens",
-    "outputs": [{ "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" }],
+    "outputs": [
+      { "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" }
+    ],
     "stateMutability": "nonpayable",
     "type": "function"
   },

--- a/packages/app/src/contracts/src/abis/router02.json
+++ b/packages/app/src/contracts/src/abis/router02.json
@@ -18,8 +18,16 @@
     "inputs": [
       { "internalType": "address", "name": "tokenA", "type": "address" },
       { "internalType": "address", "name": "tokenB", "type": "address" },
-      { "internalType": "uint256", "name": "amountADesired", "type": "uint256" },
-      { "internalType": "uint256", "name": "amountBDesired", "type": "uint256" },
+      {
+        "internalType": "uint256",
+        "name": "amountADesired",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountBDesired",
+        "type": "uint256"
+      },
       { "internalType": "uint256", "name": "amountAMin", "type": "uint256" },
       { "internalType": "uint256", "name": "amountBMin", "type": "uint256" },
       { "internalType": "address", "name": "to", "type": "address" },
@@ -37,8 +45,16 @@
   {
     "inputs": [
       { "internalType": "address", "name": "token", "type": "address" },
-      { "internalType": "uint256", "name": "amountTokenDesired", "type": "uint256" },
-      { "internalType": "uint256", "name": "amountTokenMin", "type": "uint256" },
+      {
+        "internalType": "uint256",
+        "name": "amountTokenDesired",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountTokenMin",
+        "type": "uint256"
+      },
       { "internalType": "uint256", "name": "amountETHMin", "type": "uint256" },
       { "internalType": "address", "name": "to", "type": "address" },
       { "internalType": "uint256", "name": "deadline", "type": "uint256" }
@@ -66,7 +82,9 @@
       { "internalType": "uint256", "name": "reserveOut", "type": "uint256" }
     ],
     "name": "getAmountIn",
-    "outputs": [{ "internalType": "uint256", "name": "amountIn", "type": "uint256" }],
+    "outputs": [
+      { "internalType": "uint256", "name": "amountIn", "type": "uint256" }
+    ],
     "stateMutability": "pure",
     "type": "function"
   },
@@ -77,7 +95,9 @@
       { "internalType": "uint256", "name": "reserveOut", "type": "uint256" }
     ],
     "name": "getAmountOut",
-    "outputs": [{ "internalType": "uint256", "name": "amountOut", "type": "uint256" }],
+    "outputs": [
+      { "internalType": "uint256", "name": "amountOut", "type": "uint256" }
+    ],
     "stateMutability": "pure",
     "type": "function"
   },
@@ -87,7 +107,9 @@
       { "internalType": "address[]", "name": "path", "type": "address[]" }
     ],
     "name": "getAmountsIn",
-    "outputs": [{ "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" }],
+    "outputs": [
+      { "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
@@ -97,7 +119,9 @@
       { "internalType": "address[]", "name": "path", "type": "address[]" }
     ],
     "name": "getAmountsOut",
-    "outputs": [{ "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" }],
+    "outputs": [
+      { "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
@@ -108,7 +132,9 @@
       { "internalType": "uint256", "name": "reserveB", "type": "uint256" }
     ],
     "name": "quote",
-    "outputs": [{ "internalType": "uint256", "name": "amountB", "type": "uint256" }],
+    "outputs": [
+      { "internalType": "uint256", "name": "amountB", "type": "uint256" }
+    ],
     "stateMutability": "pure",
     "type": "function"
   },
@@ -134,7 +160,11 @@
     "inputs": [
       { "internalType": "address", "name": "token", "type": "address" },
       { "internalType": "uint256", "name": "liquidity", "type": "uint256" },
-      { "internalType": "uint256", "name": "amountTokenMin", "type": "uint256" },
+      {
+        "internalType": "uint256",
+        "name": "amountTokenMin",
+        "type": "uint256"
+      },
       { "internalType": "uint256", "name": "amountETHMin", "type": "uint256" },
       { "internalType": "address", "name": "to", "type": "address" },
       { "internalType": "uint256", "name": "deadline", "type": "uint256" }
@@ -151,13 +181,19 @@
     "inputs": [
       { "internalType": "address", "name": "token", "type": "address" },
       { "internalType": "uint256", "name": "liquidity", "type": "uint256" },
-      { "internalType": "uint256", "name": "amountTokenMin", "type": "uint256" },
+      {
+        "internalType": "uint256",
+        "name": "amountTokenMin",
+        "type": "uint256"
+      },
       { "internalType": "uint256", "name": "amountETHMin", "type": "uint256" },
       { "internalType": "address", "name": "to", "type": "address" },
       { "internalType": "uint256", "name": "deadline", "type": "uint256" }
     ],
     "name": "removeLiquidityETHSupportingFeeOnTransferTokens",
-    "outputs": [{ "internalType": "uint256", "name": "amountETH", "type": "uint256" }],
+    "outputs": [
+      { "internalType": "uint256", "name": "amountETH", "type": "uint256" }
+    ],
     "stateMutability": "nonpayable",
     "type": "function"
   },
@@ -165,7 +201,11 @@
     "inputs": [
       { "internalType": "address", "name": "token", "type": "address" },
       { "internalType": "uint256", "name": "liquidity", "type": "uint256" },
-      { "internalType": "uint256", "name": "amountTokenMin", "type": "uint256" },
+      {
+        "internalType": "uint256",
+        "name": "amountTokenMin",
+        "type": "uint256"
+      },
       { "internalType": "uint256", "name": "amountETHMin", "type": "uint256" },
       { "internalType": "address", "name": "to", "type": "address" },
       { "internalType": "uint256", "name": "deadline", "type": "uint256" },
@@ -186,7 +226,11 @@
     "inputs": [
       { "internalType": "address", "name": "token", "type": "address" },
       { "internalType": "uint256", "name": "liquidity", "type": "uint256" },
-      { "internalType": "uint256", "name": "amountTokenMin", "type": "uint256" },
+      {
+        "internalType": "uint256",
+        "name": "amountTokenMin",
+        "type": "uint256"
+      },
       { "internalType": "uint256", "name": "amountETHMin", "type": "uint256" },
       { "internalType": "address", "name": "to", "type": "address" },
       { "internalType": "uint256", "name": "deadline", "type": "uint256" },
@@ -196,7 +240,9 @@
       { "internalType": "bytes32", "name": "s", "type": "bytes32" }
     ],
     "name": "removeLiquidityETHWithPermitSupportingFeeOnTransferTokens",
-    "outputs": [{ "internalType": "uint256", "name": "amountETH", "type": "uint256" }],
+    "outputs": [
+      { "internalType": "uint256", "name": "amountETH", "type": "uint256" }
+    ],
     "stateMutability": "nonpayable",
     "type": "function"
   },
@@ -230,7 +276,9 @@
       { "internalType": "uint256", "name": "deadline", "type": "uint256" }
     ],
     "name": "swapETHForExactTokens",
-    "outputs": [{ "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" }],
+    "outputs": [
+      { "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" }
+    ],
     "stateMutability": "payable",
     "type": "function"
   },
@@ -242,7 +290,9 @@
       { "internalType": "uint256", "name": "deadline", "type": "uint256" }
     ],
     "name": "swapExactETHForTokens",
-    "outputs": [{ "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" }],
+    "outputs": [
+      { "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" }
+    ],
     "stateMutability": "payable",
     "type": "function"
   },
@@ -267,7 +317,9 @@
       { "internalType": "uint256", "name": "deadline", "type": "uint256" }
     ],
     "name": "swapExactTokensForETH",
-    "outputs": [{ "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" }],
+    "outputs": [
+      { "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" }
+    ],
     "stateMutability": "nonpayable",
     "type": "function"
   },
@@ -293,7 +345,9 @@
       { "internalType": "uint256", "name": "deadline", "type": "uint256" }
     ],
     "name": "swapExactTokensForTokens",
-    "outputs": [{ "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" }],
+    "outputs": [
+      { "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" }
+    ],
     "stateMutability": "nonpayable",
     "type": "function"
   },
@@ -319,7 +373,9 @@
       { "internalType": "uint256", "name": "deadline", "type": "uint256" }
     ],
     "name": "swapTokensForExactETH",
-    "outputs": [{ "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" }],
+    "outputs": [
+      { "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" }
+    ],
     "stateMutability": "nonpayable",
     "type": "function"
   },
@@ -332,7 +388,9 @@
       { "internalType": "uint256", "name": "deadline", "type": "uint256" }
     ],
     "name": "swapTokensForExactTokens",
-    "outputs": [{ "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" }],
+    "outputs": [
+      { "internalType": "uint256[]", "name": "amounts", "type": "uint256[]" }
+    ],
     "stateMutability": "nonpayable",
     "type": "function"
   },

--- a/packages/app/src/contracts/src/abis/uni_v2_lp.json
+++ b/packages/app/src/contracts/src/abis/uni_v2_lp.json
@@ -1,713 +1,713 @@
 [
-    {
-        "inputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "constructor"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "owner",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "spender",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "value",
-                "type": "uint256"
-            }
-        ],
-        "name": "Approval",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "sender",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "amount0",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "amount1",
-                "type": "uint256"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "to",
-                "type": "address"
-            }
-        ],
-        "name": "Burn",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "sender",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "amount0",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "amount1",
-                "type": "uint256"
-            }
-        ],
-        "name": "Mint",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "sender",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "amount0In",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "amount1In",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "amount0Out",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "amount1Out",
-                "type": "uint256"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "to",
-                "type": "address"
-            }
-        ],
-        "name": "Swap",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": false,
-                "internalType": "uint112",
-                "name": "reserve0",
-                "type": "uint112"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint112",
-                "name": "reserve1",
-                "type": "uint112"
-            }
-        ],
-        "name": "Sync",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "from",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "to",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "value",
-                "type": "uint256"
-            }
-        ],
-        "name": "Transfer",
-        "type": "event"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "DOMAIN_SEPARATOR",
-        "outputs": [
-            {
-                "internalType": "bytes32",
-                "name": "",
-                "type": "bytes32"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "MINIMUM_LIQUIDITY",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "PERMIT_TYPEHASH",
-        "outputs": [
-            {
-                "internalType": "bytes32",
-                "name": "",
-                "type": "bytes32"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "name": "allowance",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "spender",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "value",
-                "type": "uint256"
-            }
-        ],
-        "name": "approve",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "name": "balanceOf",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "to",
-                "type": "address"
-            }
-        ],
-        "name": "burn",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "amount0",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "amount1",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "decimals",
-        "outputs": [
-            {
-                "internalType": "uint8",
-                "name": "",
-                "type": "uint8"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "factory",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "getReserves",
-        "outputs": [
-            {
-                "internalType": "uint112",
-                "name": "_reserve0",
-                "type": "uint112"
-            },
-            {
-                "internalType": "uint112",
-                "name": "_reserve1",
-                "type": "uint112"
-            },
-            {
-                "internalType": "uint32",
-                "name": "_blockTimestampLast",
-                "type": "uint32"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_token0",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "_token1",
-                "type": "address"
-            }
-        ],
-        "name": "initialize",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "kLast",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "to",
-                "type": "address"
-            }
-        ],
-        "name": "mint",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "liquidity",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "name",
-        "outputs": [
-            {
-                "internalType": "string",
-                "name": "",
-                "type": "string"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "name": "nonces",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "owner",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "spender",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "value",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "deadline",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint8",
-                "name": "v",
-                "type": "uint8"
-            },
-            {
-                "internalType": "bytes32",
-                "name": "r",
-                "type": "bytes32"
-            },
-            {
-                "internalType": "bytes32",
-                "name": "s",
-                "type": "bytes32"
-            }
-        ],
-        "name": "permit",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "price0CumulativeLast",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "price1CumulativeLast",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "to",
-                "type": "address"
-            }
-        ],
-        "name": "skim",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "amount0Out",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "amount1Out",
-                "type": "uint256"
-            },
-            {
-                "internalType": "address",
-                "name": "to",
-                "type": "address"
-            },
-            {
-                "internalType": "bytes",
-                "name": "data",
-                "type": "bytes"
-            }
-        ],
-        "name": "swap",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "symbol",
-        "outputs": [
-            {
-                "internalType": "string",
-                "name": "",
-                "type": "string"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [],
-        "name": "sync",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "token0",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "token1",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "totalSupply",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "to",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "value",
-                "type": "uint256"
-            }
-        ],
-        "name": "transfer",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "from",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "to",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "value",
-                "type": "uint256"
-            }
-        ],
-        "name": "transferFrom",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    }
+  {
+    "inputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "Burn",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      }
+    ],
+    "name": "Mint",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0In",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1In",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0Out",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1Out",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "Swap",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint112",
+        "name": "reserve0",
+        "type": "uint112"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint112",
+        "name": "reserve1",
+        "type": "uint112"
+      }
+    ],
+    "name": "Sync",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "DOMAIN_SEPARATOR",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "MINIMUM_LIQUIDITY",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "PERMIT_TYPEHASH",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "allowance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "approve",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "burn",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "factory",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "getReserves",
+    "outputs": [
+      {
+        "internalType": "uint112",
+        "name": "_reserve0",
+        "type": "uint112"
+      },
+      {
+        "internalType": "uint112",
+        "name": "_reserve1",
+        "type": "uint112"
+      },
+      {
+        "internalType": "uint32",
+        "name": "_blockTimestampLast",
+        "type": "uint32"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token0",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_token1",
+        "type": "address"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "kLast",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "mint",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "liquidity",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "nonces",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "v",
+        "type": "uint8"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "r",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "s",
+        "type": "bytes32"
+      }
+    ],
+    "name": "permit",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "price0CumulativeLast",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "price1CumulativeLast",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "skim",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount0Out",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount1Out",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "swap",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "sync",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "token0",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "token1",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "transfer",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferFrom",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
 ]

--- a/packages/app/src/hocs/index.ts
+++ b/packages/app/src/hocs/index.ts
@@ -1,1 +1,1 @@
-export { default as withConnectedWallet } from './withConnectedWallet';
+export { default as withConnectedWallet } from "./withConnectedWallet";

--- a/packages/app/src/hocs/withConnectedWallet.tsx
+++ b/packages/app/src/hocs/withConnectedWallet.tsx
@@ -3,19 +3,18 @@ import { usePepemon } from "../hooks";
 import { Head } from "../components";
 
 function withConnectedWallet(WrappedComponent: React.FC, props) {
-	function WithConnectedWalletComponent(props) {
+  function WithConnectedWalletComponent(props) {
+    const { account } = usePepemon();
 
-		const { account } = usePepemon();
+    return (
+      <>
+        <Head {...props.metas} />
+        <WrappedComponent {...props} />
+      </>
+    );
+  }
 
-		return (
-			<>
-				<Head {...props.metas}/>
-				<WrappedComponent {...props} />
-			</>
-		);
-	};
-
-	return () => <WithConnectedWalletComponent {...props}/>
+  return () => <WithConnectedWalletComponent {...props} />;
 }
 
 export default withConnectedWallet;

--- a/packages/app/src/hooks/index.ts
+++ b/packages/app/src/hooks/index.ts
@@ -1,52 +1,62 @@
-export { default as useAccountMerkle } from './useAccountMerkle';
-export { default as useAllowance } from './useAllowance';
-export { default as useApprove } from './useApprove';
-export { default as useBlock } from './useBlock';
-export { default as useCardsApi, useCardsMetadata, getCardMeta } from './useCardsApi';
-export type { CardMetadata } from './useCardsApi';
-export { default as useCardsFactoryData, getCardFactoryData } from './useCardsFactoryData';
-export type { CardBalances } from './useCardsFactoryData';
-export { default as useCardsStorePrices, getCardStorePrices } from './useCardsStorePrices';
-export type { CardPrice } from './useCardsStorePrices';
-export { default as useClaimBoosterPack } from './useClaimBoosterPack';
-export { default as useClaimEvent } from './useClaimEvent';
-export { default as useClaimMerkle } from './useClaimMerkle';
-export type { Merkle } from './useClaimMerkle';
-export { default as useDetectMobile } from './useDetectMobile';
-export { default as useDetectMobileScreen } from './useDetectMobileScreen';
-export { default as useEarnings } from './useEarnings';
-export { default as useHorizontalScroll } from './useHorizontalScroll';
-export { default as useIsApprovedForAll } from './useIsApprovedForAll';
-export { default as useIsClaimedMerkle } from './useIsClaimedMerkle';
-export { default as useIsVisible } from './useIsVisible';
-export { default as useJoinEvent } from './useJoinEvent';
-export { default as useLotteryClaim } from './useLotteryClaim';
-export { default as useLotteryHasClaimed } from './useLotteryHasClaimed';
-export { default as useLotteryIsStaking } from './useLotteryIsStaking';
-export { default as useLotteryLPBalance } from './useLotteryLPBalance';
-export { default as useLotteryMinLPTokens } from './useLotteryMinLPTokens';
-export { default as useLotteryRewardCard } from './useLotteryRewardCard';
-export { default as useLotteryStake } from './useLotteryStake';
-export { default as useLotteryStakingDeadline } from './useLotteryStakingDeadline';
-export { default as useLotteryStakingStartblock } from './useLotteryStakingStartblock';
-export { default as useLotteryWithdraw } from './useLotteryWithdraw';
-export { default as useModal } from './useModal';
-export { default as useOutsideClick } from './useOutsideClick';
-export { default as usePepemon } from './usePepemon';
-export { default as usePepemonApi } from './usePepemonApi';
-export { default as useRedeem } from './useRedeem';
-export { default as useRedeemCard } from './useRedeemCard';
-export { default as useReward } from './useReward';
-export { default as useSetApprovalForAll } from './useSetApprovalForAll';
-export { default as useStake } from './useStake';
-export { default as useStakedBalance } from './useStakedBalance';
-export { default as useTokenBalance } from './useTokenBalance';
-export { default as useTokenPrices } from './useTokenPrices';
-export { default as useTotalSpendInShop } from './useTotalSpendInShop';
-export { default as useTotalStakedBalance } from './useTotalStakedBalance';
-export { default as useTotalValueStaked } from './useTotalValueStaked';
+export { default as useAccountMerkle } from "./useAccountMerkle";
+export { default as useAllowance } from "./useAllowance";
+export { default as useApprove } from "./useApprove";
+export { default as useBlock } from "./useBlock";
+export {
+  default as useCardsApi,
+  useCardsMetadata,
+  getCardMeta,
+} from "./useCardsApi";
+export type { CardMetadata } from "./useCardsApi";
+export {
+  default as useCardsFactoryData,
+  getCardFactoryData,
+} from "./useCardsFactoryData";
+export type { CardBalances } from "./useCardsFactoryData";
+export {
+  default as useCardsStorePrices,
+  getCardStorePrices,
+} from "./useCardsStorePrices";
+export type { CardPrice } from "./useCardsStorePrices";
+export { default as useClaimBoosterPack } from "./useClaimBoosterPack";
+export { default as useClaimEvent } from "./useClaimEvent";
+export { default as useClaimMerkle } from "./useClaimMerkle";
+export type { Merkle } from "./useClaimMerkle";
+export { default as useDetectMobile } from "./useDetectMobile";
+export { default as useDetectMobileScreen } from "./useDetectMobileScreen";
+export { default as useEarnings } from "./useEarnings";
+export { default as useHorizontalScroll } from "./useHorizontalScroll";
+export { default as useIsApprovedForAll } from "./useIsApprovedForAll";
+export { default as useIsClaimedMerkle } from "./useIsClaimedMerkle";
+export { default as useIsVisible } from "./useIsVisible";
+export { default as useJoinEvent } from "./useJoinEvent";
+export { default as useLotteryClaim } from "./useLotteryClaim";
+export { default as useLotteryHasClaimed } from "./useLotteryHasClaimed";
+export { default as useLotteryIsStaking } from "./useLotteryIsStaking";
+export { default as useLotteryLPBalance } from "./useLotteryLPBalance";
+export { default as useLotteryMinLPTokens } from "./useLotteryMinLPTokens";
+export { default as useLotteryRewardCard } from "./useLotteryRewardCard";
+export { default as useLotteryStake } from "./useLotteryStake";
+export { default as useLotteryStakingDeadline } from "./useLotteryStakingDeadline";
+export { default as useLotteryStakingStartblock } from "./useLotteryStakingStartblock";
+export { default as useLotteryWithdraw } from "./useLotteryWithdraw";
+export { default as useModal } from "./useModal";
+export { default as useOutsideClick } from "./useOutsideClick";
+export { default as usePepemon } from "./usePepemon";
+export { default as usePepemonApi } from "./usePepemonApi";
+export { default as useRedeem } from "./useRedeem";
+export { default as useRedeemCard } from "./useRedeemCard";
+export { default as useReward } from "./useReward";
+export { default as useSetApprovalForAll } from "./useSetApprovalForAll";
+export { default as useStake } from "./useStake";
+export { default as useStakedBalance } from "./useStakedBalance";
+export { default as useTokenBalance } from "./useTokenBalance";
+export { default as useTokenPrices } from "./useTokenPrices";
+export { default as useTotalSpendInShop } from "./useTotalSpendInShop";
+export { default as useTotalStakedBalance } from "./useTotalStakedBalance";
+export { default as useTotalValueStaked } from "./useTotalValueStaked";
 // export { default as useUnstake } from './useUnstake';
-export { default as useUserEventProgress } from './useUserEventProgress';
-export { default as useUserEventStatus } from './useUserEventStatus';
-export { default as useWeb3Modal } from './useWeb3Modal';
-export { default as useWithdrawEvent } from './useWithdrawEvent';
+export { default as useUserEventProgress } from "./useUserEventProgress";
+export { default as useUserEventStatus } from "./useUserEventStatus";
+export { default as useWeb3Modal } from "./useWeb3Modal";
+export { default as useWithdrawEvent } from "./useWithdrawEvent";

--- a/packages/app/src/hooks/pepe_bridge/useBridge.ts
+++ b/packages/app/src/hooks/pepe_bridge/useBridge.ts
@@ -1,91 +1,107 @@
-import {useCallback, useContext, useEffect, useState} from "react";
-import {BigNumber} from "../../pepemon";
-import {Goerli, PepemonChain} from "../../utils/providers";
-import {PepemonProviderContext} from "../../contexts";
-import {getBalance, getNativeBalance} from "../../utils";
-import {getPpdexAddress} from "../../pepemon/utils";
-import {Layer, useBridgeContracts} from "./useBridgeContracts";
+import { useCallback, useContext, useEffect, useState } from "react";
+import { BigNumber } from "../../pepemon";
+import { Goerli, PepemonChain } from "../../utils/providers";
+import { PepemonProviderContext } from "../../contexts";
+import { getBalance, getNativeBalance } from "../../utils";
+import { getPpdexAddress } from "../../pepemon/utils";
+import { Layer, useBridgeContracts } from "./useBridgeContracts";
 
 // import {crossChainMessenger} from "../utils/bridgeContract";
 
 interface BridgeBalance {
-    nativeBalance: BigNumber;
-    ppblzBalance: BigNumber;
-    ppdexBalance: BigNumber;
-    isActivate: boolean;
+  nativeBalance: BigNumber;
+  ppblzBalance: BigNumber;
+  ppdexBalance: BigNumber;
+  isActivate: boolean;
 }
 
 interface BridgeBalances {
-    Layer1: BridgeBalance
-    Layer2: BridgeBalance
-    depositFunds: (amount: BigNumber) => void
-    withdrawFunds: (amount: BigNumber) => void
+  Layer1: BridgeBalance;
+  Layer2: BridgeBalance;
+  depositFunds: (amount: BigNumber) => void;
+  withdrawFunds: (amount: BigNumber) => void;
 }
 
 export const useBridge = (): BridgeBalances => {
-    const [pepemon] = useContext(PepemonProviderContext);
+  const [pepemon] = useContext(PepemonProviderContext);
 
-    const [layer1NativeBalance, setLayer1NativeBalance] = useState(new BigNumber(0))
-    const [layer2NativeBalance, setLayer2NativeBalance] = useState(new BigNumber(0))
-    const [layer1PpdexBalance, setLayer1PpdexBalance] = useState(new BigNumber(0))
-    const [layer2PpdexBalance, setLayer2PpdexBalance] = useState(new BigNumber(0))
-    const [layer1PpblzBalance, setLayer1PpblzBalance] = useState(new BigNumber(0))
-    const [layer2PpblzBalance, setLayer2PpblzBalance] = useState(new BigNumber(0))
-    const {messenger, activeLayer} = useBridgeContracts()
+  const [layer1NativeBalance, setLayer1NativeBalance] = useState(
+    new BigNumber(0)
+  );
+  const [layer2NativeBalance, setLayer2NativeBalance] = useState(
+    new BigNumber(0)
+  );
+  const [layer1PpdexBalance, setLayer1PpdexBalance] = useState(
+    new BigNumber(0)
+  );
+  const [layer2PpdexBalance, setLayer2PpdexBalance] = useState(
+    new BigNumber(0)
+  );
+  const [layer1PpblzBalance, setLayer1PpblzBalance] = useState(
+    new BigNumber(0)
+  );
+  const [layer2PpblzBalance, setLayer2PpblzBalance] = useState(
+    new BigNumber(0)
+  );
+  const { messenger, activeLayer } = useBridgeContracts();
 
-    const {account} = pepemon;
+  const { account } = pepemon;
 
-    useEffect(() => {
-        const fetchBalance = async () => {
-            getNativeBalance(Goerli, account).then(balance => {
-                setLayer1NativeBalance(new BigNumber(balance))
-            })
-            getNativeBalance(PepemonChain, account).then(balance => {
-                setLayer2NativeBalance(new BigNumber(balance))
-            })
+  useEffect(() => {
+    const fetchBalance = async () => {
+      getNativeBalance(Goerli, account).then((balance) => {
+        setLayer1NativeBalance(new BigNumber(balance));
+      });
+      getNativeBalance(PepemonChain, account).then((balance) => {
+        setLayer2NativeBalance(new BigNumber(balance));
+      });
 
-            getBalance(Goerli, getPpdexAddress(), account).then(balance => {
-                setLayer1PpdexBalance(new BigNumber(balance))
-            })
+      getBalance(Goerli, getPpdexAddress(), account).then((balance) => {
+        setLayer1PpdexBalance(new BigNumber(balance));
+      });
+    };
 
-        }
+    fetchBalance();
+  }, [account]);
 
-        fetchBalance()
-    }, [account]);
+  const depositFunds = useCallback(
+    async (amount: BigNumber) => {
+      if (!messenger || activeLayer !== Layer.Layer1) {
+        return;
+      }
 
-    const depositFunds = useCallback(async (amount: BigNumber) => {
-        if (!messenger || activeLayer !== Layer.Layer1) {
-            return
-        }
+      console.log(amount.toString());
 
-        console.log(amount.toString())
+      const response = await messenger.depositETH(amount.toString());
+    },
+    [messenger]
+  );
 
-        const response = await messenger.depositETH(amount.toString())
-    }, [messenger])
+  const withdrawFunds = useCallback(
+    async (amount: BigNumber) => {
+      if (!messenger || activeLayer !== Layer.Layer2) {
+        return;
+      }
 
-    const withdrawFunds = useCallback(async (amount: BigNumber) => {
-        if (!messenger || activeLayer !== Layer.Layer2) {
+      const response = await messenger.withdrawETH(amount.toString());
+    },
+    [messenger]
+  );
 
-            return
-        }
-
-        const response = await messenger.withdrawETH(amount.toString())
-    }, [messenger])
-
-    return {
-        Layer1: {
-            nativeBalance: layer1NativeBalance,
-            ppblzBalance: new BigNumber(0),
-            ppdexBalance: layer1PpdexBalance,
-            isActivate: activeLayer === Layer.Layer1
-        },
-        Layer2: {
-            nativeBalance: layer2NativeBalance,
-            ppblzBalance: new BigNumber(0),
-            ppdexBalance: new BigNumber(0),
-            isActivate: activeLayer === Layer.Layer2
-        },
-        depositFunds: depositFunds,
-        withdrawFunds: withdrawFunds
-    }
-}
+  return {
+    Layer1: {
+      nativeBalance: layer1NativeBalance,
+      ppblzBalance: new BigNumber(0),
+      ppdexBalance: layer1PpdexBalance,
+      isActivate: activeLayer === Layer.Layer1,
+    },
+    Layer2: {
+      nativeBalance: layer2NativeBalance,
+      ppblzBalance: new BigNumber(0),
+      ppdexBalance: new BigNumber(0),
+      isActivate: activeLayer === Layer.Layer2,
+    },
+    depositFunds: depositFunds,
+    withdrawFunds: withdrawFunds,
+  };
+};

--- a/packages/app/src/hooks/pepe_bridge/useBridgeContracts.ts
+++ b/packages/app/src/hooks/pepe_bridge/useBridgeContracts.ts
@@ -1,64 +1,66 @@
-import {CrossChainMessenger} from "@eth-optimism/sdk";
-import {PepemonChain, Goerli} from "../../utils/providers";
-import {useContext, useEffect, useState} from "react";
-import {getOptimismConfiguration} from "@conduitxyz/sdk";
-import {PepemonProviderContext} from "../../contexts";
-import {chainIds} from "../../constants/chains";
+import { CrossChainMessenger } from "@eth-optimism/sdk";
+import { PepemonChain, Goerli } from "../../utils/providers";
+import { useContext, useEffect, useState } from "react";
+import { getOptimismConfiguration } from "@conduitxyz/sdk";
+import { PepemonProviderContext } from "../../contexts";
+import { chainIds } from "../../constants/chains";
 
 export enum Layer {
-    Layer1 = "Layer1",
-    Layer2 = "Layer2",
-    Unknown = "Unknown"
+  Layer1 = "Layer1",
+  Layer2 = "Layer2",
+  Unknown = "Unknown",
 }
 
 export const useBridgeContracts = () => {
-    const [pepemon] = useContext(PepemonProviderContext);
+  const [pepemon] = useContext(PepemonProviderContext);
 
-    const {provider, account} = pepemon;
+  const { provider, account } = pepemon;
 
-    const [messenger, setMessenger] = useState<CrossChainMessenger>()
-    const [activeLayer, setActiveLayer] = useState<Layer>(Layer.Unknown)
+  const [messenger, setMessenger] = useState<CrossChainMessenger>();
+  const [activeLayer, setActiveLayer] = useState<Layer>(Layer.Unknown);
 
-    useEffect(() => {
-        const fetchChainMessenger = async () => {
+  useEffect(() => {
+    const fetchChainMessenger = async () => {
+      const config = await getOptimismConfiguration(
+        "conduit:pepechain-testnet-8uk55qlld4"
+      );
 
-            const config = await getOptimismConfiguration("conduit:pepechain-testnet-8uk55qlld4");
+      if (provider.network.chainId === chainIds["goerli"]?.chainId) {
+        console.log("l1");
+        // @ts-expect-error -- web3/ethers type mismatch
+        config.l1SignerOrProvider = provider.getSigner();
+        // @ts-expect-error -- web3/ethers type mismatch
+        config.l2SignerOrProvider = PepemonChain;
+        setActiveLayer(Layer.Layer1);
+      } else if (
+        provider.network.chainId === chainIds["pepemon_testnet"]?.chainId
+      ) {
+        console.log("l2");
 
-            if (provider.network.chainId === chainIds["goerli"]?.chainId) {
-                console.log('l1')
-                // @ts-ignore
-                config.l1SignerOrProvider = provider.getSigner()
-                // @ts-ignore
-                config.l2SignerOrProvider = PepemonChain;
-                setActiveLayer(Layer.Layer1)
-            } else if (provider.network.chainId === chainIds["pepemon_testnet"]?.chainId) {
-                console.log('l2')
+        // @ts-expect-error -- web3/ethers type mismatch
+        config.l1SignerOrProvider = Goerli;
+        // @ts-expect-error -- web3/ethers type mismatch
+        config.l2SignerOrProvider = provider.getSigner();
+        setActiveLayer(Layer.Layer2);
+      } else {
+        console.log("invalid chain");
+        setActiveLayer(Layer.Unknown);
+        return;
+      }
 
-                // @ts-ignore
-                config.l1SignerOrProvider = Goerli;
-                // @ts-ignore
-                config.l2SignerOrProvider = provider.getSigner();
-                setActiveLayer(Layer.Layer2)
-            } else {
-                console.log('invalid chain')
-                setActiveLayer(Layer.Unknown)
-                return
-            }
+      // @ts-expect-error -- web3/ethers type mismatch
+      const newMessenger = new CrossChainMessenger(config);
 
-            // @ts-ignore
-            let newMessenger = new CrossChainMessenger(config)
+      setMessenger(newMessenger);
+    };
 
-            // @ts-ignore
-            setMessenger(newMessenger)
-        }
-
-        if(provider && account) {
-            fetchChainMessenger()
-        }
-    }, [provider, account])
-
-    return {
-        messenger: messenger,
-        activeLayer: activeLayer
+    if (provider && account) {
+      fetchChainMessenger();
     }
-}
+  }, [provider, account]);
+
+  return {
+    messenger: messenger,
+    activeLayer: activeLayer,
+  };
+};

--- a/packages/app/src/hooks/useAccountMerkle.ts
+++ b/packages/app/src/hooks/useAccountMerkle.ts
@@ -1,63 +1,61 @@
-import {useEffect, useState} from 'react';
-import {correctChainIsLoaded} from '../utils/network';
-import usePepemon from './usePepemon';
+import { useEffect, useState } from "react";
+import { correctChainIsLoaded } from "../utils/network";
+import usePepemon from "./usePepemon";
 
-const part1start = '0x0000000000000000000000000000000000000000'
-const part2start = '0x45a69256fd9DB26A38361BfF0bDe662Fc0C84093'
-const part3start = '0x8a52055CFa76BEF08A71124f2E97E0Aff0657dE3'
-const part4start = '0xa891CB0e55C0D848317788D116Ffc992D3FE879c'
+const part1start = "0x0000000000000000000000000000000000000000";
+const part2start = "0x45a69256fd9DB26A38361BfF0bDe662Fc0C84093";
+const part3start = "0x8a52055CFa76BEF08A71124f2E97E0Aff0657dE3";
+const part4start = "0xa891CB0e55C0D848317788D116Ffc992D3FE879c";
 
 const useAccountMerkle = (account: string) => {
-    const [response, setResponse] = useState<any>(null);
-    const [isFetching, setIsFetching] = useState<boolean>(false);
-    const pepemon = usePepemon();
-    // @ts-ignore
-    const selectPart = (account: string) => {
-        if (account >= part4start) {
-            return 4;
-        }
-        if (account >= part3start) {
-            return 3;
-        }
-        if (account >= part2start) {
-            return 2;
-        }
-        if (account >= part1start) {
-            return 1;
-        }
+  const [response, setResponse] = useState<any>(null);
+  const [isFetching, setIsFetching] = useState<boolean>(false);
+  const pepemon = usePepemon();
+  const selectPart = (account: string) => {
+    if (account >= part4start) {
+      return 4;
     }
-    const fetchData = async (part: number, account: string) => {
-        setIsFetching(true)
-        const endpoint = `https://raw.githubusercontent.com/ritaritaritarita/bscdrop/main/split${part}.json`
-        const response = await fetch(
-            `${endpoint}`,
-            { method: 'GET'},
-        );
+    if (account >= part3start) {
+      return 3;
+    }
+    if (account >= part2start) {
+      return 2;
+    }
+    if (account >= part1start) {
+      return 1;
+    }
+  };
+  const fetchData = async (part: number, account: string) => {
+    setIsFetching(true);
+    const endpoint = `https://raw.githubusercontent.com/ritaritaritarita/bscdrop/main/split${part}.json`;
+    const response = await fetch(`${endpoint}`, { method: "GET" });
 
-        if (!response.ok) {
-            setIsFetching(false);
-            return null;
-        }
-
-        const json = await response.json();
-        const merkle = json[account];
-        setIsFetching( false);
-        return merkle;
+    if (!response.ok) {
+      setIsFetching(false);
+      return null;
     }
 
-    useEffect(() => {
-        correctChainIsLoaded(pepemon).then((correct) => {
-            if (correct) {
-                if (!account) {
-                    return;
-                }
-                const part = selectPart(account);
-                fetchData(part, account).then(res => setResponse(res)).catch(err => console.error(err));
-            }
-        })
-    }, [account, pepemon])
+    const json = await response.json();
+    const merkle = json[account];
+    setIsFetching(false);
+    return merkle;
+  };
 
-    return { response, isFetching };
-}
+  useEffect(() => {
+    correctChainIsLoaded(pepemon).then((correct) => {
+      if (correct) {
+        if (!account) {
+          return;
+        }
+        const part = selectPart(account);
+        fetchData(part, account)
+          .then((res) => setResponse(res))
+          .catch((err) => console.error(err));
+      }
+    });
+  }, [account, pepemon]);
+
+  return { response, isFetching };
+};
 
 export default useAccountMerkle;

--- a/packages/app/src/hooks/useAllowance.ts
+++ b/packages/app/src/hooks/useAllowance.ts
@@ -1,39 +1,37 @@
-import { useCallback, useEffect, useState } from 'react'
-import BigNumber from 'bignumber.js'
-import usePepemon from './usePepemon'
-import { Contract } from 'web3-eth-contract'
-import {getAllowance} from '../utils/erc20'
-import { getPpdexContract } from '../pepemon/utils'
-import {correctChainIsLoaded} from '../utils/network';
+import { useCallback, useEffect, useState } from "react";
+import BigNumber from "bignumber.js";
+import usePepemon from "./usePepemon";
+import { Contract } from "web3-eth-contract";
+import { getAllowance } from "../utils/erc20";
+import { getPpdexContract } from "../pepemon/utils";
+import { correctChainIsLoaded } from "../utils/network";
 
 const useAllowance = (lpContract: Contract, allowedContract?: Contract) => {
-  const [allowance, setAllowance] = useState(new BigNumber(0))
-  const { account }: { account: string } = usePepemon()
-  const pepemon = usePepemon()
-  const allowContract = allowedContract ? allowedContract : getPpdexContract(pepemon)
+  const [allowance, setAllowance] = useState(new BigNumber(0));
+  const { account }: { account: string } = usePepemon();
+  const pepemon = usePepemon();
+  const allowContract = allowedContract
+    ? allowedContract
+    : getPpdexContract(pepemon);
 
   const fetchAllowance = useCallback(async () => {
-    const allowance = await getAllowance(
-      allowContract,
-      lpContract,
-      account,
-    )
-    setAllowance(new BigNumber(allowance))
-  }, [account, allowContract, lpContract])
+    const allowance = await getAllowance(allowContract, lpContract, account);
+    setAllowance(new BigNumber(allowance));
+  }, [account, allowContract, lpContract]);
 
   useEffect(() => {
     correctChainIsLoaded(pepemon).then((correct) => {
       if (correct) {
         if (account && allowContract && lpContract) {
-          fetchAllowance()
+          fetchAllowance();
         }
-        let refreshInterval = setInterval(fetchAllowance, 30000)
-        return () => clearInterval(refreshInterval)
+        const refreshInterval = setInterval(fetchAllowance, 30000);
+        return () => clearInterval(refreshInterval);
       }
     });
-  }, [pepemon, account, allowContract, lpContract, fetchAllowance])
+  }, [pepemon, account, allowContract, lpContract, fetchAllowance]);
 
-  return allowance
-}
+  return allowance;
+};
 
-export default useAllowance
+export default useAllowance;

--- a/packages/app/src/hooks/useApprove.ts
+++ b/packages/app/src/hooks/useApprove.ts
@@ -1,13 +1,14 @@
-import {useCallback, useState} from 'react'
-import usePepemon from './usePepemon'
-import { Contract } from 'web3-eth-contract'
-import { approve, getPpdexContract } from '../pepemon/utils'
+import { useCallback, useState } from "react";
+import usePepemon from "./usePepemon";
+import { Contract } from "web3-eth-contract";
+import { approve, getPpdexContract } from "../pepemon/utils";
 
 const useApprove = (spenderContract: Contract, approvalContract?: Contract) => {
   const [isApproving, setIsApproving] = useState<boolean>(false);
-  const pepemon = usePepemon()
-  // @ts-ignore
-  const approveContract = approvalContract ? approvalContract : getPpdexContract(pepemon)
+  const pepemon = usePepemon();
+  const approveContract = approvalContract
+    ? approvalContract
+    : getPpdexContract(pepemon);
 
   const handleApprove = useCallback(async () => {
     try {
@@ -16,17 +17,21 @@ const useApprove = (spenderContract: Contract, approvalContract?: Contract) => {
       }
 
       setIsApproving(true);
-      const tx = await approve(pepemon.provider, approveContract, spenderContract)
+      const tx = await approve(
+        pepemon.provider,
+        approveContract,
+        spenderContract
+      );
 
-      setIsApproving(false)
-      return tx
+      setIsApproving(false);
+      return tx;
     } catch (e) {
-      setIsApproving(false)
-      return false
+      setIsApproving(false);
+      return false;
     }
-}, [spenderContract, approveContract, pepemon.provider])
+  }, [spenderContract, approveContract, pepemon.provider]);
 
-  return { onApprove: handleApprove, isApproving }
-}
+  return { onApprove: handleApprove, isApproving };
+};
 
-export default useApprove
+export default useApprove;

--- a/packages/app/src/hooks/useBlock.ts
+++ b/packages/app/src/hooks/useBlock.ts
@@ -1,29 +1,27 @@
-import { useEffect, useState } from 'react'
-import usePepemon from './usePepemon';
+import { useEffect, useState } from "react";
+import usePepemon from "./usePepemon";
 
 const useBlock = () => {
-  const [block, setBlock] = useState(0)
-  const { provider }: { web3: any, provider: any } = usePepemon()
+  const [block, setBlock] = useState(0);
+  const { provider }: { web3: any; provider: any } = usePepemon();
 
   useEffect(() => {
     let interval: any;
-    if (!provider) return
+    if (!provider) return;
 
     const setBlockNumber = async () => {
       const latestBlockNumber = await provider.getBlockNumber();
-      if (block !== latestBlockNumber)
-      setBlock(latestBlockNumber);
-    }
+      if (block !== latestBlockNumber) setBlock(latestBlockNumber);
+    };
     setBlockNumber().then(() => {
       interval = setInterval(async () => {
-        await setBlockNumber()
-      }, 10000)
-    })
-    return () => clearInterval(interval)
+        await setBlockNumber();
+      }, 10000);
+    });
+    return () => clearInterval(interval);
+  }, [provider, block]);
 
-  }, [provider, block])
+  return block;
+};
 
-  return block
-}
-
-export default useBlock
+export default useBlock;

--- a/packages/app/src/hooks/useCardsApi.ts
+++ b/packages/app/src/hooks/useCardsApi.ts
@@ -1,89 +1,90 @@
-import {useEffect, useState} from 'react';
-import usePepemon from './usePepemon';
+import { useEffect, useState } from "react";
+import usePepemon from "./usePepemon";
 
 export interface CardTrait {
-	trait_type: string,
-	value: string,
+  trait_type: string;
+  value: string;
 }
 export interface CardMetadata {
-	tokenId: number,
-	pool: any,
-	external_url: string,
-	image: string,
-	name: string,
-	description: string,
-	attributes: CardTrait[],
+  tokenId: number;
+  pool: any;
+  external_url: string;
+  image: string;
+  name: string;
+  description: string;
+  attributes: CardTrait[];
 }
 
 export const useCardsMetadata = (tokenIds: number[]) => {
-	const [cards, setCards] = useState<any[]>([]);
-	const apiUri = new Map([
-		[1, `/metadata/cards/`],
-		[4, `/metadata/cards/`],
-		[56, `/metadata/cards/bsc/`],
-		[137, `/metadata/cards/matic/`],
-	])
-	const pepemon = usePepemon();
+  const [cards, setCards] = useState<any[]>([]);
+  const apiUri = new Map([
+    [1, `/metadata/cards/`],
+    [4, `/metadata/cards/`],
+    [56, `/metadata/cards/bsc/`],
+    [137, `/metadata/cards/matic/`],
+  ]);
+  const pepemon = usePepemon();
 
-	useEffect(() => {
-		const fetchCardInfo = async (tokenId: number) => {
-			const chainId = pepemon?.chainId || 1;
-			const response = await fetch(
-				`${apiUri.get(chainId)}${tokenId}`,
-				{ method: 'GET'},
-			)
-			if (!response.ok) {
-				return {tokenId, status: 'failed'};
-			}
-			const data = await response.json();
-			if (data.image) data.image = data.image.replace('https://pepemon.world/', '/');
-			return {tokenId, ...data};
-		}
+  useEffect(() => {
+    const fetchCardInfo = async (tokenId: number) => {
+      const chainId = pepemon?.chainId || 1;
+      const response = await fetch(`${apiUri.get(chainId)}${tokenId}`, {
+        method: "GET",
+      });
+      if (!response.ok) {
+        return { tokenId, status: "failed" };
+      }
+      const data = await response.json();
+      if (data.image)
+        data.image = data.image.replace("https://pepemon.world/", "/");
+      return { tokenId, ...data };
+    };
 
-		Promise.all(tokenIds.map((tokenId) => fetchCardInfo(tokenId)))
-			.then((responses) => {
-				// @ts-ignore
-				setCards(responses.filter(response => {
-					return response !== undefined
-				}));
-			})
-	}, [tokenIds, pepemon.chainId])
+    Promise.all(tokenIds.map((tokenId) => fetchCardInfo(tokenId))).then(
+      (responses) => {
+        setCards(
+          responses.filter((response) => {
+            return response !== undefined;
+          })
+        );
+      }
+    );
+  }, [tokenIds, pepemon.chainId]);
 
-	return cards;
-}
+  return cards;
+};
 
 export const getCardMeta = async (tokenId: number, pepemon: any) => {
-	const apiUri = new Map([
-		[1, `/metadata/cards/`],
-		[4, `/metadata/cards/`],
-		[56, `/metadata/cards/bsc/`],
-		[137, `/metadata/cards/matic/`],
-	])
+  const apiUri = new Map([
+    [1, `/metadata/cards/`],
+    [4, `/metadata/cards/`],
+    [56, `/metadata/cards/bsc/`],
+    [137, `/metadata/cards/matic/`],
+  ]);
 
-	const fetchCardInfo = async (tokenId: number) => {
-		const chainId = pepemon?.chainId || 1;
-		const response = await fetch(
-			`${apiUri.get(chainId)}${tokenId}`,
-			{ method: 'GET'},
-		)
-		if (!response.ok) {
-			return {tokenId, status: 'failed'};
-		}
-		const data = await response.json();
-		if (data.image) data.image = data.image.replace('https://pepemon.world/', '/');
-		return {tokenId, ...data};
-	}
+  const fetchCardInfo = async (tokenId: number) => {
+    const chainId = pepemon?.chainId || 1;
+    const response = await fetch(`${apiUri.get(chainId)}${tokenId}`, {
+      method: "GET",
+    });
+    if (!response.ok) {
+      return { tokenId, status: "failed" };
+    }
+    const data = await response.json();
+    if (data.image)
+      data.image = data.image.replace("https://pepemon.world/", "/");
+    return { tokenId, ...data };
+  };
 
-	return await fetchCardInfo(tokenId);
+  return await fetchCardInfo(tokenId);
 
-
-	// Promise.all(tokenIds.map((tokenId) => fetchCardInfo(tokenId)))
-	//     .then((responses) => {
-	//         // @ts-ignore
-	//         setCards(responses.filter(response => {
-	//             return response !== undefined
-	//         }));
-	//     })
-}
+  // Promise.all(tokenIds.map((tokenId) => fetchCardInfo(tokenId)))
+  //     .then((responses) => {
+  //         // @ts-expect-error -- web3/ethers type mismatch
+  //         setCards(responses.filter(response => {
+  //             return response !== undefined
+  //         }));
+  //     })
+};
 
 export default useCardsMetadata;

--- a/packages/app/src/hooks/useCardsFactoryData.ts
+++ b/packages/app/src/hooks/useCardsFactoryData.ts
@@ -1,116 +1,140 @@
-import {useCallback, useEffect, useState} from 'react'
-import {getBalanceOfBatch, getMaxSupply, getTotalSupply} from '../utils/erc1155';
-import usePepemon from './usePepemon';
-import {getPepemonFactoryContract} from '../pepemon/utils';
-import {correctChainIsLoaded} from '../utils/network';
+import { useCallback, useEffect, useState } from "react";
+import {
+  getBalanceOfBatch,
+  getMaxSupply,
+  getTotalSupply,
+} from "../utils/erc1155";
+import usePepemon from "./usePepemon";
+import { getPepemonFactoryContract } from "../pepemon/utils";
+import { correctChainIsLoaded } from "../utils/network";
 import { JsonRpcProvider } from "@ethersproject/providers";
 import { Contract } from "@ethersproject/contracts";
-import PepemonFactoryAbi from '../pepemon/lib/abi/pepemon_factory.json';
+import PepemonFactoryAbi from "../pepemon/lib/abi/pepemon_factory.json";
 
 const PUBLIC_ETH_RPC = "https://0xrpc.io/eth";
 const FACTORY_ADDRESS_MAINNET = "0xCB6768a968440187157Cfe13b67Cac82ef6cc5a4";
 
 export interface CardBalances {
-    tokenId: number,
-    userBalance: string,
-    maxSupply: string,
-    totalSupply: string,
+  tokenId: number;
+  userBalance: string;
+  maxSupply: string;
+  totalSupply: string;
 }
 
 const setIntervalAsync = (fn: any, ms: any) => {
-    fn().then(() => {
-        setTimeout(() => setIntervalAsync(fn, ms), ms);
-    });
+  fn().then(() => {
+    setTimeout(() => setIntervalAsync(fn, ms), ms);
+  });
 };
 
 const useCardsFactoryData = (tokenIds: number[], transactions: number) => {
-    const [cardsBalance, setCardsBalance] = useState([])
-    const {
-        account,
-        provider,
-        chainId,
-    }: { account: string; provider: any, chainId: number } = usePepemon()
-    const pepemon = usePepemon();
+  const [cardsBalance, setCardsBalance] = useState([]);
+  const {
+    account,
+    provider,
+    chainId,
+  }: { account: string; provider: any; chainId: number } = usePepemon();
+  const pepemon = usePepemon();
 
+  const fetchCardBalances = useCallback(
+    async (factoryContract) => {
+      const batches = tokenIds.reduce((resultArray, item, index) => {
+        const chunkIndex = Math.floor(index / 10);
 
-    const fetchCardBalances = useCallback(async (factoryContract) => {
-        const batches = tokenIds.reduce((resultArray, item, index) => {
-            const chunkIndex = Math.floor(index / 10)
-
-            if(!resultArray[chunkIndex]) {
-                resultArray[chunkIndex] = [] // start a new chunk
-            }
-
-            resultArray[chunkIndex].push(item)
-
-            return resultArray
-        }, [])
-
-        let runBatch = 0;
-        let userBalances: any = []
-        await new Promise<void>((resolve) => {
-            setIntervalAsync(async () => {
-                if (runBatch >= batches.length) {
-                    return resolve()
-                }
-
-                const batchBalances = await getBalanceOfBatch(factoryContract, account, batches[runBatch]);
-                userBalances = [...userBalances, ...batchBalances];
-
-                runBatch += 1
-            }, 100);
-        });
-
-        // const userBalances = await getBalanceOfBatch(factoryContract, account, tokenIds);
-        return Promise.all(tokenIds.map(async (tokenId, index) => {
-            return {
-                tokenId,
-                userBalance: userBalances && userBalances[index],
-                maxSupply: await getMaxSupply(factoryContract, tokenId),
-                totalSupply: await getTotalSupply(factoryContract, tokenId),
-            }
-        }))
-    }, [tokenIds, account])
-
-    useEffect(() => {
-        if (provider && tokenIds.length) {
-            correctChainIsLoaded(pepemon).then((correct) => {
-                if (correct) {
-                    const factoryContract = getPepemonFactoryContract(pepemon);
-                    fetchCardBalances(factoryContract).then((balances) => setCardsBalance(balances))
-                }
-            })
+        if (!resultArray[chunkIndex]) {
+          resultArray[chunkIndex] = []; // start a new chunk
         }
-    }, [provider, pepemon, tokenIds, transactions, chainId, fetchCardBalances])
 
-    return cardsBalance
-}
+        resultArray[chunkIndex].push(item);
 
-export const getCardFactoryData = async (tokenId: number, pepemon: any, transactions: number) => {
-    const account = pepemon?.account || null;
+        return resultArray;
+      }, []);
 
-    let factoryContract: any;
-    const correct = await correctChainIsLoaded(pepemon);
-    if (correct) {
-        factoryContract = getPepemonFactoryContract(pepemon);
-    } else {
-        // No wallet or wrong chain — use public RPC for read-only supply data
-        const readProvider = new JsonRpcProvider(PUBLIC_ETH_RPC);
-        factoryContract = new Contract(FACTORY_ADDRESS_MAINNET, PepemonFactoryAbi, readProvider);
+      let runBatch = 0;
+      let userBalances: any = [];
+      await new Promise<void>((resolve) => {
+        setIntervalAsync(async () => {
+          if (runBatch >= batches.length) {
+            return resolve();
+          }
+
+          const batchBalances = await getBalanceOfBatch(
+            factoryContract,
+            account,
+            batches[runBatch]
+          );
+          userBalances = [...userBalances, ...batchBalances];
+
+          runBatch += 1;
+        }, 100);
+      });
+
+      // const userBalances = await getBalanceOfBatch(factoryContract, account, tokenIds);
+      return Promise.all(
+        tokenIds.map(async (tokenId, index) => {
+          return {
+            tokenId,
+            userBalance: userBalances && userBalances[index],
+            maxSupply: await getMaxSupply(factoryContract, tokenId),
+            totalSupply: await getTotalSupply(factoryContract, tokenId),
+          };
+        })
+      );
+    },
+    [tokenIds, account]
+  );
+
+  useEffect(() => {
+    if (provider && tokenIds.length) {
+      correctChainIsLoaded(pepemon).then((correct) => {
+        if (correct) {
+          const factoryContract = getPepemonFactoryContract(pepemon);
+          fetchCardBalances(factoryContract).then((balances) =>
+            setCardsBalance(balances)
+          );
+        }
+      });
     }
+  }, [provider, pepemon, tokenIds, transactions, chainId, fetchCardBalances]);
 
-    if (!factoryContract) return [];
+  return cardsBalance;
+};
 
-    const userBalance = account
-        ? await getBalanceOfBatch(factoryContract, account, [tokenId])
-        : null;
+export const getCardFactoryData = async (
+  tokenId: number,
+  pepemon: any,
+  transactions: number
+) => {
+  const account = pepemon?.account || null;
 
-    return [{
-        tokenId,
-        userBalance: userBalance?.[0] ?? null,
-        maxSupply: await getMaxSupply(factoryContract, tokenId),
-        totalSupply: await getTotalSupply(factoryContract, tokenId),
-    }];
-}
+  let factoryContract: any;
+  const correct = await correctChainIsLoaded(pepemon);
+  if (correct) {
+    factoryContract = getPepemonFactoryContract(pepemon);
+  } else {
+    // No wallet or wrong chain — use public RPC for read-only supply data
+    const readProvider = new JsonRpcProvider(PUBLIC_ETH_RPC);
+    factoryContract = new Contract(
+      FACTORY_ADDRESS_MAINNET,
+      PepemonFactoryAbi,
+      readProvider
+    );
+  }
 
-export default useCardsFactoryData
+  if (!factoryContract) return [];
+
+  const userBalance = account
+    ? await getBalanceOfBatch(factoryContract, account, [tokenId])
+    : null;
+
+  return [
+    {
+      tokenId,
+      userBalance: userBalance?.[0] ?? null,
+      maxSupply: await getMaxSupply(factoryContract, tokenId),
+      totalSupply: await getTotalSupply(factoryContract, tokenId),
+    },
+  ];
+};
+
+export default useCardsFactoryData;

--- a/packages/app/src/hooks/useCardsStorePrices.ts
+++ b/packages/app/src/hooks/useCardsStorePrices.ts
@@ -1,53 +1,71 @@
-import {useCallback, useEffect, useState} from 'react'
-import BigNumber from 'bignumber.js';
-import { getCardPrice, getPepemonPromoStoreContract, getPepemonStoreContract } from '../pepemon/utils';
-import usePepemon from './usePepemon';
-import { correctChainIsLoaded } from '../utils/network';
+import { useCallback, useEffect, useState } from "react";
+import BigNumber from "bignumber.js";
+import {
+  getCardPrice,
+  getPepemonPromoStoreContract,
+  getPepemonStoreContract,
+} from "../pepemon/utils";
+import usePepemon from "./usePepemon";
+import { correctChainIsLoaded } from "../utils/network";
 
 export interface CardPrice {
-    tokenId: number,
-    price: BigNumber,
+  tokenId: number;
+  price: BigNumber;
 }
 
 const useCardsStorePrices = (tokenIds: number[], promo = false) => {
-    const [cardsPrices, setCardsPrices] = useState([])
-    const { provider }: { provider: any } = usePepemon()
-    const pepemon = usePepemon();
+  const [cardsPrices, setCardsPrices] = useState([]);
+  const { provider }: { provider: any } = usePepemon();
+  const pepemon = usePepemon();
 
-    const fetchCardsPrices = useCallback(async (storeContract: any) => {
-        return await Promise.all(tokenIds.map(async (tokenId, index) => {
-            return {
-                tokenId,
-                price: await getCardPrice(storeContract, tokenId)
-            }
-        }))
-    }, [tokenIds])
+  const fetchCardsPrices = useCallback(
+    async (storeContract: any) => {
+      return await Promise.all(
+        tokenIds.map(async (tokenId, index) => {
+          return {
+            tokenId,
+            price: await getCardPrice(storeContract, tokenId),
+          };
+        })
+      );
+    },
+    [tokenIds]
+  );
 
-    useEffect(() => {
-
-        if (pepemon && provider && tokenIds.length) {
-            correctChainIsLoaded(pepemon).then((correct) => {
-                if (correct) {
-                    const storeContract = promo ? getPepemonPromoStoreContract(pepemon) : getPepemonStoreContract(pepemon)
-                    fetchCardsPrices(storeContract).then((prices) => setCardsPrices(prices))
-                }
-            });
+  useEffect(() => {
+    if (pepemon && provider && tokenIds.length) {
+      correctChainIsLoaded(pepemon).then((correct) => {
+        if (correct) {
+          const storeContract = promo
+            ? getPepemonPromoStoreContract(pepemon)
+            : getPepemonStoreContract(pepemon);
+          fetchCardsPrices(storeContract).then((prices) =>
+            setCardsPrices(prices)
+          );
         }
-    }, [pepemon, provider, tokenIds, fetchCardsPrices, promo])
-
-    return cardsPrices
-}
-
-export const getCardStorePrices = async (tokenId: number, pepemon: any, promo = false) => {
-	const correct = await correctChainIsLoaded(pepemon);
-    if (correct) {
-        const storeContract = promo ? getPepemonPromoStoreContract(pepemon) : getPepemonStoreContract(pepemon);
-
-        return {
-			tokenId,
-			price: await getCardPrice(storeContract, tokenId)
-		};
+      });
     }
-}
+  }, [pepemon, provider, tokenIds, fetchCardsPrices, promo]);
 
-export default useCardsStorePrices
+  return cardsPrices;
+};
+
+export const getCardStorePrices = async (
+  tokenId: number,
+  pepemon: any,
+  promo = false
+) => {
+  const correct = await correctChainIsLoaded(pepemon);
+  if (correct) {
+    const storeContract = promo
+      ? getPepemonPromoStoreContract(pepemon)
+      : getPepemonStoreContract(pepemon);
+
+    return {
+      tokenId,
+      price: await getCardPrice(storeContract, tokenId),
+    };
+  }
+};
+
+export default useCardsStorePrices;

--- a/packages/app/src/hooks/useClaimBoosterPack.ts
+++ b/packages/app/src/hooks/useClaimBoosterPack.ts
@@ -1,88 +1,117 @@
-import { useState, useCallback } from 'react';
-import { Contract } from '@ethersproject/contracts';
-import usePepemon from './usePepemon';
-import FaucetAbi from '../contracts/src/abis/boosterPackFaucet.json';
-import { OnchainBoosterpackConfig } from '../constants/boosterpacks';
+import { useState, useCallback } from "react";
+import { Contract } from "@ethersproject/contracts";
+import usePepemon from "./usePepemon";
+import FaucetAbi from "../contracts/src/abis/boosterPackFaucet.json";
+import { OnchainBoosterpackConfig } from "../constants/boosterpacks";
 
 export interface ReceivedCard {
   id: number;
   amount: number;
 }
 
-export type ClaimPhase = 'idle' | 'wallet-pending' | 'video-playing' | 'revealing';
+export type ClaimPhase =
+  | "idle"
+  | "wallet-pending"
+  | "video-playing"
+  | "revealing";
 
-const TRANSFER_SINGLE = '0xc3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7aacaa2d0f62';
+const TRANSFER_SINGLE =
+  "0xc3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7aacaa2d0f62";
 
-function parseCards(receipt: any, userAddress: string, faucet: string, factory: string): ReceivedCard[] {
+function parseCards(
+  receipt: any,
+  userAddress: string,
+  faucet: string,
+  factory: string
+): ReceivedCard[] {
   return receipt.logs
     .filter((log: any) => {
       if (log.address.toLowerCase() !== factory.toLowerCase()) return false;
       if (log.topics[0] !== TRANSFER_SINGLE) return false;
-      const from = '0x' + log.topics[2].slice(-40);
-      const to   = '0x' + log.topics[3].slice(-40);
-      return from.toLowerCase() === faucet.toLowerCase()
-          && to.toLowerCase()   === userAddress.toLowerCase();
+      const from = "0x" + log.topics[2].slice(-40);
+      const to = "0x" + log.topics[3].slice(-40);
+      return (
+        from.toLowerCase() === faucet.toLowerCase() &&
+        to.toLowerCase() === userAddress.toLowerCase()
+      );
     })
     .map((log: any) => {
       const hex = log.data.slice(2);
-      return { id: parseInt(hex.slice(0, 64), 16), amount: parseInt(hex.slice(64, 128), 16) };
+      return {
+        id: parseInt(hex.slice(0, 64), 16),
+        amount: parseInt(hex.slice(64, 128), 16),
+      };
     });
 }
 
 // Merge duplicate card IDs by summing amounts
 function mergeCards(cards: ReceivedCard[]): ReceivedCard[] {
   const map = new Map<number, number>();
-  cards.forEach(c => map.set(c.id, (map.get(c.id) ?? 0) + c.amount));
+  cards.forEach((c) => map.set(c.id, (map.get(c.id) ?? 0) + c.amount));
   return Array.from(map.entries()).map(([id, amount]) => ({ id, amount }));
 }
 
 const useClaimBoosterPack = (config: OnchainBoosterpackConfig) => {
   const pepemon = usePepemon();
-  const [phase, setPhase]                = useState<ClaimPhase>('idle');
+  const [phase, setPhase] = useState<ClaimPhase>("idle");
   const [receivedCards, setReceivedCards] = useState<ReceivedCard[]>([]);
-  const [claimError, setClaimError]      = useState<string | null>(null);
-  const [packCount, setPackCount]        = useState(0); // how many packs are being opened
+  const [claimError, setClaimError] = useState<string | null>(null);
+  const [packCount, setPackCount] = useState(0); // how many packs are being opened
 
-  const onClaim = useCallback(async (quantity: number = 1) => {
-    if (!pepemon.provider) { setClaimError('No wallet connected'); return; }
-    if (pepemon.chainId !== config.chainId) { setClaimError(`Switch to chainId ${config.chainId}`); return; }
-
-    setClaimError(null);
-    setReceivedCards([]);
-    setPackCount(quantity);
-    setPhase('wallet-pending');
-
-    try {
-      const signer  = pepemon.provider.getSigner();
-      const faucet  = new Contract(config.faucetAddress, FaucetAbi, signer);
-      const userAddress = await signer.getAddress();
-
-      // Submit all N transactions (N wallet popups in sequence), collect tx objects
-      const txs: any[] = [];
-      for (let i = 0; i < quantity; i++) {
-        const tx = await faucet.claimAndReveal(config.packId, config.cardIds);
-        txs.push(tx);
-        // Start the video as soon as the first tx is submitted
-        if (i === 0) setPhase('video-playing');
+  const onClaim = useCallback(
+    async (quantity = 1) => {
+      if (!pepemon.provider) {
+        setClaimError("No wallet connected");
+        return;
+      }
+      if (pepemon.chainId !== config.chainId) {
+        setClaimError(`Switch to chainId ${config.chainId}`);
+        return;
       }
 
-      // Wait for all to confirm concurrently (video plays during this)
-      const receipts = await Promise.all(txs.map((tx: any) => tx.wait()));
+      setClaimError(null);
+      setReceivedCards([]);
+      setPackCount(quantity);
+      setPhase("wallet-pending");
 
-      // Parse all cards from all receipts, merge amounts
-      const all = receipts.flatMap((receipt: any) =>
-        parseCards(receipt, userAddress, config.faucetAddress, config.factoryAddress)
-      );
-      setReceivedCards(mergeCards(all));
-      setPhase('revealing');
-    } catch (e: any) {
-      setPhase('idle');
-      setClaimError(e?.reason || e?.message || 'Transaction failed');
-    }
-  }, [pepemon.provider, pepemon.chainId, config]);
+      try {
+        const signer = pepemon.provider.getSigner();
+        const faucet = new Contract(config.faucetAddress, FaucetAbi, signer);
+        const userAddress = await signer.getAddress();
+
+        // Submit all N transactions (N wallet popups in sequence), collect tx objects
+        const txs: any[] = [];
+        for (let i = 0; i < quantity; i++) {
+          const tx = await faucet.claimAndReveal(config.packId, config.cardIds);
+          txs.push(tx);
+          // Start the video as soon as the first tx is submitted
+          if (i === 0) setPhase("video-playing");
+        }
+
+        // Wait for all to confirm concurrently (video plays during this)
+        const receipts = await Promise.all(txs.map((tx: any) => tx.wait()));
+
+        // Parse all cards from all receipts, merge amounts
+        const all = receipts.flatMap((receipt: any) =>
+          parseCards(
+            receipt,
+            userAddress,
+            config.faucetAddress,
+            config.factoryAddress
+          )
+        );
+        setReceivedCards(mergeCards(all));
+        setPhase("revealing");
+      } catch (e: any) {
+        setPhase("idle");
+        setClaimError(e?.reason || e?.message || "Transaction failed");
+      }
+    },
+    [pepemon.provider, pepemon.chainId, config]
+  );
 
   const onDismiss = useCallback(() => {
-    setPhase('idle');
+    setPhase("idle");
     setReceivedCards([]);
     setPackCount(0);
   }, []);

--- a/packages/app/src/hooks/useClaimEvent.ts
+++ b/packages/app/src/hooks/useClaimEvent.ts
@@ -1,33 +1,29 @@
-import {useCallback, useState} from 'react'
+import { useCallback, useState } from "react";
 
-import usePepemon from './usePepemon'
+import usePepemon from "./usePepemon";
 
-
-import {getPepemonStakeContract, claimEvent} from '../pepemon/utils'
+import { getPepemonStakeContract, claimEvent } from "../pepemon/utils";
 
 const useClaimEvent = (eventId: number) => {
-    const [isClaiming, setIsClaiming] = useState<boolean>(false)
-    const pepemon = usePepemon()
+  const [isClaiming, setIsClaiming] = useState<boolean>(false);
+  const pepemon = usePepemon();
 
-    const handleClaimEvent = useCallback(
-        async () => {
-            try {
-                setIsClaiming(true);
-                await claimEvent(
-                    pepemon.provider,
-                    getPepemonStakeContract(pepemon),
-                    eventId,
-                )
-                setIsClaiming(false);
-            } catch(err) {
-                console.error(err);
-                setIsClaiming(false);
-            }
-        },
-        [eventId, pepemon],
-    )
+  const handleClaimEvent = useCallback(async () => {
+    try {
+      setIsClaiming(true);
+      await claimEvent(
+        pepemon.provider,
+        getPepemonStakeContract(pepemon),
+        eventId
+      );
+      setIsClaiming(false);
+    } catch (err) {
+      console.error(err);
+      setIsClaiming(false);
+    }
+  }, [eventId, pepemon]);
 
-    return { onClaimEvent: handleClaimEvent, isClaiming }
-}
+  return { onClaimEvent: handleClaimEvent, isClaiming };
+};
 
-export default useClaimEvent
+export default useClaimEvent;

--- a/packages/app/src/hooks/useClaimMerkle.ts
+++ b/packages/app/src/hooks/useClaimMerkle.ts
@@ -1,65 +1,73 @@
-import {useCallback, useState} from 'react'
-import usePepemon from './usePepemon'
-import { claimMerkle, getMerkleContract, getMerkleDegoContract, getMerklePpblzContract, getMerklePpdexContract, getMerkleDistributor } from '../pepemon/utils'
-import {Contract} from '@ethersproject/contracts';
+import { useCallback, useState } from "react";
+import usePepemon from "./usePepemon";
+import {
+  claimMerkle,
+  getMerkleContract,
+  getMerkleDegoContract,
+  getMerklePpblzContract,
+  getMerklePpdexContract,
+  getMerkleDistributor,
+} from "../pepemon/utils";
+import { Contract } from "@ethersproject/contracts";
 
 export interface Merkle {
-    account: string,
-    index: number,
-    amount: string|number,
-    proof: string[],
+  account: string;
+  index: number;
+  amount: string | number;
+  proof: string[];
 }
 
-const useClaimMerkle = (merkle: Merkle, merkleType?: 'ppblz' | 'ppdex' | 'univ2' | 'dego' | 'distributor', tokenId = null) => {
-    const [isClaiming, setIsClaiming] = useState<boolean>(false)
-    const { provider } = usePepemon()
-    const pepemon = usePepemon()
-    let contract: Contract;
+const useClaimMerkle = (
+  merkle: Merkle,
+  merkleType?: "ppblz" | "ppdex" | "univ2" | "dego" | "distributor",
+  tokenId = null
+) => {
+  const [isClaiming, setIsClaiming] = useState<boolean>(false);
+  const { provider } = usePepemon();
+  const pepemon = usePepemon();
+  let contract: Contract;
 
-    switch (merkleType) {
-        case 'ppblz':
-            contract = getMerklePpblzContract(pepemon);
-            break;
-        case 'ppdex':
-            contract = getMerklePpdexContract(pepemon);
-            break;
-        case 'dego':
-            contract = getMerkleDegoContract(pepemon);
-            break;
-        case 'distributor':
-            contract = getMerkleDistributor(pepemon);
-            break;
-        default:
-            contract = getMerkleContract(pepemon);
+  switch (merkleType) {
+    case "ppblz":
+      contract = getMerklePpblzContract(pepemon);
+      break;
+    case "ppdex":
+      contract = getMerklePpdexContract(pepemon);
+      break;
+    case "dego":
+      contract = getMerkleDegoContract(pepemon);
+      break;
+    case "distributor":
+      contract = getMerkleDistributor(pepemon);
+      break;
+    default:
+      contract = getMerkleContract(pepemon);
+  }
+
+  const handleClaimMerkle = useCallback(async () => {
+    if (!merkle) {
+      console.error("[useClaimMerkle] no merkle data");
+      return;
     }
+    try {
+      setIsClaiming(true);
+      await claimMerkle(
+        provider,
+        contract,
+        merkle.index,
+        merkle.account,
+        merkle.amount,
+        merkle.proof,
+        tokenId && tokenId
+      );
+      setIsClaiming(false);
+    } catch (err) {
+      console.error(err);
+      setIsClaiming(false);
+    }
+  }, [merkle, contract, provider, tokenId]);
 
-    const handleClaimMerkle = useCallback(
-        async () => {
-            if (!merkle) {
-                console.error('[useClaimMerkle] no merkle data');
-                return;
-            }
-            try {
-                setIsClaiming(true);
-                await claimMerkle(
-                    provider,
-                    contract,
-                    merkle.index,
-                    merkle.account,
-                    merkle.amount,
-                    merkle.proof,
-					tokenId && tokenId
-                )
-                setIsClaiming(false);
-            } catch(err) {
-                console.error(err);
-                setIsClaiming(false);
-            }
-        },
-        [merkle, contract, provider, tokenId],
-    )
+  return { onClaimMerkle: handleClaimMerkle, isClaiming };
+};
 
-    return { onClaimMerkle: handleClaimMerkle, isClaiming }
-}
-
-export default useClaimMerkle
+export default useClaimMerkle;

--- a/packages/app/src/hooks/useDetectMobile.ts
+++ b/packages/app/src/hooks/useDetectMobile.ts
@@ -1,25 +1,28 @@
-import { useEffect } from 'react'
+import { useEffect } from "react";
 
-const getMobileDetect = (userAgent: NavigatorID['userAgent']) => {
-    const isAndroid = () => Boolean(userAgent.match(/Android/i))
-    const isIos = () => Boolean(userAgent.match(/iPhone|iPad|iPod/i))
-    const isOpera = () => Boolean(userAgent.match(/Opera Mini/i))
-    const isWindows = () => Boolean(userAgent.match(/IEMobile/i))
-    const isSSR = () => Boolean(userAgent.match(/SSR/i))
-    const isMobile = () => Boolean(isAndroid() || isIos() || isOpera() || isWindows())
-    const isDesktop = () => Boolean(!isMobile() && !isSSR())
-    return {
-        isMobile,
-        isDesktop,
-        isAndroid,
-        isIos,
-        isSSR,
-    }
-}
+const getMobileDetect = (userAgent: NavigatorID["userAgent"]) => {
+  const isAndroid = () => Boolean(userAgent.match(/Android/i));
+  const isIos = () => Boolean(userAgent.match(/iPhone|iPad|iPod/i));
+  const isOpera = () => Boolean(userAgent.match(/Opera Mini/i));
+  const isWindows = () => Boolean(userAgent.match(/IEMobile/i));
+  const isSSR = () => Boolean(userAgent.match(/SSR/i));
+  const isMobile = () =>
+    Boolean(isAndroid() || isIos() || isOpera() || isWindows());
+  const isDesktop = () => Boolean(!isMobile() && !isSSR());
+  return {
+    isMobile,
+    isDesktop,
+    isAndroid,
+    isIos,
+    isSSR,
+  };
+};
 const useDetectMobile = () => {
-    useEffect(() => {}, [])
-    const userAgent = typeof navigator === 'undefined' ? 'SSR' : navigator.userAgent
-    return getMobileDetect(userAgent)
-}
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  useEffect(() => {}, []);
+  const userAgent =
+    typeof navigator === "undefined" ? "SSR" : navigator.userAgent;
+  return getMobileDetect(userAgent);
+};
 
-export default useDetectMobile
+export default useDetectMobile;

--- a/packages/app/src/hooks/useDetectMobileScreen.ts
+++ b/packages/app/src/hooks/useDetectMobileScreen.ts
@@ -1,19 +1,19 @@
-import {useEffect, useState} from "react";
+import { useEffect, useState } from "react";
 
 const useDetectMobileScreen = () => {
-    const [width, setWidth] = useState(window.innerWidth);
-    const handleWindowSizeChange = () => {
-        setWidth(window.innerWidth);
-    }
+  const [width, setWidth] = useState(window.innerWidth);
+  const handleWindowSizeChange = () => {
+    setWidth(window.innerWidth);
+  };
 
-    useEffect(() => {
-        window.addEventListener('resize', handleWindowSizeChange);
-        return () => {
-            window.removeEventListener('resize', handleWindowSizeChange);
-        }
-    }, []);
+  useEffect(() => {
+    window.addEventListener("resize", handleWindowSizeChange);
+    return () => {
+      window.removeEventListener("resize", handleWindowSizeChange);
+    };
+  }, []);
 
-    return (width <= 768);
-}
+  return width <= 768;
+};
 
-export default useDetectMobileScreen
+export default useDetectMobileScreen;

--- a/packages/app/src/hooks/useEarnings.ts
+++ b/packages/app/src/hooks/useEarnings.ts
@@ -1,28 +1,26 @@
-import { useCallback, useEffect, useState } from 'react'
-import BigNumber from 'bignumber.js'
-import { getEarned, getPpdexContract } from '../pepemon/utils'
-import usePepemon from './usePepemon';
+import { useCallback, useEffect, useState } from "react";
+import BigNumber from "bignumber.js";
+import { getEarned, getPpdexContract } from "../pepemon/utils";
+import usePepemon from "./usePepemon";
 
 const useEarnings = (pid: number) => {
-  const [balance, setBalance] = useState(new BigNumber(0))
-  const {
-    account,
-  }: { account: string } = usePepemon()
-  const pepemon = usePepemon()
-  const ppdexContract = getPpdexContract(pepemon)
+  const [balance, setBalance] = useState(new BigNumber(0));
+  const { account }: { account: string } = usePepemon();
+  const pepemon = usePepemon();
+  const ppdexContract = getPpdexContract(pepemon);
 
   const fetchBalance = useCallback(async () => {
-    const balance = await getEarned(ppdexContract, pid, account)
-    setBalance(new BigNumber(balance))
-  }, [account, ppdexContract, pid])
+    const balance = await getEarned(ppdexContract, pid, account);
+    setBalance(new BigNumber(balance));
+  }, [account, ppdexContract, pid]);
 
   useEffect(() => {
     if (account && ppdexContract && pepemon) {
-      fetchBalance()
+      fetchBalance();
     }
-  }, [account, ppdexContract, setBalance, pepemon, fetchBalance])
+  }, [account, ppdexContract, setBalance, pepemon, fetchBalance]);
 
-  return balance
-}
+  return balance;
+};
 
-export default useEarnings
+export default useEarnings;

--- a/packages/app/src/hooks/useHorizontalScroll.ts
+++ b/packages/app/src/hooks/useHorizontalScroll.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect } from "react";
 
 const useHorizontalScroll = (ref: any) => {
   useEffect(() => {
@@ -8,21 +8,23 @@ const useHorizontalScroll = (ref: any) => {
         if (e.deltaY === 0) return;
         if (
           !(el.scrollLeft === 0 && e.deltaY < 0) &&
-          !(el.scrollWidth - el.clientWidth - Math.round(el.scrollLeft) === 0 &&
-              e.deltaY > 0)
+          !(
+            el.scrollWidth - el.clientWidth - Math.round(el.scrollLeft) === 0 &&
+            e.deltaY > 0
+          )
         ) {
           e.preventDefault();
         }
         el.scrollTo({
           left: el.scrollLeft + e.deltaY,
-          behavior: 'smooth'
+          behavior: "smooth",
         });
       };
-      el.addEventListener('wheel', onWheel);
-      return () => el.removeEventListener('wheel', onWheel);
+      el.addEventListener("wheel", onWheel);
+      return () => el.removeEventListener("wheel", onWheel);
     }
-	}, [ref]);
+  }, [ref]);
   return ref;
-}
+};
 
 export default useHorizontalScroll;

--- a/packages/app/src/hooks/useIsApprovedForAll.ts
+++ b/packages/app/src/hooks/useIsApprovedForAll.ts
@@ -1,28 +1,36 @@
-import { useCallback, useEffect, useState } from 'react';
-import usePepemon from './usePepemon';
-import { getIsApprovedForAll, getPepemonFactoryContract, getPepemonStakeAddress } from '../pepemon/utils';
-import { correctChainIsLoaded } from '../utils/network';
+import { useCallback, useEffect, useState } from "react";
+import usePepemon from "./usePepemon";
+import {
+  getIsApprovedForAll,
+  getPepemonFactoryContract,
+  getPepemonStakeAddress,
+} from "../pepemon/utils";
+import { correctChainIsLoaded } from "../utils/network";
 
 const useIsApprovedForAll = () => {
-    const [isApprovedForAll, setIsApprovedForAll] = useState(false)
-    const { account }: { account: string } = usePepemon()
-    const pepemon = usePepemon()
-    const factoryContract = getPepemonFactoryContract(pepemon)
+  const [isApprovedForAll, setIsApprovedForAll] = useState(false);
+  const { account }: { account: string } = usePepemon();
+  const pepemon = usePepemon();
+  const factoryContract = getPepemonFactoryContract(pepemon);
 
-    const fetchIsApprovedForAll = useCallback(async () => {
-        const isApproved = await getIsApprovedForAll( factoryContract, getPepemonStakeAddress(pepemon), account )
-        setIsApprovedForAll(isApproved)
-    }, [account, factoryContract, pepemon])
+  const fetchIsApprovedForAll = useCallback(async () => {
+    const isApproved = await getIsApprovedForAll(
+      factoryContract,
+      getPepemonStakeAddress(pepemon),
+      account
+    );
+    setIsApprovedForAll(isApproved);
+  }, [account, factoryContract, pepemon]);
 
-    useEffect(() => {
-        correctChainIsLoaded(pepemon).then(correct => {
-            if (account && factoryContract && correct) {
-                fetchIsApprovedForAll()
-            }
-        })
-    }, [pepemon, account, factoryContract, fetchIsApprovedForAll])
+  useEffect(() => {
+    correctChainIsLoaded(pepemon).then((correct) => {
+      if (account && factoryContract && correct) {
+        fetchIsApprovedForAll();
+      }
+    });
+  }, [pepemon, account, factoryContract, fetchIsApprovedForAll]);
 
-    return isApprovedForAll;
-}
+  return isApprovedForAll;
+};
 
 export default useIsApprovedForAll;

--- a/packages/app/src/hooks/useIsClaimedMerkle.ts
+++ b/packages/app/src/hooks/useIsClaimedMerkle.ts
@@ -1,54 +1,62 @@
-import {useCallback, useEffect, useState} from 'react'
-import usePepemon from './usePepemon'
-import { getMerkleContract, getMerkleDegoContract, getMerklePpblzContract, getMerklePpdexContract, getMerkleDistributor, merkleIsClaimed } from '../pepemon/utils'
-import {Contract} from '@ethersproject/contracts';
+import { useCallback, useEffect, useState } from "react";
+import usePepemon from "./usePepemon";
+import {
+  getMerkleContract,
+  getMerkleDegoContract,
+  getMerklePpblzContract,
+  getMerklePpdexContract,
+  getMerkleDistributor,
+  merkleIsClaimed,
+} from "../pepemon/utils";
+import { Contract } from "@ethersproject/contracts";
 
-const useIsClaimedMerkle = (index: number, merkleType?: 'ppblz' | 'ppdex' | 'univ2' | 'dego' | 'distributor', tokenId = null) => {
-    const [isClaimed, setIsClaimed] = useState(null);
-    const { account } = usePepemon()
-    const pepemon = usePepemon()
-    let contract: Contract;
-    switch (merkleType) {
-        case 'ppblz':
-            contract = getMerklePpblzContract(pepemon);
-            break;
-        case 'ppdex':
-            contract = getMerklePpdexContract(pepemon);
-            break;
-        case 'dego':
-            contract = getMerkleDegoContract(pepemon);
-            break;
-		case 'distributor':
-            contract = getMerkleDistributor(pepemon);
-            break;
-        default:
-            contract = getMerkleContract(pepemon);
+const useIsClaimedMerkle = (
+  index: number,
+  merkleType?: "ppblz" | "ppdex" | "univ2" | "dego" | "distributor",
+  tokenId = null
+) => {
+  const [isClaimed, setIsClaimed] = useState(null);
+  const { account } = usePepemon();
+  const pepemon = usePepemon();
+  let contract: Contract;
+  switch (merkleType) {
+    case "ppblz":
+      contract = getMerklePpblzContract(pepemon);
+      break;
+    case "ppdex":
+      contract = getMerklePpdexContract(pepemon);
+      break;
+    case "dego":
+      contract = getMerkleDegoContract(pepemon);
+      break;
+    case "distributor":
+      contract = getMerkleDistributor(pepemon);
+      break;
+    default:
+      contract = getMerkleContract(pepemon);
+  }
+  const handleClaimedMerkle = useCallback(async () => {
+    try {
+      return merkleIsClaimed(
+        contract,
+        merkleType === "dego" ? account : index,
+        merkleType === "dego",
+        tokenId && tokenId
+      );
+    } catch (err) {
+      console.error(err);
     }
-    const handleClaimedMerkle = useCallback(
-        async () => {
-            try {
-                return merkleIsClaimed(
-                    contract,
-                    merkleType === 'dego' ? account : index,
-                    merkleType === 'dego',
-					tokenId && tokenId
-                )
-            } catch(err) {
-                console.error(err);
-            }
-        },
-        [account, index, contract, merkleType, tokenId]
-    )
+  }, [account, index, contract, merkleType, tokenId]);
 
-    useEffect(() => {
-        if (index) {
-            handleClaimedMerkle().then((claimed) => {
-                setIsClaimed(claimed);
-            })
-        }
-    }, [index, handleClaimedMerkle])
+  useEffect(() => {
+    if (index) {
+      handleClaimedMerkle().then((claimed) => {
+        setIsClaimed(claimed);
+      });
+    }
+  }, [index, handleClaimedMerkle]);
 
-    return isClaimed;
-}
+  return isClaimed;
+};
 
-export default useIsClaimedMerkle
+export default useIsClaimedMerkle;

--- a/packages/app/src/hooks/useJoinEvent.ts
+++ b/packages/app/src/hooks/useJoinEvent.ts
@@ -1,33 +1,29 @@
-import {useCallback, useState} from 'react'
+import { useCallback, useState } from "react";
 
-import usePepemon from './usePepemon'
+import usePepemon from "./usePepemon";
 
-
-import {joinEvent, getPepemonStakeContract} from '../pepemon/utils'
+import { joinEvent, getPepemonStakeContract } from "../pepemon/utils";
 
 const useJoinEvent = (eventId: number) => {
-    const [isJoining, setIsJoining] = useState<boolean>(false)
-    const pepemon = usePepemon()
+  const [isJoining, setIsJoining] = useState<boolean>(false);
+  const pepemon = usePepemon();
 
-    const handleJoinEvent = useCallback(
-        async () => {
-            try {
-                setIsJoining(true);
-                await joinEvent(
-                    pepemon.provider,
-                    getPepemonStakeContract(pepemon),
-                    eventId,
-                )
-                setIsJoining(false);
-            } catch(err) {
-                console.error(err);
-                setIsJoining(false);
-            }
-        },
-        [eventId, pepemon],
-    )
+  const handleJoinEvent = useCallback(async () => {
+    try {
+      setIsJoining(true);
+      await joinEvent(
+        pepemon.provider,
+        getPepemonStakeContract(pepemon),
+        eventId
+      );
+      setIsJoining(false);
+    } catch (err) {
+      console.error(err);
+      setIsJoining(false);
+    }
+  }, [eventId, pepemon]);
 
-    return { onJoinEvent: handleJoinEvent, isJoining }
-}
+  return { onJoinEvent: handleJoinEvent, isJoining };
+};
 
-export default useJoinEvent
+export default useJoinEvent;

--- a/packages/app/src/hooks/useLotteryClaim.ts
+++ b/packages/app/src/hooks/useLotteryClaim.ts
@@ -1,32 +1,28 @@
-import {useCallback, useState} from 'react'
+import { useCallback, useState } from "react";
 
-import usePepemon from './usePepemon'
+import usePepemon from "./usePepemon";
 
-
-import {getPepemonLotteryContract, mintNFTLottery} from '../pepemon/utils'
+import { getPepemonLotteryContract, mintNFTLottery } from "../pepemon/utils";
 
 const useLotteryClaim = () => {
-    const [isClaiming, setIsClaiming] = useState<boolean>(false)
-    const pepemon = usePepemon()
+  const [isClaiming, setIsClaiming] = useState<boolean>(false);
+  const pepemon = usePepemon();
 
-    const handleClaim = useCallback(
-        async () => {
-            try {
-                setIsClaiming(true);
-                await mintNFTLottery(
-                    pepemon.provider,
-                    getPepemonLotteryContract(pepemon),
-                )
-                setIsClaiming(false);
-            } catch(err) {
-                console.error(err);
-                setIsClaiming(false);
-            }
-        },
-        [pepemon],
-    )
+  const handleClaim = useCallback(async () => {
+    try {
+      setIsClaiming(true);
+      await mintNFTLottery(
+        pepemon.provider,
+        getPepemonLotteryContract(pepemon)
+      );
+      setIsClaiming(false);
+    } catch (err) {
+      console.error(err);
+      setIsClaiming(false);
+    }
+  }, [pepemon]);
 
-    return { onLotteryClaim: handleClaim, isClaiming }
-}
+  return { onLotteryClaim: handleClaim, isClaiming };
+};
 
-export default useLotteryClaim
+export default useLotteryClaim;

--- a/packages/app/src/hooks/useLotteryHasClaimed.ts
+++ b/packages/app/src/hooks/useLotteryHasClaimed.ts
@@ -1,24 +1,27 @@
-import { useCallback, useEffect, useState } from 'react'
-import {getPepemonLotteryContract, hasUserMinted} from '../pepemon/utils'
-import usePepemon from './usePepemon'
+import { useCallback, useEffect, useState } from "react";
+import { getPepemonLotteryContract, hasUserMinted } from "../pepemon/utils";
+import usePepemon from "./usePepemon";
 
 const useLotteryHasClaimed = (cardId: number, transaction: number) => {
-    const [hasClaimed, setHasClaimed] = useState(null)
-    const pepemon = usePepemon()
-    const { account }: { account: string } = usePepemon()
-    const lotteryContract = getPepemonLotteryContract(pepemon)
+  const [hasClaimed, setHasClaimed] = useState(null);
+  const pepemon = usePepemon();
+  const { account }: { account: string } = usePepemon();
+  const lotteryContract = getPepemonLotteryContract(pepemon);
 
-    const fetchHasMinted = useCallback(async (account, cardId) => {
-        return hasUserMinted(lotteryContract, account, cardId)
-    }, [lotteryContract])
+  const fetchHasMinted = useCallback(
+    async (account, cardId) => {
+      return hasUserMinted(lotteryContract, account, cardId);
+    },
+    [lotteryContract]
+  );
 
-    useEffect(() => {
-        if (account && cardId) {
-            fetchHasMinted(account, cardId).then(result => setHasClaimed(result));
-        }
-    }, [fetchHasMinted, account, cardId])
+  useEffect(() => {
+    if (account && cardId) {
+      fetchHasMinted(account, cardId).then((result) => setHasClaimed(result));
+    }
+  }, [fetchHasMinted, account, cardId]);
 
-    return hasClaimed
-}
+  return hasClaimed;
+};
 
-export default useLotteryHasClaimed
+export default useLotteryHasClaimed;

--- a/packages/app/src/hooks/useLotteryIsStaking.ts
+++ b/packages/app/src/hooks/useLotteryIsStaking.ts
@@ -1,24 +1,24 @@
-import { useCallback, useEffect, useState } from 'react'
-import {getPepemonLotteryContract, isUserStaking} from '../pepemon/utils'
-import usePepemon from './usePepemon'
+import { useCallback, useEffect, useState } from "react";
+import { getPepemonLotteryContract, isUserStaking } from "../pepemon/utils";
+import usePepemon from "./usePepemon";
 
 const useLotteryIsStaking = (transaction: number) => {
-    const [isStaking, setIsStaking] = useState(null)
-    const pepemon = usePepemon()
-    const { account }: { account: string } = usePepemon()
-    const lotteryContract = getPepemonLotteryContract(pepemon)
+  const [isStaking, setIsStaking] = useState(null);
+  const pepemon = usePepemon();
+  const { account }: { account: string } = usePepemon();
+  const lotteryContract = getPepemonLotteryContract(pepemon);
 
-    const fetchIsStaking = useCallback(async () => {
-        return isUserStaking(lotteryContract, account)
-    }, [account, lotteryContract])
+  const fetchIsStaking = useCallback(async () => {
+    return isUserStaking(lotteryContract, account);
+  }, [account, lotteryContract]);
 
-    useEffect(() => {
-        if (pepemon && account) {
-            fetchIsStaking().then(result => setIsStaking(result));
-        }
-    }, [pepemon, account, fetchIsStaking])
+  useEffect(() => {
+    if (pepemon && account) {
+      fetchIsStaking().then((result) => setIsStaking(result));
+    }
+  }, [pepemon, account, fetchIsStaking]);
 
-    return isStaking
-}
+  return isStaking;
+};
 
-export default useLotteryIsStaking
+export default useLotteryIsStaking;

--- a/packages/app/src/hooks/useLotteryLPBalance.ts
+++ b/packages/app/src/hooks/useLotteryLPBalance.ts
@@ -1,25 +1,27 @@
-import { useCallback, useEffect, useState } from 'react'
-import {getPepemonLotteryContract, getLPBalance} from '../pepemon/utils'
-import usePepemon from './usePepemon'
-import BigNumber from 'bignumber.js';
+import { useCallback, useEffect, useState } from "react";
+import { getPepemonLotteryContract, getLPBalance } from "../pepemon/utils";
+import usePepemon from "./usePepemon";
+import BigNumber from "bignumber.js";
 
 const useLotteryLPBalance = (transaction: number) => {
-    const [lpBalance, setLpBalance] = useState(new BigNumber(0))
-    const pepemon = usePepemon()
-    const { account }: { account: string } = usePepemon()
-    const lotteryContract = getPepemonLotteryContract(pepemon)
+  const [lpBalance, setLpBalance] = useState(new BigNumber(0));
+  const pepemon = usePepemon();
+  const { account }: { account: string } = usePepemon();
+  const lotteryContract = getPepemonLotteryContract(pepemon);
 
-    const fetchStakedBalance = useCallback(async () => {
-        return getLPBalance(lotteryContract, account)
-    }, [account, lotteryContract])
+  const fetchStakedBalance = useCallback(async () => {
+    return getLPBalance(lotteryContract, account);
+  }, [account, lotteryContract]);
 
-    useEffect(() => {
-        if (pepemon) {
-            fetchStakedBalance().then(result => setLpBalance(new BigNumber(result)));
-        }
-    }, [pepemon, fetchStakedBalance])
+  useEffect(() => {
+    if (pepemon) {
+      fetchStakedBalance().then((result) =>
+        setLpBalance(new BigNumber(result))
+      );
+    }
+  }, [pepemon, fetchStakedBalance]);
 
-    return lpBalance
-}
+  return lpBalance;
+};
 
-export default useLotteryLPBalance
+export default useLotteryLPBalance;

--- a/packages/app/src/hooks/useLotteryMinLPTokens.ts
+++ b/packages/app/src/hooks/useLotteryMinLPTokens.ts
@@ -1,26 +1,26 @@
-import { useCallback, useEffect, useState } from 'react'
-import BigNumber from 'bignumber.js'
-import {getPepemonLotteryContract, getMinLPTokens} from '../pepemon/utils'
-import usePepemon from './usePepemon'
+import { useCallback, useEffect, useState } from "react";
+import BigNumber from "bignumber.js";
+import { getPepemonLotteryContract, getMinLPTokens } from "../pepemon/utils";
+import usePepemon from "./usePepemon";
 
 const useLotteryMinLPTokens = () => {
-    const [minLPTokens, setMinLPTokens] = useState(null)
-    const pepemon = usePepemon()
-    const lotteryContract = getPepemonLotteryContract(pepemon)
+  const [minLPTokens, setMinLPTokens] = useState(null);
+  const pepemon = usePepemon();
+  const lotteryContract = getPepemonLotteryContract(pepemon);
 
-    const fetchMinLPTokens = useCallback(async () => {
-        return getMinLPTokens(lotteryContract)
-    }, [lotteryContract])
+  const fetchMinLPTokens = useCallback(async () => {
+    return getMinLPTokens(lotteryContract);
+  }, [lotteryContract]);
 
-    useEffect(() => {
-        if (pepemon) {
-            fetchMinLPTokens().then(result => {
-                setMinLPTokens(new BigNumber(result))
-            });
-        }
-    }, [pepemon, fetchMinLPTokens])
+  useEffect(() => {
+    if (pepemon) {
+      fetchMinLPTokens().then((result) => {
+        setMinLPTokens(new BigNumber(result));
+      });
+    }
+  }, [pepemon, fetchMinLPTokens]);
 
-    return minLPTokens
-}
+  return minLPTokens;
+};
 
-export default useLotteryMinLPTokens
+export default useLotteryMinLPTokens;

--- a/packages/app/src/hooks/useLotteryRewardCard.ts
+++ b/packages/app/src/hooks/useLotteryRewardCard.ts
@@ -1,24 +1,24 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from "react";
 
-import {getPepemonLotteryContract, getRewardCardId} from '../pepemon/utils'
-import usePepemon from './usePepemon'
+import { getPepemonLotteryContract, getRewardCardId } from "../pepemon/utils";
+import usePepemon from "./usePepemon";
 
 const useLotteryRewardCard = () => {
-    const [rewardCard, setRewardCard] = useState(null)
-    const pepemon = usePepemon()
-    const lotteryContract = getPepemonLotteryContract(pepemon)
+  const [rewardCard, setRewardCard] = useState(null);
+  const pepemon = usePepemon();
+  const lotteryContract = getPepemonLotteryContract(pepemon);
 
-    const fetchRewardCard = useCallback(async () => {
-        return getRewardCardId(lotteryContract)
-    }, [lotteryContract])
+  const fetchRewardCard = useCallback(async () => {
+    return getRewardCardId(lotteryContract);
+  }, [lotteryContract]);
 
-    useEffect(() => {
-        if (pepemon) {
-            fetchRewardCard().then(result => setRewardCard(result));
-        }
-    }, [pepemon, fetchRewardCard])
+  useEffect(() => {
+    if (pepemon) {
+      fetchRewardCard().then((result) => setRewardCard(result));
+    }
+  }, [pepemon, fetchRewardCard]);
 
-    return rewardCard
-}
+  return rewardCard;
+};
 
-export default useLotteryRewardCard
+export default useLotteryRewardCard;

--- a/packages/app/src/hooks/useLotteryStake.ts
+++ b/packages/app/src/hooks/useLotteryStake.ts
@@ -1,31 +1,25 @@
-import {useCallback, useState} from 'react'
+import { useCallback, useState } from "react";
 
-import usePepemon from './usePepemon'
+import usePepemon from "./usePepemon";
 
-import {getPepemonLotteryContract, stakeLottery} from '../pepemon/utils'
+import { getPepemonLotteryContract, stakeLottery } from "../pepemon/utils";
 
 const useLotteryStake = () => {
-    const [isJoining, setIsJoining] = useState<boolean>(false)
-    const pepemon = usePepemon()
+  const [isJoining, setIsJoining] = useState<boolean>(false);
+  const pepemon = usePepemon();
 
-    const handleStake = useCallback(
-        async () => {
-            try {
-                setIsJoining(true);
-                await stakeLottery(
-                    pepemon.provider,
-                    getPepemonLotteryContract(pepemon),
-                )
-                setIsJoining(false);
-            } catch(err) {
-                console.error(err);
-                setIsJoining(false);
-            }
-        },
-        [pepemon],
-    )
+  const handleStake = useCallback(async () => {
+    try {
+      setIsJoining(true);
+      await stakeLottery(pepemon.provider, getPepemonLotteryContract(pepemon));
+      setIsJoining(false);
+    } catch (err) {
+      console.error(err);
+      setIsJoining(false);
+    }
+  }, [pepemon]);
 
-    return { onLotteryStake: handleStake, isJoining }
-}
+  return { onLotteryStake: handleStake, isJoining };
+};
 
-export default useLotteryStake
+export default useLotteryStake;

--- a/packages/app/src/hooks/useLotteryStakingDeadline.ts
+++ b/packages/app/src/hooks/useLotteryStakingDeadline.ts
@@ -1,24 +1,27 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from "react";
 
-import {getPepemonLotteryContract, getStakingDeadline} from '../pepemon/utils'
-import usePepemon from './usePepemon'
+import {
+  getPepemonLotteryContract,
+  getStakingDeadline,
+} from "../pepemon/utils";
+import usePepemon from "./usePepemon";
 
 const useLotteryStakingDeadline = () => {
-    const [stakingDeadline, setStakingDeadline] = useState(null)
-    const pepemon = usePepemon()
-    const lotteryContract = getPepemonLotteryContract(pepemon)
+  const [stakingDeadline, setStakingDeadline] = useState(null);
+  const pepemon = usePepemon();
+  const lotteryContract = getPepemonLotteryContract(pepemon);
 
-    const fetchStakingDeadline = useCallback(async () => {
-        return getStakingDeadline(lotteryContract)
-    }, [lotteryContract])
+  const fetchStakingDeadline = useCallback(async () => {
+    return getStakingDeadline(lotteryContract);
+  }, [lotteryContract]);
 
-    useEffect(() => {
-        if (pepemon) {
-            fetchStakingDeadline().then(result => setStakingDeadline(result));
-        }
-    }, [pepemon, fetchStakingDeadline])
+  useEffect(() => {
+    if (pepemon) {
+      fetchStakingDeadline().then((result) => setStakingDeadline(result));
+    }
+  }, [pepemon, fetchStakingDeadline]);
 
-    return stakingDeadline
-}
+  return stakingDeadline;
+};
 
-export default useLotteryStakingDeadline
+export default useLotteryStakingDeadline;

--- a/packages/app/src/hooks/useLotteryStakingStartblock.ts
+++ b/packages/app/src/hooks/useLotteryStakingStartblock.ts
@@ -1,24 +1,24 @@
-import { useCallback, useEffect, useState } from 'react'
-import {getPepemonLotteryContract, getStakingStart} from '../pepemon/utils'
-import usePepemon from './usePepemon'
+import { useCallback, useEffect, useState } from "react";
+import { getPepemonLotteryContract, getStakingStart } from "../pepemon/utils";
+import usePepemon from "./usePepemon";
 
 const useLotteryStakingStartblock = (transaction: number) => {
-    const [stakingStartBlock, setStakingStartBlock] = useState(null)
-    const pepemon = usePepemon()
-    const { account }: { account: string } = usePepemon()
-    const lotteryContract = getPepemonLotteryContract(pepemon)
+  const [stakingStartBlock, setStakingStartBlock] = useState(null);
+  const pepemon = usePepemon();
+  const { account }: { account: string } = usePepemon();
+  const lotteryContract = getPepemonLotteryContract(pepemon);
 
-    const fetchStakingStartBlock = useCallback(async () => {
-        return getStakingStart(lotteryContract, account)
-    }, [account, lotteryContract])
+  const fetchStakingStartBlock = useCallback(async () => {
+    return getStakingStart(lotteryContract, account);
+  }, [account, lotteryContract]);
 
-    useEffect(() => {
-        if (pepemon) {
-            fetchStakingStartBlock().then(result => setStakingStartBlock(result));
-        }
-    }, [pepemon, fetchStakingStartBlock])
+  useEffect(() => {
+    if (pepemon) {
+      fetchStakingStartBlock().then((result) => setStakingStartBlock(result));
+    }
+  }, [pepemon, fetchStakingStartBlock]);
 
-    return stakingStartBlock
-}
+  return stakingStartBlock;
+};
 
-export default useLotteryStakingStartblock
+export default useLotteryStakingStartblock;

--- a/packages/app/src/hooks/useLotteryWithdraw.ts
+++ b/packages/app/src/hooks/useLotteryWithdraw.ts
@@ -1,32 +1,28 @@
-import {useCallback, useState} from 'react'
+import { useCallback, useState } from "react";
 
-import usePepemon from './usePepemon'
+import usePepemon from "./usePepemon";
 
-
-import {getPepemonLotteryContract, withdrawLottery} from '../pepemon/utils'
+import { getPepemonLotteryContract, withdrawLottery } from "../pepemon/utils";
 
 const useLotteryWithdraw = () => {
-    const [isWithdrawing, setIsWithdrawing] = useState<boolean>(false)
-    const pepemon = usePepemon()
+  const [isWithdrawing, setIsWithdrawing] = useState<boolean>(false);
+  const pepemon = usePepemon();
 
-    const handleWithdraw = useCallback(
-        async () => {
-            try {
-                setIsWithdrawing(true);
-                await withdrawLottery(
-                    pepemon.provider,
-                    getPepemonLotteryContract(pepemon),
-                )
-                setIsWithdrawing(false);
-            } catch(err) {
-                console.error(err);
-                setIsWithdrawing(false);
-            }
-        },
-        [pepemon],
-    )
+  const handleWithdraw = useCallback(async () => {
+    try {
+      setIsWithdrawing(true);
+      await withdrawLottery(
+        pepemon.provider,
+        getPepemonLotteryContract(pepemon)
+      );
+      setIsWithdrawing(false);
+    } catch (err) {
+      console.error(err);
+      setIsWithdrawing(false);
+    }
+  }, [pepemon]);
 
-    return { onLotteryWithdraw: handleWithdraw, isWithdrawing }
-}
+  return { onLotteryWithdraw: handleWithdraw, isWithdrawing };
+};
 
-export default useLotteryWithdraw
+export default useLotteryWithdraw;

--- a/packages/app/src/hooks/useModal.ts
+++ b/packages/app/src/hooks/useModal.ts
@@ -1,14 +1,14 @@
-import { useCallback, useContext } from 'react';
-import { ModalsProviderContext, ModalData } from '../contexts';
+import { useCallback, useContext } from "react";
+import { ModalsProviderContext, ModalData } from "../contexts";
 
 const useModal = (modalData?: ModalData, key?: string) => {
-	const { onPresent, onDismiss } = useContext(ModalsProviderContext)
+  const { onPresent, onDismiss } = useContext(ModalsProviderContext);
 
-	const handlePresent = useCallback(() => {
-		onPresent(modalData, key);
-	}, [key, modalData, onPresent])
+  const handlePresent = useCallback(() => {
+    onPresent(modalData, key);
+  }, [key, modalData, onPresent]);
 
-	return [handlePresent, onDismiss]
-}
+  return [handlePresent, onDismiss];
+};
 
-export default useModal
+export default useModal;

--- a/packages/app/src/hooks/useOutsideClick.ts
+++ b/packages/app/src/hooks/useOutsideClick.ts
@@ -1,19 +1,19 @@
 import { useEffect } from "react";
 
 const useOutsideClick = (ref: any, callback: any) => {
-    const handleClick = (e: any) => {
-        if (ref.current && !ref.current.contains(e.target)) {
-            callback();
-        }
+  const handleClick = (e: any) => {
+    if (ref.current && !ref.current.contains(e.target)) {
+      callback();
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener("click", handleClick);
+
+    return () => {
+      document.removeEventListener("click", handleClick);
     };
-
-    useEffect(() => {
-        document.addEventListener("click", handleClick);
-
-        return () => {
-            document.removeEventListener("click", handleClick);
-        };
-    });
+  });
 };
 
 export default useOutsideClick;

--- a/packages/app/src/hooks/usePepemon.ts
+++ b/packages/app/src/hooks/usePepemon.ts
@@ -1,9 +1,9 @@
-import { useContext } from 'react'
-import { Context } from '../contexts/PepemonProvider'
+import { useContext } from "react";
+import { Context } from "../contexts/PepemonProvider";
 
 const usePepemon = () => {
-  const [pepemon] = useContext(Context)
-  return pepemon
-}
+  const [pepemon] = useContext(Context);
+  return pepemon;
+};
 
-export default usePepemon
+export default usePepemon;

--- a/packages/app/src/hooks/usePepemonApi.ts
+++ b/packages/app/src/hooks/usePepemonApi.ts
@@ -1,32 +1,34 @@
-import {useEffect, useState} from 'react';
-import usePepemon from './usePepemon';
+import { useEffect, useState } from "react";
+import usePepemon from "./usePepemon";
 
 const usePepemonApi = (endpoint: string) => {
-    const [response, setResponse] = useState<any>(null);
-    const [isFetching, setIsFetching] = useState<boolean>(false);
-    const { chainId } = usePepemon();
+  const [response, setResponse] = useState<any>(null);
+  const [isFetching, setIsFetching] = useState<boolean>(false);
+  const { chainId } = usePepemon();
 
-    useEffect(() => {
-		const fetchData = async (endpoint: string) => {
-	        setIsFetching(true);
-	        const effectiveChainId = chainId || 1;
-	        const host = effectiveChainId === 1 ? `https://pepemon.world/api` : `https://dev.pepemon.finance/api`;
-	        const response = await fetch(
-	            `${host}${endpoint}`,
-	            { method: 'GET'},
-	        );
-	        if (!response.ok) {
-	            setIsFetching(false);
-	            return null;
-	        }
-	        setIsFetching(false);
-	        return response.json();
-	    }
+  useEffect(() => {
+    const fetchData = async (endpoint: string) => {
+      setIsFetching(true);
+      const effectiveChainId = chainId || 1;
+      const host =
+        effectiveChainId === 1
+          ? `https://pepemon.world/api`
+          : `https://dev.pepemon.finance/api`;
+      const response = await fetch(`${host}${endpoint}`, { method: "GET" });
+      if (!response.ok) {
+        setIsFetching(false);
+        return null;
+      }
+      setIsFetching(false);
+      return response.json();
+    };
 
-        fetchData(endpoint).then(res => setResponse(res)).catch(err => console.error(err));
-    }, [chainId, endpoint])
+    fetchData(endpoint)
+      .then((res) => setResponse(res))
+      .catch((err) => console.error(err));
+  }, [chainId, endpoint]);
 
-    return { response, isFetching };
-}
+  return { response, isFetching };
+};
 
 export default usePepemonApi;

--- a/packages/app/src/hooks/useRedeem.ts
+++ b/packages/app/src/hooks/useRedeem.ts
@@ -1,18 +1,18 @@
-import { useCallback } from 'react'
+import { useCallback } from "react";
 
-import { Contract } from 'web3-eth-contract'
-import { redeem } from '../pepemon/utils'
-import usePepemon from './usePepemon';
+import { Contract } from "web3-eth-contract";
+import { redeem } from "../pepemon/utils";
+import usePepemon from "./usePepemon";
 
 const useRedeem = (contract: Contract) => {
-  const { account } = usePepemon()
+  const { account } = usePepemon();
 
   const handleRedeem = useCallback(async () => {
-    const txHash = await redeem(contract, account)
-    return txHash
-  }, [account, contract])
+    const txHash = await redeem(contract, account);
+    return txHash;
+  }, [account, contract]);
 
-  return { onRedeem: handleRedeem }
-}
+  return { onRedeem: handleRedeem };
+};
 
-export default useRedeem
+export default useRedeem;

--- a/packages/app/src/hooks/useRedeemCard.ts
+++ b/packages/app/src/hooks/useRedeemCard.ts
@@ -1,31 +1,42 @@
-import {useCallback, useState} from 'react'
-import {redeemCard, redeemCardNative} from '../pepemon/utils'
-import usePepemon from './usePepemon';
+import { useCallback, useState } from "react";
+import { redeemCard, redeemCardNative } from "../pepemon/utils";
+import usePepemon from "./usePepemon";
 
 const useRedeemCard = (storeContract: any) => {
-	const [isRedeeming, setIsRedeeming] = useState<Array<string | boolean> | number>([])
-    const pepemon = usePepemon();
+  const [isRedeeming, setIsRedeeming] = useState<
+    Array<string | boolean> | number
+  >([]);
+  const pepemon = usePepemon();
 
-    const handleRedeem = useCallback(async (tokenId, amount = null) => {
-        try {
-            setIsRedeeming([tokenId, true]);
-            if (amount) {
-                await redeemCardNative(pepemon.provider, storeContract, tokenId, amount)
-            } else {
-                await redeemCard(pepemon.provider, storeContract, tokenId)
-            }
-
-            setIsRedeeming([tokenId, false]);
-        } catch (error) {
-            console.log(error);
-            setIsRedeeming([tokenId, false]);
+  const handleRedeem = useCallback(
+    async (tokenId, amount = null) => {
+      try {
+        setIsRedeeming([tokenId, true]);
+        if (amount) {
+          await redeemCardNative(
+            pepemon.provider,
+            storeContract,
+            tokenId,
+            amount
+          );
+        } else {
+          await redeemCard(pepemon.provider, storeContract, tokenId);
         }
-    }, [pepemon, storeContract])
 
-	return {
-        onRedeemCard: (tokenId: number, amount?: string) => handleRedeem(tokenId, amount),
-        isRedeemingCard: isRedeeming[1] ? isRedeeming : false,
-    }
+        setIsRedeeming([tokenId, false]);
+      } catch (error) {
+        console.log(error);
+        setIsRedeeming([tokenId, false]);
+      }
+    },
+    [pepemon, storeContract]
+  );
+
+  return {
+    onRedeemCard: (tokenId: number, amount?: string) =>
+      handleRedeem(tokenId, amount),
+    isRedeemingCard: isRedeeming[1] ? isRedeeming : false,
+  };
 };
 
 export default useRedeemCard;

--- a/packages/app/src/hooks/useReward.ts
+++ b/packages/app/src/hooks/useReward.ts
@@ -1,18 +1,18 @@
-import { useCallback } from 'react'
-import usePepemon from './usePepemon'
-import { harvest, getPpdexContract } from '../pepemon/utils'
+import { useCallback } from "react";
+import usePepemon from "./usePepemon";
+import { harvest, getPpdexContract } from "../pepemon/utils";
 
 const useReward = (pid: number) => {
-  const { account } = usePepemon()
-  const pepemon = usePepemon()
-  const ppdexContract = getPpdexContract(pepemon)
+  const { account } = usePepemon();
+  const pepemon = usePepemon();
+  const ppdexContract = getPpdexContract(pepemon);
 
   const handleReward = useCallback(async () => {
-    const txHash = await harvest(ppdexContract, pid, account)
-    return txHash
-  }, [account, pid, ppdexContract])
+    const txHash = await harvest(ppdexContract, pid, account);
+    return txHash;
+  }, [account, pid, ppdexContract]);
 
-  return { onReward: handleReward }
-}
+  return { onReward: handleReward };
+};
 
-export default useReward
+export default useReward;

--- a/packages/app/src/hooks/useSetApprovalForAll.ts
+++ b/packages/app/src/hooks/useSetApprovalForAll.ts
@@ -1,33 +1,33 @@
-import {useCallback, useState} from 'react'
+import { useCallback, useState } from "react";
 
-import usePepemon from './usePepemon'
+import usePepemon from "./usePepemon";
 
-
-import {getPepemonFactoryContract, setApprovalForAll, getPepemonStakeAddress} from '../pepemon/utils'
+import {
+  getPepemonFactoryContract,
+  setApprovalForAll,
+  getPepemonStakeAddress,
+} from "../pepemon/utils";
 
 const useSetApprovalForAll = () => {
-    const [isApproving, setIsApproving] = useState<boolean>(false)
-    const pepemon = usePepemon()
+  const [isApproving, setIsApproving] = useState<boolean>(false);
+  const pepemon = usePepemon();
 
-    const handleSetApprovalForAll = useCallback(
-        async () => {
-            try {
-                setIsApproving(true);
-                await setApprovalForAll(
-                    pepemon.provider,
-                    getPepemonFactoryContract(pepemon),
-                    getPepemonStakeAddress(pepemon),
-                )
-                setIsApproving(false);
-            } catch(err) {
-                console.error(err);
-                setIsApproving(false);
-            }
-        },
-        [pepemon],
-    )
+  const handleSetApprovalForAll = useCallback(async () => {
+    try {
+      setIsApproving(true);
+      await setApprovalForAll(
+        pepemon.provider,
+        getPepemonFactoryContract(pepemon),
+        getPepemonStakeAddress(pepemon)
+      );
+      setIsApproving(false);
+    } catch (err) {
+      console.error(err);
+      setIsApproving(false);
+    }
+  }, [pepemon]);
 
-    return { onSetApprovalForAll: handleSetApprovalForAll, isApproving }
-}
+  return { onSetApprovalForAll: handleSetApprovalForAll, isApproving };
+};
 
-export default useSetApprovalForAll
+export default useSetApprovalForAll;

--- a/packages/app/src/hooks/useStake.ts
+++ b/packages/app/src/hooks/useStake.ts
@@ -1,27 +1,21 @@
-import { useCallback } from 'react'
+import { useCallback } from "react";
 
-import usePepemon from './usePepemon'
+import usePepemon from "./usePepemon";
 
-
-import { stake, getPpdexContract } from '../pepemon/utils'
+import { stake, getPpdexContract } from "../pepemon/utils";
 
 const useStake = (pid: number) => {
-  const { account } = usePepemon()
-  const pepemon = usePepemon()
+  const { account } = usePepemon();
+  const pepemon = usePepemon();
 
   const handleStake = useCallback(
     async (amount: string) => {
-      await stake(
-        getPpdexContract(pepemon),
-        pid,
-        amount,
-        account,
-      )
+      await stake(getPpdexContract(pepemon), pid, amount, account);
     },
-    [account, pid, pepemon],
-  )
+    [account, pid, pepemon]
+  );
 
-  return { onStake: handleStake }
-}
+  return { onStake: handleStake };
+};
 
-export default useStake
+export default useStake;

--- a/packages/app/src/hooks/useStakedBalance.ts
+++ b/packages/app/src/hooks/useStakedBalance.ts
@@ -1,26 +1,26 @@
-import { useCallback, useEffect, useState } from 'react'
-import BigNumber from 'bignumber.js'
-import { getStaked, getPpdexContract } from '../pepemon/utils'
-import usePepemon from './usePepemon'
+import { useCallback, useEffect, useState } from "react";
+import BigNumber from "bignumber.js";
+import { getStaked, getPpdexContract } from "../pepemon/utils";
+import usePepemon from "./usePepemon";
 
 const useStakedBalance = (pid: number) => {
-  const [balance, setBalance] = useState(new BigNumber(0))
-  const { account }: { account: string } = usePepemon()
-  const pepemon = usePepemon()
-  const ppdexContract = getPpdexContract(pepemon)
+  const [balance, setBalance] = useState(new BigNumber(0));
+  const { account }: { account: string } = usePepemon();
+  const pepemon = usePepemon();
+  const ppdexContract = getPpdexContract(pepemon);
 
   const fetchBalance = useCallback(async () => {
-    const balance = await getStaked(ppdexContract, pid, account)
-    setBalance(new BigNumber(balance))
-  }, [account, pid, ppdexContract])
+    const balance = await getStaked(ppdexContract, pid, account);
+    setBalance(new BigNumber(balance));
+  }, [account, pid, ppdexContract]);
 
   useEffect(() => {
     if (account && pepemon) {
-      fetchBalance()
+      fetchBalance();
     }
-  }, [account, pepemon, fetchBalance])
+  }, [account, pepemon, fetchBalance]);
 
-  return balance
-}
+  return balance;
+};
 
-export default useStakedBalance
+export default useStakedBalance;

--- a/packages/app/src/hooks/useTokenBalance.ts
+++ b/packages/app/src/hooks/useTokenBalance.ts
@@ -1,30 +1,30 @@
-import { useCallback, useEffect, useState } from 'react'
-import BigNumber from 'bignumber.js'
-import { getBalance } from '../utils';
-import usePepemon from './usePepemon';
-import { correctChainIsLoaded } from '../utils/network';
+import { useCallback, useEffect, useState } from "react";
+import BigNumber from "bignumber.js";
+import { getBalance } from "../utils";
+import usePepemon from "./usePepemon";
+import { correctChainIsLoaded } from "../utils/network";
 
 const useTokenBalance = (tokenAddress: string) => {
-  const [balance, setBalance] = useState(new BigNumber(0))
+  const [balance, setBalance] = useState(new BigNumber(0));
   const pepemon = usePepemon();
   const { account, provider }: { account: string; provider: any } = pepemon;
 
   const fetchBalance = useCallback(async () => {
     const balance = await getBalance(provider, tokenAddress, account);
-    setBalance(new BigNumber(balance))
-  }, [account, provider, tokenAddress])
+    setBalance(new BigNumber(balance));
+  }, [account, provider, tokenAddress]);
 
   useEffect(() => {
     if (account) {
       correctChainIsLoaded(pepemon).then((correct) => {
         if (correct) {
-          fetchBalance()
+          fetchBalance();
         }
       });
     }
-  }, [account, fetchBalance, pepemon])
+  }, [account, fetchBalance, pepemon]);
 
-  return balance
-}
+  return balance;
+};
 
-export default useTokenBalance
+export default useTokenBalance;

--- a/packages/app/src/hooks/useTotalSpendInShop.ts
+++ b/packages/app/src/hooks/useTotalSpendInShop.ts
@@ -1,31 +1,38 @@
-import {useCallback, useEffect, useState} from 'react';
-import BigNumber from 'bignumber.js';
-import usePepemon from './usePepemon';
-import {getPepemonStoreContract, getTotalSpend, getTotalSpendBNB} from '../pepemon/utils';
-import {correctChainIsLoaded} from '../utils/network';
+import { useCallback, useEffect, useState } from "react";
+import BigNumber from "bignumber.js";
+import usePepemon from "./usePepemon";
+import {
+  getPepemonStoreContract,
+  getTotalSpend,
+  getTotalSpendBNB,
+} from "../pepemon/utils";
+import { correctChainIsLoaded } from "../utils/network";
 
 const useTotalSpendInShop = () => {
-    const [totalSpend, setTotalSpend] = useState(new BigNumber(0))
-    const { account }: { account: string } = usePepemon()
-    const pepemon = usePepemon()
-    const storeContract = getPepemonStoreContract(pepemon)
+  const [totalSpend, setTotalSpend] = useState(new BigNumber(0));
+  const { account }: { account: string } = usePepemon();
+  const pepemon = usePepemon();
+  const storeContract = getPepemonStoreContract(pepemon);
 
-    const fetchTotalSpend = useCallback(async () => {
-        const balance = parseFloat(pepemon.chainId) === 56 ? await getTotalSpendBNB(storeContract) : await getTotalSpend(storeContract);
-        setTotalSpend(new BigNumber(balance))
-    }, [pepemon, storeContract])
+  const fetchTotalSpend = useCallback(async () => {
+    const balance =
+      parseFloat(pepemon.chainId) === 56
+        ? await getTotalSpendBNB(storeContract)
+        : await getTotalSpend(storeContract);
+    setTotalSpend(new BigNumber(balance));
+  }, [pepemon, storeContract]);
 
-    useEffect(() => {
-        if (account && pepemon) {
-            correctChainIsLoaded(pepemon).then((correct) => {
-                if (correct) {
-                    fetchTotalSpend()
-                }
-            })
+  useEffect(() => {
+    if (account && pepemon) {
+      correctChainIsLoaded(pepemon).then((correct) => {
+        if (correct) {
+          fetchTotalSpend();
         }
-    }, [account, pepemon, fetchTotalSpend])
+      });
+    }
+  }, [account, pepemon, fetchTotalSpend]);
 
-    return totalSpend
-}
+  return totalSpend;
+};
 
-export default useTotalSpendInShop
+export default useTotalSpendInShop;

--- a/packages/app/src/hooks/useTotalStakedBalance.ts
+++ b/packages/app/src/hooks/useTotalStakedBalance.ts
@@ -1,26 +1,26 @@
-import {useCallback, useEffect, useState} from 'react';
-import BigNumber from 'bignumber.js';
-import usePepemon from './usePepemon';
-import {getPpdexContract, getTotalStaked} from '../pepemon/utils';
+import { useCallback, useEffect, useState } from "react";
+import BigNumber from "bignumber.js";
+import usePepemon from "./usePepemon";
+import { getPpdexContract, getTotalStaked } from "../pepemon/utils";
 
 const useTotalStakedBalance = (pid: number) => {
-    const [balance, setBalance] = useState(new BigNumber(0))
-    const { account }: { account: string } = usePepemon()
-    const pepemon = usePepemon()
-    const ppdexContract = getPpdexContract(pepemon)
+  const [balance, setBalance] = useState(new BigNumber(0));
+  const { account }: { account: string } = usePepemon();
+  const pepemon = usePepemon();
+  const ppdexContract = getPpdexContract(pepemon);
 
-    const fetchBalance = useCallback(async () => {
-        const balance = await getTotalStaked(ppdexContract)
-        setBalance(new BigNumber(balance))
-    }, [ppdexContract])
+  const fetchBalance = useCallback(async () => {
+    const balance = await getTotalStaked(ppdexContract);
+    setBalance(new BigNumber(balance));
+  }, [ppdexContract]);
 
-    useEffect(() => {
-        if (account && pepemon) {
-            fetchBalance()
-        }
-    }, [account, pepemon, fetchBalance])
+  useEffect(() => {
+    if (account && pepemon) {
+      fetchBalance();
+    }
+  }, [account, pepemon, fetchBalance]);
 
-    return balance
-}
+  return balance;
+};
 
-export default useTotalStakedBalance
+export default useTotalStakedBalance;

--- a/packages/app/src/hooks/useTotalValueStaked.ts
+++ b/packages/app/src/hooks/useTotalValueStaked.ts
@@ -1,61 +1,74 @@
-import {useEffect, useState} from 'react';
-
+import { useEffect, useState } from "react";
 
 const useTotalValueStaked = () => {
-    const [totalValueStaked, setTotalValueStaked] = useState<any>({})
+  const [totalValueStaked, setTotalValueStaked] = useState<any>({});
 
-    const fetchUniV2PpblzStakedValue = async () => {
-        const response = await fetch(
-            'https://api.ethplorer.io/getAddressInfo/0x9479b62FD1CB36F8FEd1EEBb1Bb373d238d08216?apiKey=EK-rbHn9-RbvTYb7-GWodE',
-            { method: 'GET'} ,
-        );
-        const addressInfo = await response.json();
-        const uniV2Pool = addressInfo.tokens.reduce((accumulator: any, current: any) => {
-            if (current.tokenInfo.symbol === 'WETH') {
-                return {
-                    ...accumulator,
-                    wethBalance: current.balance / (10 ** 18),
-                    wethPrice: current.tokenInfo.price.rate,
-                }
-            }
-
-            return {
-                ...accumulator,
-                ppblzBalance: current.balance / (10 ** 18),
-            }
-        }, { wethBalance: 0, wethPrice: 0, ppblzBalance: 0 })
-        const ppblzPrice = (uniV2Pool.wethBalance * uniV2Pool.wethPrice) / uniV2Pool.ppblzBalance;
+  const fetchUniV2PpblzStakedValue = async () => {
+    const response = await fetch(
+      "https://api.ethplorer.io/getAddressInfo/0x9479b62FD1CB36F8FEd1EEBb1Bb373d238d08216?apiKey=EK-rbHn9-RbvTYb7-GWodE",
+      { method: "GET" }
+    );
+    const addressInfo = await response.json();
+    const uniV2Pool = addressInfo.tokens.reduce(
+      (accumulator: any, current: any) => {
+        if (current.tokenInfo.symbol === "WETH") {
+          return {
+            ...accumulator,
+            wethBalance: current.balance / 10 ** 18,
+            wethPrice: current.tokenInfo.price.rate,
+          };
+        }
 
         return {
-            ...uniV2Pool,
-            ppblzPrice,
-            tvl: (ppblzPrice * uniV2Pool.ppblzBalance) + (uniV2Pool.wethPrice * uniV2Pool.wethBalance)
-        }
-    }
+          ...accumulator,
+          ppblzBalance: current.balance / 10 ** 18,
+        };
+      },
+      { wethBalance: 0, wethPrice: 0, ppblzBalance: 0 }
+    );
+    const ppblzPrice =
+      (uniV2Pool.wethBalance * uniV2Pool.wethPrice) / uniV2Pool.ppblzBalance;
 
-    const fetchPpblzStakedValue = async () => {
-        const response = await fetch(
-            'https://api.ethplorer.io/getAddressInfo/0xf1F508c7C9f0d1b15a76fbA564eEf2d956220cf7?apiKey=EK-rbHn9-RbvTYb7-GWodE',
-            { method: 'GET'},
-        );
-        const addressInfo = await response.json();
-        return { ppblzBalance: addressInfo.tokens.find((token: any) => token.tokenInfo.symbol === 'PPBLZ').balance / (10 ** 18) };
+    return {
+      ...uniV2Pool,
+      ppblzPrice,
+      tvl:
+        ppblzPrice * uniV2Pool.ppblzBalance +
+        uniV2Pool.wethPrice * uniV2Pool.wethBalance,
     };
+  };
 
-    useEffect(() => {
-        Promise.all([fetchUniV2PpblzStakedValue(), fetchPpblzStakedValue()])
-        .then(([uniV2Pool, ppblzPool]) => {
-            setTotalValueStaked({
-                uniV2Pool,
-                ppblzPool: {
-                    ...ppblzPool,
-                    ppblzPrice: uniV2Pool.ppblzPrice,
-                    tvl: ppblzPool.ppblzBalance * uniV2Pool.ppblzPrice,
-                }});
-        })
-    }, [])
+  const fetchPpblzStakedValue = async () => {
+    const response = await fetch(
+      "https://api.ethplorer.io/getAddressInfo/0xf1F508c7C9f0d1b15a76fbA564eEf2d956220cf7?apiKey=EK-rbHn9-RbvTYb7-GWodE",
+      { method: "GET" }
+    );
+    const addressInfo = await response.json();
+    return {
+      ppblzBalance:
+        addressInfo.tokens.find(
+          (token: any) => token.tokenInfo.symbol === "PPBLZ"
+        ).balance /
+        10 ** 18,
+    };
+  };
 
-    return totalValueStaked;
-}
+  useEffect(() => {
+    Promise.all([fetchUniV2PpblzStakedValue(), fetchPpblzStakedValue()]).then(
+      ([uniV2Pool, ppblzPool]) => {
+        setTotalValueStaked({
+          uniV2Pool,
+          ppblzPool: {
+            ...ppblzPool,
+            ppblzPrice: uniV2Pool.ppblzPrice,
+            tvl: ppblzPool.ppblzBalance * uniV2Pool.ppblzPrice,
+          },
+        });
+      }
+    );
+  }, []);
+
+  return totalValueStaked;
+};
 
 export default useTotalValueStaked;

--- a/packages/app/src/hooks/useUnstake.ts
+++ b/packages/app/src/hooks/useUnstake.ts
@@ -1,23 +1,22 @@
-import { useCallback } from 'react'
+import { useCallback } from "react";
 
-import usePepemon from './usePepemon'
+import usePepemon from "./usePepemon";
 
-
-import { unstake, getPpdexContract } from '../pepemon/utils'
+import { unstake, getPpdexContract } from "../pepemon/utils";
 
 const useUnstake = (pid: number) => {
-  const { account } = usePepemon()
-  const pepemon = usePepemon()
-  const ppdexContract = getPpdexContract(pepemon)
+  const { account } = usePepemon();
+  const pepemon = usePepemon();
+  const ppdexContract = getPpdexContract(pepemon);
 
   const handleUnstake = useCallback(
     async (amount: string) => {
-      await unstake(ppdexContract, pid, amount, account)
+      await unstake(ppdexContract, pid, amount, account);
     },
-    [ppdexContract, pid, account],
-  )
+    [ppdexContract, pid, account]
+  );
 
-  return { onUnstake: handleUnstake }
-}
+  return { onUnstake: handleUnstake };
+};
 
-export default useUnstake
+export default useUnstake;

--- a/packages/app/src/hooks/useUserEventProgress.ts
+++ b/packages/app/src/hooks/useUserEventProgress.ts
@@ -1,28 +1,28 @@
-import { useCallback, useEffect, useState } from 'react'
-import usePepemon from './usePepemon'
-import { getPepemonStakeContract, getUserProgress } from '../pepemon/utils'
-import { correctChainIsLoaded } from '../utils/network';
+import { useCallback, useEffect, useState } from "react";
+import usePepemon from "./usePepemon";
+import { getPepemonStakeContract, getUserProgress } from "../pepemon/utils";
+import { correctChainIsLoaded } from "../utils/network";
 
-const useUserEventProgress = (eventId: number, transactions: number,) => {
-    const [userProgress, setUserProgress] = useState('0')
-    const { account }: { account: string } = usePepemon()
-    const pepemon = usePepemon()
-    const stakeContract = getPepemonStakeContract(pepemon)
+const useUserEventProgress = (eventId: number, transactions: number) => {
+  const [userProgress, setUserProgress] = useState("0");
+  const { account }: { account: string } = usePepemon();
+  const pepemon = usePepemon();
+  const stakeContract = getPepemonStakeContract(pepemon);
 
-    const fetchUserProgress = useCallback(async () => {
-        const userProgress = await getUserProgress( stakeContract, eventId, account )
-        setUserProgress(userProgress)
-    }, [account, stakeContract, eventId])
+  const fetchUserProgress = useCallback(async () => {
+    const userProgress = await getUserProgress(stakeContract, eventId, account);
+    setUserProgress(userProgress);
+  }, [account, stakeContract, eventId]);
 
-    useEffect(() => {
-        correctChainIsLoaded(pepemon).then(correct => {
-            if (account && stakeContract && correct) {
-                fetchUserProgress()
-            }
-        });
-    }, [pepemon, account, stakeContract, fetchUserProgress])
+  useEffect(() => {
+    correctChainIsLoaded(pepemon).then((correct) => {
+      if (account && stakeContract && correct) {
+        fetchUserProgress();
+      }
+    });
+  }, [pepemon, account, stakeContract, fetchUserProgress]);
 
-    return userProgress;
-}
+  return userProgress;
+};
 
 export default useUserEventProgress;

--- a/packages/app/src/hooks/useUserEventStatus.ts
+++ b/packages/app/src/hooks/useUserEventStatus.ts
@@ -1,28 +1,32 @@
-import { useCallback, useEffect, useState } from 'react'
-import usePepemon from './usePepemon'
-import { getPepemonStakeContract, getUserEventStatus } from '../pepemon/utils'
-import { correctChainIsLoaded } from '../utils/network';
+import { useCallback, useEffect, useState } from "react";
+import usePepemon from "./usePepemon";
+import { getPepemonStakeContract, getUserEventStatus } from "../pepemon/utils";
+import { correctChainIsLoaded } from "../utils/network";
 
 const useUserEventStatus = (eventId: number, transactions: number) => {
-    const [userEventStatus, setUserEventStatus] = useState(null)
-    const { account }: { account: string } = usePepemon()
-    const pepemon = usePepemon()
-    const stakeContract = getPepemonStakeContract(pepemon)
+  const [userEventStatus, setUserEventStatus] = useState(null);
+  const { account }: { account: string } = usePepemon();
+  const pepemon = usePepemon();
+  const stakeContract = getPepemonStakeContract(pepemon);
 
-    const fetchUserEventStatus = useCallback(async () => {
-        const userEventStatus = await getUserEventStatus( stakeContract, eventId, account )
-        setUserEventStatus({...userEventStatus})
-    }, [account, stakeContract, eventId])
+  const fetchUserEventStatus = useCallback(async () => {
+    const userEventStatus = await getUserEventStatus(
+      stakeContract,
+      eventId,
+      account
+    );
+    setUserEventStatus({ ...userEventStatus });
+  }, [account, stakeContract, eventId]);
 
-    useEffect(() => {
-        correctChainIsLoaded(pepemon).then(correct => {
-            if (account && stakeContract && correct) {
-                fetchUserEventStatus()
-            }
-        })
-    }, [account, stakeContract, pepemon, fetchUserEventStatus])
+  useEffect(() => {
+    correctChainIsLoaded(pepemon).then((correct) => {
+      if (account && stakeContract && correct) {
+        fetchUserEventStatus();
+      }
+    });
+  }, [account, stakeContract, pepemon, fetchUserEventStatus]);
 
-    return userEventStatus;
-}
+  return userEventStatus;
+};
 
 export default useUserEventStatus;

--- a/packages/app/src/hooks/useWeb3Modal.ts
+++ b/packages/app/src/hooks/useWeb3Modal.ts
@@ -1,74 +1,79 @@
-import {useCallback, useContext, useState} from 'react';
+import { useCallback, useContext, useState } from "react";
 import { Web3Provider } from "@ethersproject/providers";
 import Web3Modal from "web3modal";
 import WalletConnectProvider from "@walletconnect/web3-provider";
-import {Contracts} from '../pepemon/lib/contracts';
-import {PepemonProviderContext} from '../contexts';
+import { Contracts } from "../pepemon/lib/contracts";
+import { PepemonProviderContext } from "../contexts";
 
 const INFURA_ID = "7a9c4ff3188d481f9143904079638424";
 
 // Singleton — one instance shared across all hook calls so concurrent
 // connect() calls from re-renders on data-heavy pages don't stomp each other.
 const web3Modal = new Web3Modal({
-    network: "mainnet",
-    cacheProvider: false,
-    providerOptions: {
-        walletconnect: {
-            package: WalletConnectProvider,
-            options: { infuraId: INFURA_ID },
-        },
+  network: "mainnet",
+  cacheProvider: false,
+  providerOptions: {
+    walletconnect: {
+      package: WalletConnectProvider,
+      options: { infuraId: INFURA_ID },
     },
-    theme: "light",
+  },
+  theme: "light",
 });
 
 function useWeb3Modal() {
-    const [provider, setProvider] = useState(null);
-    const [, dispatch] = useContext(PepemonProviderContext);
+  const [provider, setProvider] = useState(null);
+  const [, dispatch] = useContext(PepemonProviderContext);
 
-    const loadWeb3Modal = useCallback(async () => {
-        const setPepemon = async (newProvider: any, newChainId: any = null) => {
-            if (!newProvider) return;
-            const { chainId } = await newProvider.getNetwork();
-            const accounts = await newProvider.listAccounts();
-            const contracts = new Contracts(newProvider, newChainId ? parseInt(newChainId, 16) : chainId);
-            return await dispatch({
-                type: 'all',
-                contracts,
-                chainId: newChainId ? parseInt(newChainId, 16) : chainId,
-                account: accounts[0],
-                provider: newProvider,
-            });
-        };
+  const loadWeb3Modal = useCallback(async () => {
+    const setPepemon = async (newProvider: any, newChainId: any = null) => {
+      if (!newProvider) return;
+      const { chainId } = await newProvider.getNetwork();
+      const accounts = await newProvider.listAccounts();
+      const contracts = new Contracts(
+        newProvider,
+        newChainId ? parseInt(newChainId, 16) : chainId
+      );
+      return await dispatch({
+        type: "all",
+        contracts,
+        chainId: newChainId ? parseInt(newChainId, 16) : chainId,
+        account: accounts[0],
+        provider: newProvider,
+      });
+    };
 
-        const subscribeProvider = async (rawProvider: any) => {
-            if (!rawProvider.on) return;
-            rawProvider.on("chainChanged", async (chainId: string) => {
-                const web3Provider = new Web3Provider(rawProvider, "any");
-                setPepemon(web3Provider, chainId).then(() => console.log('Contracts LOADED'));
-            });
-            rawProvider.on("accountsChanged", async () => {
-                const web3Provider = new Web3Provider(rawProvider, "any");
-                setPepemon(web3Provider).then(() => console.log('Contracts LOADED'));
-            });
-        };
-
-        const rawProvider = await web3Modal.connect();
-        await subscribeProvider(rawProvider);
+    const subscribeProvider = async (rawProvider: any) => {
+      if (!rawProvider.on) return;
+      rawProvider.on("chainChanged", async (chainId: string) => {
         const web3Provider = new Web3Provider(rawProvider, "any");
-        setProvider(web3Provider);
-        setPepemon(web3Provider).then(() => console.log('Contracts LOADED'));
-    }, [dispatch]);
+        setPepemon(web3Provider, chainId).then(() =>
+          console.log("Contracts LOADED")
+        );
+      });
+      rawProvider.on("accountsChanged", async () => {
+        const web3Provider = new Web3Provider(rawProvider, "any");
+        setPepemon(web3Provider).then(() => console.log("Contracts LOADED"));
+      });
+    };
 
-    const logoutOfWeb3Modal = useCallback(async () => {
-        if (provider && typeof (provider as any).close === 'function') {
-            await (provider as any).close();
-        }
-        setProvider(null);
-        await web3Modal.clearCachedProvider();
-        await dispatch({ type: 'reset' });
-    }, [dispatch, provider]);
+    const rawProvider = await web3Modal.connect();
+    await subscribeProvider(rawProvider);
+    const web3Provider = new Web3Provider(rawProvider, "any");
+    setProvider(web3Provider);
+    setPepemon(web3Provider).then(() => console.log("Contracts LOADED"));
+  }, [dispatch]);
 
-    return [provider, loadWeb3Modal, logoutOfWeb3Modal];
+  const logoutOfWeb3Modal = useCallback(async () => {
+    if (provider && typeof (provider as any).close === "function") {
+      await (provider as any).close();
+    }
+    setProvider(null);
+    await web3Modal.clearCachedProvider();
+    await dispatch({ type: "reset" });
+  }, [dispatch, provider]);
+
+  return [provider, loadWeb3Modal, logoutOfWeb3Modal];
 }
 
 export default useWeb3Modal;

--- a/packages/app/src/hooks/useWithdrawEvent.ts
+++ b/packages/app/src/hooks/useWithdrawEvent.ts
@@ -1,34 +1,29 @@
-import {useCallback, useState} from 'react'
+import { useCallback, useState } from "react";
 
-import usePepemon from './usePepemon'
+import usePepemon from "./usePepemon";
 
-
-import {getPepemonStakeContract, withdrawEvent} from '../pepemon/utils'
+import { getPepemonStakeContract, withdrawEvent } from "../pepemon/utils";
 
 const useWithdrawEvent = (eventId: number) => {
-    const [isWithdrawing, setIsWithdrawing] = useState<boolean>(false)
-    const pepemon = usePepemon()
+  const [isWithdrawing, setIsWithdrawing] = useState<boolean>(false);
+  const pepemon = usePepemon();
 
-    const handleWithdrawEvent = useCallback(
-        async () => {
-            try {
-                setIsWithdrawing(true);
-                await withdrawEvent(
-                    pepemon.provider,
-                    getPepemonStakeContract(pepemon),
-                    eventId,
-                )
-                setIsWithdrawing(false);
-            } catch(err) {
-                console.error(err);
-                setIsWithdrawing(false);
-            }
+  const handleWithdrawEvent = useCallback(async () => {
+    try {
+      setIsWithdrawing(true);
+      await withdrawEvent(
+        pepemon.provider,
+        getPepemonStakeContract(pepemon),
+        eventId
+      );
+      setIsWithdrawing(false);
+    } catch (err) {
+      console.error(err);
+      setIsWithdrawing(false);
+    }
+  }, [eventId, pepemon]);
 
-        },
-        [eventId, pepemon],
-    )
+  return { onWithdrawEvent: handleWithdrawEvent, isWithdrawing };
+};
 
-    return { onWithdrawEvent: handleWithdrawEvent, isWithdrawing }
-}
-
-export default useWithdrawEvent
+export default useWithdrawEvent;

--- a/packages/app/src/i18n.ts
+++ b/packages/app/src/i18n.ts
@@ -2,26 +2,24 @@ import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
 
 const resources = {
-	en: {
-		translation: {
-			'hello': 'Hello world'
-		}
-	},
-	de: {
-		translation: {
-			'hello': 'Hallo Welt'
-		}
-	}
-}
+  en: {
+    translation: {
+      hello: "Hello world",
+    },
+  },
+  de: {
+    translation: {
+      hello: "Hallo Welt",
+    },
+  },
+};
 
-i18n
-	.use(initReactI18next)
-	.init({
-		resources,
-		lng: 'en',
-		interpolation: {
-			escapeValue: false
-		}
-	})
+i18n.use(initReactI18next).init({
+  resources,
+  lng: "en",
+  interpolation: {
+    escapeValue: false,
+  },
+});
 
 export default i18n;

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -1,26 +1,27 @@
 :root {
-	font-size: 16px;
-	font-weight: normal;
-	letter-spacing: normal;
+  font-size: 16px;
+  font-weight: normal;
+  letter-spacing: normal;
 }
 
 * {
-	box-sizing: border-box;
-	letter-spacing: normal;
+  box-sizing: border-box;
+  letter-spacing: normal;
 }
 
-html, body {
-	width: 100vw;
+html,
+body {
+  width: 100vw;
 }
 
 body {
-	overflow-x: hidden;
+  overflow-x: hidden;
 }
 
 body {
   margin: 0;
-  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
-    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto",
+    "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -32,35 +33,38 @@ code {
 }
 
 @font-face {
-	font-family: "SpaceMace";
-	src: local("SpaceMace"), url("./assets/fonts/SpaceMace/SpaceMace.otf") format("truetype");
-	font-weight: normal;
+  font-family: "SpaceMace";
+  src: local("SpaceMace"),
+    url("./assets/fonts/SpaceMace/SpaceMace.otf") format("truetype");
+  font-weight: normal;
 }
 @font-face {
-	font-family: "Inter";
-	src: local("Inter"), url("./assets/fonts/Inter/Inter-Regular.ttf") format("truetype");
-	font-weight: normal;
+  font-family: "Inter";
+  src: local("Inter"),
+    url("./assets/fonts/Inter/Inter-Regular.ttf") format("truetype");
+  font-weight: normal;
 }
 @font-face {
-	font-family: "Inter";
-	src: local("Inter"), url("./assets/fonts/Inter/Inter-Bold.ttf") format("truetype");
-	font-weight: bold;
+  font-family: "Inter";
+  src: local("Inter"),
+    url("./assets/fonts/Inter/Inter-Bold.ttf") format("truetype");
+  font-weight: bold;
 }
 @font-face {
-	font-family: "Neometric";
-	src: local("Neometric"),
-	url("./assets/fonts/Neometric/Neometric-Regular.otf") format("truetype");
-	font-weight: normal;
+  font-family: "Neometric";
+  src: local("Neometric"),
+    url("./assets/fonts/Neometric/Neometric-Regular.otf") format("truetype");
+  font-weight: normal;
 }
 
 @font-face {
-	font-family: "Neometric";
-	src: local("Neometric"),
-	url("./assets/fonts/Neometric/Neometric-Alt-Black.otf") format("truetype");
-	font-weight: 900;
+  font-family: "Neometric";
+  src: local("Neometric"),
+    url("./assets/fonts/Neometric/Neometric-Alt-Black.otf") format("truetype");
+  font-weight: 900;
 }
 
 img {
-	height: auto;
-	max-width: 100%;
+  height: auto;
+  max-width: 100%;
 }

--- a/packages/app/src/index.js
+++ b/packages/app/src/index.js
@@ -1,14 +1,14 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import './index.css';
-import App from './App';
+import React from "react";
+import ReactDOM from "react-dom";
+import "./index.css";
+import App from "./App";
 // import LogRocket from 'logrocket';
 // import './i18n';
 
 // LogRocket.init('h4pvlb/pepemon');
 
 document.onreadystatechange = function () {
-	if (document.readyState === 'complete') {
-		ReactDOM.render(<App />, document.getElementById('root'));
-	}
-}
+  if (document.readyState === "complete") {
+    ReactDOM.render(<App />, document.getElementById("root"));
+  }
+};

--- a/packages/app/src/pepemon/Pepemon.js
+++ b/packages/app/src/pepemon/Pepemon.js
@@ -1,10 +1,10 @@
-import Web3 from 'web3';
-import BigNumber from 'bignumber.js';
-import { Contracts } from './lib/contracts.js';
-import { Account } from './lib/accounts.js';
-import { EVM } from './lib/evm.js';
+import Web3 from "web3";
+import BigNumber from "bignumber.js";
+import { Contracts } from "./lib/contracts.js";
+import { Account } from "./lib/accounts.js";
+import { EVM } from "./lib/evm.js";
 
-import { contractAddresses } from './lib/constants';
+import { contractAddresses } from "./lib/constants";
 
 export class Pepemon {
   networkId;
@@ -15,81 +15,88 @@ export class Pepemon {
     // Ganache fix
     networkId = networkId === 1337 ? 5777 : networkId;
 
-    if (typeof provider === 'string') {
-      if (provider.includes('wss')) {
+    if (typeof provider === "string") {
+      if (provider.includes("wss")) {
         this.realProvider = new Web3.providers.WebsocketProvider(
           provider,
-          options.ethereumNodeTimeout || 10000,
-        )
+          options.ethereumNodeTimeout || 10000
+        );
       } else {
         this.realProvider = new Web3.providers.HttpProvider(
           provider,
-          options.ethereumNodeTimeout || 10000,
-        )
+          options.ethereumNodeTimeout || 10000
+        );
       }
     } else {
-      this.realProvider = provider
+      this.realProvider = provider;
     }
 
-    this.web3 = new Web3(this.realProvider)
+    this.web3 = new Web3(this.realProvider);
 
     if (testing) {
-      this.testing = new EVM(this.realProvider)
-      this.snapshot = this.testing.snapshot()
+      this.testing = new EVM(this.realProvider);
+      this.snapshot = this.testing.snapshot();
     }
 
     if (options.defaultAccount) {
-      this.web3.eth.defaultAccount = options.defaultAccount
+      this.web3.eth.defaultAccount = options.defaultAccount;
     }
 
     // Debug chainId / networkId
     // this.web3.eth.net.getId().then((x) => console.log('networkId: ', x));
     // this.web3.eth.getChainId().then(x => console.log('chainId: ', x));
 
-    this.contracts = new Contracts(this.realProvider, networkId, this.web3, options)
-    this.ppblzAddress = contractAddresses.ppblz[networkId]
-    this.ppdexAddress = contractAddresses.ppdex[networkId]
-    this.wethAddress = contractAddresses.weth[networkId]
-    this.uniV2Address = contractAddresses.uniV2_ppblz[networkId]
-    this.pepemonFactoryAddress = contractAddresses.pepemonFactory[networkId]
-    this.pepemonStoreAddress = contractAddresses.pepemonStore[networkId]
-    this.pepemonStakeAddress = contractAddresses.pepemonStake[networkId]
-    this.merkleAddress = contractAddresses.merkle[networkId]
-    this.merkleAddressPpblz = contractAddresses.merklePpblz[networkId]
-    this.merkleAddressPpdex = contractAddresses.merklePpdex[networkId]
-    this.merkleAddressUniV2 = contractAddresses.merkleUniV2[networkId]
-	this.merkleDistributor = contractAddresses.merkleDistributor[networkId]
-    this.pepemonLottery = contractAddresses.pepemonLottery[networkId]
-    this.uniV2PpdexAddress = contractAddresses.uniV2_ppdex[networkId]
-    this.pepemonPromoStoreAddress = contractAddresses.pepemonPromoStore[networkId]
-    this.pepemonPromoTokenAddress = contractAddresses.pepemonPromoToken[networkId]
+    this.contracts = new Contracts(
+      this.realProvider,
+      networkId,
+      this.web3,
+      options
+    );
+    this.ppblzAddress = contractAddresses.ppblz[networkId];
+    this.ppdexAddress = contractAddresses.ppdex[networkId];
+    this.wethAddress = contractAddresses.weth[networkId];
+    this.uniV2Address = contractAddresses.uniV2_ppblz[networkId];
+    this.pepemonFactoryAddress = contractAddresses.pepemonFactory[networkId];
+    this.pepemonStoreAddress = contractAddresses.pepemonStore[networkId];
+    this.pepemonStakeAddress = contractAddresses.pepemonStake[networkId];
+    this.merkleAddress = contractAddresses.merkle[networkId];
+    this.merkleAddressPpblz = contractAddresses.merklePpblz[networkId];
+    this.merkleAddressPpdex = contractAddresses.merklePpdex[networkId];
+    this.merkleAddressUniV2 = contractAddresses.merkleUniV2[networkId];
+    this.merkleDistributor = contractAddresses.merkleDistributor[networkId];
+    this.pepemonLottery = contractAddresses.pepemonLottery[networkId];
+    this.uniV2PpdexAddress = contractAddresses.uniV2_ppdex[networkId];
+    this.pepemonPromoStoreAddress =
+      contractAddresses.pepemonPromoStore[networkId];
+    this.pepemonPromoTokenAddress =
+      contractAddresses.pepemonPromoToken[networkId];
   }
 
   async resetEVM() {
-    this.testing.resetEVM(this.snapshot)
+    this.testing.resetEVM(this.snapshot);
   }
 
   addAccount(address, number) {
-    this.accounts.push(new Account(this.contracts, address, number))
+    this.accounts.push(new Account(this.contracts, address, number));
   }
 
   setProvider(provider, networkId) {
-    this.web3.setProvider(provider)
-    this.contracts.setProvider(provider, networkId)
+    this.web3.setProvider(provider);
+    this.contracts.setProvider(provider, networkId);
     // this.operation.setNetworkId(networkId)
   }
 
   setDefaultAccount(account) {
-    this.web3.eth.defaultAccount = account
-    this.contracts.setDefaultAccount(account)
+    this.web3.eth.defaultAccount = account;
+    this.contracts.setDefaultAccount(account);
   }
 
   getDefaultAccount() {
-    return this.web3.eth.defaultAccount
+    return this.web3.eth.defaultAccount;
   }
 
   loadAccount(account) {
-    const newAccount = this.web3.eth.accounts.wallet.add(account.privateKey)
+    const newAccount = this.web3.eth.accounts.wallet.add(account.privateKey);
 
     if (
       !newAccount ||
@@ -99,11 +106,11 @@ export class Pepemon {
       throw new Error(`Loaded account address mismatch.
         Expected ${account.address}, got ${
         newAccount ? newAccount.address : null
-      }`)
+      }`);
     }
   }
 
   toBigN(a) {
-    return BigNumber(a)
+    return BigNumber(a);
   }
 }

--- a/packages/app/src/pepemon/index.js
+++ b/packages/app/src/pepemon/index.js
@@ -1,10 +1,10 @@
-import BigNumber from 'bignumber.js'
-import Web3 from 'web3'
+import BigNumber from "bignumber.js";
+import Web3 from "web3";
 
 BigNumber.config({
   EXPONENTIAL_AT: 1000,
   DECIMAL_PLACES: 80,
-})
+});
 
-export { Pepemon } from './Pepemon.js'
-export { Web3, BigNumber }
+export { Pepemon } from "./Pepemon.js";
+export { Web3, BigNumber };

--- a/packages/app/src/pepemon/lib/abi/merkle.json
+++ b/packages/app/src/pepemon/lib/abi/merkle.json
@@ -1,1 +1,135 @@
-[{"inputs":[{"internalType":"address","name":"_pepemonFactory","type":"address"},{"internalType":"bytes32","name":"merkleRoot_","type":"bytes32"},{"internalType":"uint256","name":"_pepemonId","type":"uint256"}],"stateMutability":"nonpayable","type":"constructor"},{"anonymous":false,"inputs":[{"indexed":false,"internalType":"uint256","name":"index","type":"uint256"},{"indexed":false,"internalType":"address","name":"account","type":"address"},{"indexed":false,"internalType":"uint256","name":"amount","type":"uint256"}],"name":"Claimed","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"previousOwner","type":"address"},{"indexed":true,"internalType":"address","name":"newOwner","type":"address"}],"name":"OwnershipTransferred","type":"event"},{"inputs":[{"internalType":"uint256","name":"index","type":"uint256"},{"internalType":"address","name":"account","type":"address"},{"internalType":"uint256","name":"amount","type":"uint256"},{"internalType":"bytes32[]","name":"merkleProof","type":"bytes32[]"}],"name":"claim","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"uint256","name":"index","type":"uint256"}],"name":"isClaimed","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"merkleRoot","outputs":[{"internalType":"bytes32","name":"","type":"bytes32"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"owner","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"pepemonId","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"renounceOwnership","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"uint256","name":"id","type":"uint256"}],"name":"setPepemonId","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[],"name":"token","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"newOwner","type":"address"}],"name":"transferOwnership","outputs":[],"stateMutability":"nonpayable","type":"function"}]
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_pepemonFactory",
+        "type": "address"
+      },
+      { "internalType": "bytes32", "name": "merkleRoot_", "type": "bytes32" },
+      { "internalType": "uint256", "name": "_pepemonId", "type": "uint256" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Claimed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "index", "type": "uint256" },
+      { "internalType": "address", "name": "account", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" },
+      {
+        "internalType": "bytes32[]",
+        "name": "merkleProof",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "claim",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "index", "type": "uint256" }
+    ],
+    "name": "isClaimed",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "merkleRoot",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pepemonId",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "id", "type": "uint256" }],
+    "name": "setPepemonId",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "token",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "newOwner", "type": "address" }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/packages/app/src/pepemon/lib/abi/merkleBSC.json
+++ b/packages/app/src/pepemon/lib/abi/merkleBSC.json
@@ -1,1 +1,140 @@
-[{"inputs":[{"internalType":"bytes32","name":"merkleRoot_","type":"bytes32"},{"internalType":"uint256","name":"_pepemonId","type":"uint256"},{"internalType":"address","name":"factory","type":"address"}],"stateMutability":"nonpayable","type":"constructor"},{"anonymous":false,"inputs":[{"indexed":false,"internalType":"uint256","name":"index","type":"uint256"},{"indexed":false,"internalType":"address","name":"account","type":"address"},{"indexed":false,"internalType":"uint256","name":"amount","type":"uint256"}],"name":"Claimed","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"previousOwner","type":"address"},{"indexed":true,"internalType":"address","name":"newOwner","type":"address"}],"name":"OwnershipTransferred","type":"event"},{"inputs":[{"internalType":"uint256","name":"index","type":"uint256"},{"internalType":"address","name":"account","type":"address"},{"internalType":"uint256","name":"amount","type":"uint256"},{"internalType":"bytes32[]","name":"merkleProof","type":"bytes32[]"}],"name":"claim","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"addr","type":"address"}],"name":"isAddressClaimed","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"merkleRoot","outputs":[{"internalType":"bytes32","name":"","type":"bytes32"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"owner","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"pepemonId","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"renounceOwnership","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"bytes32","name":"_root","type":"bytes32"}],"name":"setMerkleRoot","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[],"name":"timelock","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"token","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"newOwner","type":"address"}],"name":"transferOwnership","outputs":[],"stateMutability":"nonpayable","type":"function"}]
+[
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "merkleRoot_", "type": "bytes32" },
+      { "internalType": "uint256", "name": "_pepemonId", "type": "uint256" },
+      { "internalType": "address", "name": "factory", "type": "address" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Claimed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "index", "type": "uint256" },
+      { "internalType": "address", "name": "account", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" },
+      {
+        "internalType": "bytes32[]",
+        "name": "merkleProof",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "claim",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "addr", "type": "address" }
+    ],
+    "name": "isAddressClaimed",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "merkleRoot",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pepemonId",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "_root", "type": "bytes32" }
+    ],
+    "name": "setMerkleRoot",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "timelock",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "token",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "newOwner", "type": "address" }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/packages/app/src/pepemon/lib/abi/merkle_distributor.json
+++ b/packages/app/src/pepemon/lib/abi/merkle_distributor.json
@@ -1,96 +1,124 @@
-[{
-	"inputs": [{
-		"internalType": "address",
-		"name": "pepemonFactory_",
-		"type": "address"
-	}, {
-		"internalType": "bytes32[]",
-		"name": "merkleRoots_",
-		"type": "bytes32[]"
-	}, {
-		"internalType": "uint256[]",
-		"name": "pepemonIds_",
-		"type": "uint256[]"
-	}],
-	"stateMutability": "nonpayable",
-	"type": "constructor"
-}, {
-	"anonymous": false,
-	"inputs": [{
-		"indexed": false,
-		"internalType": "uint256",
-		"name": "tokenId",
-		"type": "uint256"
-	}, {
-		"indexed": false,
-		"internalType": "uint256",
-		"name": "index",
-		"type": "uint256"
-	}, {
-		"indexed": false,
-		"internalType": "address",
-		"name": "account",
-		"type": "address"
-	}, {
-		"indexed": false,
-		"internalType": "uint256",
-		"name": "amount",
-		"type": "uint256"
-	}],
-	"name": "Claimed",
-	"type": "event"
-}, {
-	"inputs": [{
-		"internalType": "uint256",
-		"name": "tokenId",
-		"type": "uint256"
-	}, {
-		"internalType": "uint256",
-		"name": "index",
-		"type": "uint256"
-	}, {
-		"internalType": "address",
-		"name": "account",
-		"type": "address"
-	}, {
-		"internalType": "uint256",
-		"name": "amount",
-		"type": "uint256"
-	}, {
-		"internalType": "bytes32[]",
-		"name": "merkleProof",
-		"type": "bytes32[]"
-	}],
-	"name": "claim",
-	"outputs": [],
-	"stateMutability": "nonpayable",
-	"type": "function"
-}, {
-	"inputs": [],
-	"name": "factory",
-	"outputs": [{
-		"internalType": "contract IPepemonFactory",
-		"name": "",
-		"type": "address"
-	}],
-	"stateMutability": "view",
-	"type": "function"
-}, {
-	"inputs": [{
-		"internalType": "uint256",
-		"name": "pepemonTokenId",
-		"type": "uint256"
-	}, {
-		"internalType": "uint256",
-		"name": "index",
-		"type": "uint256"
-	}],
-	"name": "isClaimed",
-	"outputs": [{
-		"internalType": "bool",
-		"name": "",
-		"type": "bool"
-	}],
-	"stateMutability": "view",
-	"type": "function"
-}]
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pepemonFactory_",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "merkleRoots_",
+        "type": "bytes32[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "pepemonIds_",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Claimed",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32[]",
+        "name": "merkleProof",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "claim",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "factory",
+    "outputs": [
+      {
+        "internalType": "contract IPepemonFactory",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "pepemonTokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "isClaimed",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/packages/app/src/pepemon/lib/abi/pepemon_factory.json
+++ b/packages/app/src/pepemon/lib/abi/pepemon_factory.json
@@ -1,893 +1,893 @@
 [
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_proxyRegistryAddress",
-                "type": "address"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "constructor"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "_owner",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "_operator",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "bool",
-                "name": "_approved",
-                "type": "bool"
-            }
-        ],
-        "name": "ApprovalForAll",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
-        ],
-        "name": "MinterAdded",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
-        ],
-        "name": "MinterRemoved",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "previousOwner",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "newOwner",
-                "type": "address"
-            }
-        ],
-        "name": "OwnershipTransferred",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "_operator",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "_from",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "_to",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256[]",
-                "name": "_ids",
-                "type": "uint256[]"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256[]",
-                "name": "_amounts",
-                "type": "uint256[]"
-            }
-        ],
-        "name": "TransferBatch",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "_operator",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "_from",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "_to",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "_id",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "_amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "TransferSingle",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": false,
-                "internalType": "string",
-                "name": "_uri",
-                "type": "string"
-            },
-            {
-                "indexed": true,
-                "internalType": "uint256",
-                "name": "_id",
-                "type": "uint256"
-            }
-        ],
-        "name": "URI",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
-        ],
-        "name": "WhitelistAdminAdded",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
-        ],
-        "name": "WhitelistAdminRemoved",
-        "type": "event"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
-        ],
-        "name": "addMinter",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
-        ],
-        "name": "addWhitelistAdmin",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_owner",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_id",
-                "type": "uint256"
-            }
-        ],
-        "name": "balanceOf",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [
-            {
-                "internalType": "address[]",
-                "name": "_owners",
-                "type": "address[]"
-            },
-            {
-                "internalType": "uint256[]",
-                "name": "_ids",
-                "type": "uint256[]"
-            }
-        ],
-        "name": "balanceOfBatch",
-        "outputs": [
-            {
-                "internalType": "uint256[]",
-                "name": "",
-                "type": "uint256[]"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_maxSupply",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_initialSupply",
-                "type": "uint256"
-            },
-            {
-                "internalType": "string",
-                "name": "_uri",
-                "type": "string"
-            },
-            {
-                "internalType": "bytes",
-                "name": "_data",
-                "type": "bytes"
-            }
-        ],
-        "name": "create",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "tokenId",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "name": "creators",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_owner",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "_operator",
-                "type": "address"
-            }
-        ],
-        "name": "isApprovedForAll",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "isOperator",
-                "type": "bool"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
-        ],
-        "name": "isMinter",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "isOwner",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
-        ],
-        "name": "isWhitelistAdmin",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_id",
-                "type": "uint256"
-            }
-        ],
-        "name": "maxSupply",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_to",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_id",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_quantity",
-                "type": "uint256"
-            },
-            {
-                "internalType": "bytes",
-                "name": "_data",
-                "type": "bytes"
-            }
-        ],
-        "name": "mint",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "name",
-        "outputs": [
-            {
-                "internalType": "string",
-                "name": "",
-                "type": "string"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "owner",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
-        ],
-        "name": "removeMinter",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
-        ],
-        "name": "removeWhitelistAdmin",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [],
-        "name": "renounceMinter",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [],
-        "name": "renounceOwnership",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [],
-        "name": "renounceWhitelistAdmin",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_from",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "_to",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256[]",
-                "name": "_ids",
-                "type": "uint256[]"
-            },
-            {
-                "internalType": "uint256[]",
-                "name": "_amounts",
-                "type": "uint256[]"
-            },
-            {
-                "internalType": "bytes",
-                "name": "_data",
-                "type": "bytes"
-            }
-        ],
-        "name": "safeBatchTransferFrom",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_from",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "_to",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_id",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_amount",
-                "type": "uint256"
-            },
-            {
-                "internalType": "bytes",
-                "name": "_data",
-                "type": "bytes"
-            }
-        ],
-        "name": "safeTransferFrom",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_operator",
-                "type": "address"
-            },
-            {
-                "internalType": "bool",
-                "name": "_approved",
-                "type": "bool"
-            }
-        ],
-        "name": "setApprovalForAll",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [
-            {
-                "internalType": "bytes4",
-                "name": "_interfaceID",
-                "type": "bytes4"
-            }
-        ],
-        "name": "supportsInterface",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "symbol",
-        "outputs": [
-            {
-                "internalType": "string",
-                "name": "",
-                "type": "string"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "name": "tokenMaxSupply",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "name": "tokenSupply",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_id",
-                "type": "uint256"
-            }
-        ],
-        "name": "totalSupply",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "newOwner",
-                "type": "address"
-            }
-        ],
-        "name": "transferOwnership",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_id",
-                "type": "uint256"
-            }
-        ],
-        "name": "uri",
-        "outputs": [
-            {
-                "internalType": "string",
-                "name": "",
-                "type": "string"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "string",
-                "name": "newURI",
-                "type": "string"
-            }
-        ],
-        "name": "setBaseMetadataURI",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "string",
-                "name": "newURI",
-                "type": "string"
-            }
-        ],
-        "name": "setContractURI",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "contractURI",
-        "outputs": [
-            {
-                "internalType": "string",
-                "name": "",
-                "type": "string"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_id",
-                "type": "uint256"
-            }
-        ],
-        "name": "endMinting",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_account",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_id",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "burn",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_id",
-                "type": "uint256"
-            },
-            {
-                "internalType": "address[]",
-                "name": "_addresses",
-                "type": "address[]"
-            }
-        ],
-        "name": "airdrop",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    }
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_proxyRegistryAddress",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_operator",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "_approved",
+        "type": "bool"
+      }
+    ],
+    "name": "ApprovalForAll",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "MinterAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "MinterRemoved",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_operator",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "_ids",
+        "type": "uint256[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "_amounts",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "TransferBatch",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_operator",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_id",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "TransferSingle",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "_uri",
+        "type": "string"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "_id",
+        "type": "uint256"
+      }
+    ],
+    "name": "URI",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "WhitelistAdminAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "WhitelistAdminRemoved",
+    "type": "event"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "addMinter",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "addWhitelistAdmin",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_owner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_id",
+        "type": "uint256"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "_owners",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "_ids",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "balanceOfBatch",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_maxSupply",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_initialSupply",
+        "type": "uint256"
+      },
+      {
+        "internalType": "string",
+        "name": "_uri",
+        "type": "string"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_data",
+        "type": "bytes"
+      }
+    ],
+    "name": "create",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "creators",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_operator",
+        "type": "address"
+      }
+    ],
+    "name": "isApprovedForAll",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "isOperator",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "isMinter",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "isOwner",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "isWhitelistAdmin",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_id",
+        "type": "uint256"
+      }
+    ],
+    "name": "maxSupply",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_id",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_quantity",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_data",
+        "type": "bytes"
+      }
+    ],
+    "name": "mint",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "removeMinter",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "removeWhitelistAdmin",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "renounceMinter",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "renounceWhitelistAdmin",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "_ids",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "_amounts",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_data",
+        "type": "bytes"
+      }
+    ],
+    "name": "safeBatchTransferFrom",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_id",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_data",
+        "type": "bytes"
+      }
+    ],
+    "name": "safeTransferFrom",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_operator",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_approved",
+        "type": "bool"
+      }
+    ],
+    "name": "setApprovalForAll",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "bytes4",
+        "name": "_interfaceID",
+        "type": "bytes4"
+      }
+    ],
+    "name": "supportsInterface",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "tokenMaxSupply",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "tokenSupply",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_id",
+        "type": "uint256"
+      }
+    ],
+    "name": "totalSupply",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_id",
+        "type": "uint256"
+      }
+    ],
+    "name": "uri",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "newURI",
+        "type": "string"
+      }
+    ],
+    "name": "setBaseMetadataURI",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "newURI",
+        "type": "string"
+      }
+    ],
+    "name": "setContractURI",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "contractURI",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_id",
+        "type": "uint256"
+      }
+    ],
+    "name": "endMinting",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_id",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "burn",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_id",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address[]",
+        "name": "_addresses",
+        "type": "address[]"
+      }
+    ],
+    "name": "airdrop",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
 ]

--- a/packages/app/src/pepemon/lib/abi/pepemon_lottery.json
+++ b/packages/app/src/pepemon/lib/abi/pepemon_lottery.json
@@ -1,528 +1,528 @@
 [
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_UniV2Address",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "_PPDEX",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "_pepemonFactory",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_blockTime",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "nonpayable",
-        "type": "constructor"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "previousOwner",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "newOwner",
-                "type": "address"
-            }
-        ],
-        "name": "OwnershipTransferred",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "user",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "id",
-                "type": "uint256"
-            }
-        ],
-        "name": "Redeemed",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "user",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "Staked",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "user",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "Unstaked",
-        "type": "event"
-    },
-    {
-        "inputs": [],
-        "name": "PPDEX",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function",
-        "constant": true
-    },
-    {
-        "inputs": [],
-        "name": "UniV2Address",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function",
-        "constant": true
-    },
-    {
-        "inputs": [],
-        "name": "blockTime",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function",
-        "constant": true
-    },
-    {
-        "inputs": [],
-        "name": "goldenID",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function",
-        "constant": true
-    },
-    {
-        "inputs": [],
-        "name": "minPPDEX",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function",
-        "constant": true
-    },
-    {
-        "inputs": [],
-        "name": "minPPDEXGolden",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function",
-        "constant": true
-    },
-    {
-        "inputs": [],
-        "name": "normalID",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function",
-        "constant": true
-    },
-    {
-        "inputs": [],
-        "name": "owner",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function",
-        "constant": true
-    },
-    {
-        "inputs": [],
-        "name": "pepemonFactory",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function",
-        "constant": true
-    },
-    {
-        "inputs": [],
-        "name": "renounceOwnership",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "stakingDeadline",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function",
-        "constant": true
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "newOwner",
-                "type": "address"
-            }
-        ],
-        "name": "transferOwnership",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "addr",
-                "type": "address"
-            }
-        ],
-        "name": "setUniV2Address",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_PPDEX",
-                "type": "address"
-            }
-        ],
-        "name": "setPPDEX",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_pepemonFactory",
-                "type": "address"
-            }
-        ],
-        "name": "setPepemonFactory",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_minPPDEXGolden",
-                "type": "uint256"
-            }
-        ],
-        "name": "setminPPDEXGolden",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_minPPDEX",
-                "type": "uint256"
-            }
-        ],
-        "name": "setminPPDEX",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_normalID",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_goldenID",
-                "type": "uint256"
-            }
-        ],
-        "name": "updateNFT",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "MinLPTokens",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function",
-        "constant": true
-    },
-    {
-        "inputs": [],
-        "name": "MinLPTokensGolden",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function",
-        "constant": true
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "lp",
-                "type": "uint256"
-            }
-        ],
-        "name": "LPToPPDEX",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function",
-        "constant": true
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "addr",
-                "type": "address"
-            }
-        ],
-        "name": "getStakingStart",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function",
-        "constant": true
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "addr",
-                "type": "address"
-            }
-        ],
-        "name": "getLPBalance",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function",
-        "constant": true
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "addr",
-                "type": "address"
-            }
-        ],
-        "name": "isUserStaking",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function",
-        "constant": true
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "addr",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "id",
-                "type": "uint256"
-            }
-        ],
-        "name": "hasUserMinted",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function",
-        "constant": true
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "addr",
-                "type": "address"
-            }
-        ],
-        "name": "isUserStakingNormalNFT",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function",
-        "constant": true
-    },
-    {
-        "inputs": [],
-        "name": "stakeForNormalNFT",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "stakeForGoldenNFT",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "withdrawLP",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "mintNFT",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    }
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_UniV2Address",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_PPDEX",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_pepemonFactory",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_blockTime",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "Redeemed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Staked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Unstaked",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "PPDEX",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "constant": true
+  },
+  {
+    "inputs": [],
+    "name": "UniV2Address",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "constant": true
+  },
+  {
+    "inputs": [],
+    "name": "blockTime",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "constant": true
+  },
+  {
+    "inputs": [],
+    "name": "goldenID",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "constant": true
+  },
+  {
+    "inputs": [],
+    "name": "minPPDEX",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "constant": true
+  },
+  {
+    "inputs": [],
+    "name": "minPPDEXGolden",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "constant": true
+  },
+  {
+    "inputs": [],
+    "name": "normalID",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "constant": true
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "constant": true
+  },
+  {
+    "inputs": [],
+    "name": "pepemonFactory",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "constant": true
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "stakingDeadline",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "constant": true
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "addr",
+        "type": "address"
+      }
+    ],
+    "name": "setUniV2Address",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_PPDEX",
+        "type": "address"
+      }
+    ],
+    "name": "setPPDEX",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_pepemonFactory",
+        "type": "address"
+      }
+    ],
+    "name": "setPepemonFactory",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_minPPDEXGolden",
+        "type": "uint256"
+      }
+    ],
+    "name": "setminPPDEXGolden",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_minPPDEX",
+        "type": "uint256"
+      }
+    ],
+    "name": "setminPPDEX",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_normalID",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_goldenID",
+        "type": "uint256"
+      }
+    ],
+    "name": "updateNFT",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MinLPTokens",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "constant": true
+  },
+  {
+    "inputs": [],
+    "name": "MinLPTokensGolden",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "constant": true
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "lp",
+        "type": "uint256"
+      }
+    ],
+    "name": "LPToPPDEX",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "constant": true
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "addr",
+        "type": "address"
+      }
+    ],
+    "name": "getStakingStart",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "constant": true
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "addr",
+        "type": "address"
+      }
+    ],
+    "name": "getLPBalance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "constant": true
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "addr",
+        "type": "address"
+      }
+    ],
+    "name": "isUserStaking",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "constant": true
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "addr",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "hasUserMinted",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "constant": true
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "addr",
+        "type": "address"
+      }
+    ],
+    "name": "isUserStakingNormalNFT",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function",
+    "constant": true
+  },
+  {
+    "inputs": [],
+    "name": "stakeForNormalNFT",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "stakeForGoldenNFT",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "withdrawLP",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "mintNFT",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
 ]

--- a/packages/app/src/pepemon/lib/abi/pepemon_promo_store.json
+++ b/packages/app/src/pepemon/lib/abi/pepemon_promo_store.json
@@ -1,347 +1,347 @@
 [
-    {
-        "inputs": [
-            {
-                "internalType": "contract ERC1155Tradable",
-                "name": "_PepemonFactoryAddress",
-                "type": "address"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "constructor"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "card",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "points",
-                "type": "uint256"
-            }
-        ],
-        "name": "CardAdded",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "previousOwner",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "newOwner",
-                "type": "address"
-            }
-        ],
-        "name": "OwnershipTransferred",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "user",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "Redeemed",
-        "type": "event"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "PepemonFactory",
-        "outputs": [
-            {
-                "internalType": "contract ERC1155Tradable",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "name": "cardCosts",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "fundAddress",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "fundPercentage",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "isOwner",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "owner",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "promoAddress",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [],
-        "name": "renounceOwnership",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "secondaryFundAddress",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "secondaryFundPercentage",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "name": "totalSpend",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "newOwner",
-                "type": "address"
-            }
-        ],
-        "name": "transferOwnership",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_promoAddress",
-                "type": "address"
-            }
-        ],
-        "name": "setPromoToken",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_fundAddress",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_percentage",
-                "type": "uint256"
-            }
-        ],
-        "name": "setFundAddress",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_secondaryFundAddress",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_percentage",
-                "type": "uint256"
-            }
-        ],
-        "name": "setSecondaryFundAddress",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "cardId",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "addCard",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "card",
-                "type": "uint256"
-            }
-        ],
-        "name": "redeem",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    }
+  {
+    "inputs": [
+      {
+        "internalType": "contract ERC1155Tradable",
+        "name": "_PepemonFactoryAddress",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "card",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "points",
+        "type": "uint256"
+      }
+    ],
+    "name": "CardAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Redeemed",
+    "type": "event"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "PepemonFactory",
+    "outputs": [
+      {
+        "internalType": "contract ERC1155Tradable",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "cardCosts",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "fundAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "fundPercentage",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "isOwner",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "promoAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "secondaryFundAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "secondaryFundPercentage",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "totalSpend",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_promoAddress",
+        "type": "address"
+      }
+    ],
+    "name": "setPromoToken",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_fundAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_percentage",
+        "type": "uint256"
+      }
+    ],
+    "name": "setFundAddress",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_secondaryFundAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_percentage",
+        "type": "uint256"
+      }
+    ],
+    "name": "setSecondaryFundAddress",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "cardId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "addCard",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "card",
+        "type": "uint256"
+      }
+    ],
+    "name": "redeem",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
 ]

--- a/packages/app/src/pepemon/lib/abi/pepemon_stake.json
+++ b/packages/app/src/pepemon/lib/abi/pepemon_stake.json
@@ -1,630 +1,629 @@
 [
-    {
-        "inputs": [
-            {
-                "internalType": "contract IPepemonFactory",
-                "name": "_pepemonFactoryAddress",
-                "type": "address"
-            }
+  {
+    "inputs": [
+      {
+        "internalType": "contract IPepemonFactory",
+        "name": "_pepemonFactoryAddress",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "eventId",
+        "type": "uint256"
+      }
+    ],
+    "name": "StakingEventCancelled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "eventId",
+        "type": "uint256"
+      }
+    ],
+    "name": "StakingEventCompleted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "eventId",
+        "type": "uint256"
+      }
+    ],
+    "name": "StakingEventCreated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "eventId",
+        "type": "uint256"
+      }
+    ],
+    "name": "StakingEventEntered",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "cardsStaked",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isOwner",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pepemonFactory",
+    "outputs": [
+      {
+        "internalType": "contract IPepemonFactory",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "stakingEvents",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "cardAmountAny",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "cardRewardId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "blockStakeLength",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "blockEventClose",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "userInfo",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "isCompleted",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "blockEnd",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getStakingEventsLength",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getAllEvents",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256[]",
+            "name": "cardIdList",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256",
+            "name": "cardAmountAny",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "cardAmountList",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256",
+            "name": "cardRewardId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "blockStakeLength",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "blockEventClose",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "toBurnIdList",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "toBurnAmountList",
+            "type": "uint256[]"
+          }
         ],
-        "stateMutability": "nonpayable",
-        "type": "constructor"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "previousOwner",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "newOwner",
-                "type": "address"
-            }
-        ],
-        "name": "OwnershipTransferred",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "user",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "eventId",
-                "type": "uint256"
-            }
-        ],
-        "name": "StakingEventCancelled",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "user",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "eventId",
-                "type": "uint256"
-            }
-        ],
-        "name": "StakingEventCompleted",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "eventId",
-                "type": "uint256"
-            }
-        ],
-        "name": "StakingEventCreated",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "user",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "eventId",
-                "type": "uint256"
-            }
-        ],
-        "name": "StakingEventEntered",
-        "type": "event"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "name": "cardsStaked",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "isOwner",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "owner",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "pepemonFactory",
-        "outputs": [
-            {
-                "internalType": "contract IPepemonFactory",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "renounceOwnership",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "name": "stakingEvents",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "cardAmountAny",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "cardRewardId",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "blockStakeLength",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "blockEventClose",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "newOwner",
-                "type": "address"
-            }
-        ],
-        "name": "transferOwnership",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "name": "userInfo",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "isCompleted",
-                "type": "bool"
-            },
-            {
-                "internalType": "uint256",
-                "name": "blockEnd",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "getStakingEventsLength",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "getAllEvents",
-        "outputs": [
-            {
-                "components": [
-                    {
-                        "internalType": "uint256[]",
-                        "name": "cardIdList",
-                        "type": "uint256[]"
-                    },
-                    {
-                        "internalType": "uint256",
-                        "name": "cardAmountAny",
-                        "type": "uint256"
-                    },
-                    {
-                        "internalType": "uint256[]",
-                        "name": "cardAmountList",
-                        "type": "uint256[]"
-                    },
-                    {
-                        "internalType": "uint256",
-                        "name": "cardRewardId",
-                        "type": "uint256"
-                    },
-                    {
-                        "internalType": "uint256",
-                        "name": "blockStakeLength",
-                        "type": "uint256"
-                    },
-                    {
-                        "internalType": "uint256",
-                        "name": "blockEventClose",
-                        "type": "uint256"
-                    },
-                    {
-                        "internalType": "uint256[]",
-                        "name": "toBurnIdList",
-                        "type": "uint256[]"
-                    },
-                    {
-                        "internalType": "uint256[]",
-                        "name": "toBurnAmountList",
-                        "type": "uint256[]"
-                    }
-                ],
-                "internalType": "struct PepemonStake.StakingEvent[]",
-                "name": "",
-                "type": "tuple[]"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "getActiveEvents",
-        "outputs": [
-            {
-                "internalType": "uint256[]",
-                "name": "",
-                "type": "uint256[]"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "getClosedEvents",
-        "outputs": [
-            {
-                "internalType": "uint256[]",
-                "name": "",
-                "type": "uint256[]"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_eventId",
-                "type": "uint256"
-            }
-        ],
-        "name": "getCardIdListOfEvent",
-        "outputs": [
-            {
-                "internalType": "uint256[]",
-                "name": "",
-                "type": "uint256[]"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_eventId",
-                "type": "uint256"
-            }
-        ],
-        "name": "getCardAmountListOfEvent",
-        "outputs": [
-            {
-                "internalType": "uint256[]",
-                "name": "",
-                "type": "uint256[]"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_user",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_eventId",
-                "type": "uint256"
-            }
-        ],
-        "name": "getUserProgress",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256[]",
-                "name": "_cardIdList",
-                "type": "uint256[]"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_cardAmountAny",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256[]",
-                "name": "_cardAmountList",
-                "type": "uint256[]"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_cardRewardId",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_blockStakeLength",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_blockEventClose",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256[]",
-                "name": "_toBurnIdList",
-                "type": "uint256[]"
-            },
-            {
-                "internalType": "uint256[]",
-                "name": "_toBurnAmountList",
-                "type": "uint256[]"
-            }
-        ],
-        "name": "createStakingEvent",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_eventId",
-                "type": "uint256"
-            }
-        ],
-        "name": "closeStakingEvent",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_eventId",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256[]",
-                "name": "_cardIdList",
-                "type": "uint256[]"
-            },
-            {
-                "internalType": "uint256[]",
-                "name": "_cardAmountList",
-                "type": "uint256[]"
-            }
-        ],
-        "name": "stakeAny",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_eventId",
-                "type": "uint256"
-            }
-        ],
-        "name": "stake",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_eventId",
-                "type": "uint256"
-            }
-        ],
-        "name": "claim",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_eventId",
-                "type": "uint256"
-            }
-        ],
-        "name": "cancel",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_operator",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "_from",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_id",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "_amount",
-                "type": "uint256"
-            },
-            {
-                "internalType": "bytes",
-                "name": "_data",
-                "type": "bytes"
-            }
-        ],
-        "name": "onERC1155Received",
-        "outputs": [
-            {
-                "internalType": "bytes4",
-                "name": "",
-                "type": "bytes4"
-            }
-        ],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_operator",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "_from",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256[]",
-                "name": "_ids",
-                "type": "uint256[]"
-            },
-            {
-                "internalType": "uint256[]",
-                "name": "_amounts",
-                "type": "uint256[]"
-            },
-            {
-                "internalType": "bytes",
-                "name": "_data",
-                "type": "bytes"
-            }
-        ],
-        "name": "onERC1155BatchReceived",
-        "outputs": [
-            {
-                "internalType": "bytes4",
-                "name": "",
-                "type": "bytes4"
-            }
-        ],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "bytes4",
-                "name": "interfaceID",
-                "type": "bytes4"
-            }
-        ],
-        "name": "supportsInterface",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    }
+        "internalType": "struct PepemonStake.StakingEvent[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getActiveEvents",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getClosedEvents",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_eventId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getCardIdListOfEvent",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_eventId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getCardAmountListOfEvent",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_user",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_eventId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getUserProgress",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "_cardIdList",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_cardAmountAny",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "_cardAmountList",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_cardRewardId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_blockStakeLength",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_blockEventClose",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "_toBurnIdList",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "_toBurnAmountList",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "createStakingEvent",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_eventId",
+        "type": "uint256"
+      }
+    ],
+    "name": "closeStakingEvent",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_eventId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "_cardIdList",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "_cardAmountList",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "stakeAny",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_eventId",
+        "type": "uint256"
+      }
+    ],
+    "name": "stake",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_eventId",
+        "type": "uint256"
+      }
+    ],
+    "name": "claim",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_eventId",
+        "type": "uint256"
+      }
+    ],
+    "name": "cancel",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_operator",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_from",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_id",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_data",
+        "type": "bytes"
+      }
+    ],
+    "name": "onERC1155Received",
+    "outputs": [
+      {
+        "internalType": "bytes4",
+        "name": "",
+        "type": "bytes4"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_operator",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_from",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "_ids",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "_amounts",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_data",
+        "type": "bytes"
+      }
+    ],
+    "name": "onERC1155BatchReceived",
+    "outputs": [
+      {
+        "internalType": "bytes4",
+        "name": "",
+        "type": "bytes4"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes4",
+        "name": "interfaceID",
+        "type": "bytes4"
+      }
+    ],
+    "name": "supportsInterface",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
 ]
-

--- a/packages/app/src/pepemon/lib/abi/pepemon_store_native.json
+++ b/packages/app/src/pepemon/lib/abi/pepemon_store_native.json
@@ -1,1 +1,191 @@
-[{"inputs":[{"internalType":"contract ERC1155Tradable","name":"_PepemonFactoryAddress","type":"address"}],"payable":false,"stateMutability":"nonpayable","type":"constructor"},{"anonymous":false,"inputs":[{"indexed":false,"internalType":"uint256","name":"card","type":"uint256"},{"indexed":false,"internalType":"uint256","name":"points","type":"uint256"}],"name":"CardAdded","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"previousOwner","type":"address"},{"indexed":true,"internalType":"address","name":"newOwner","type":"address"}],"name":"OwnershipTransferred","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"user","type":"address"},{"indexed":false,"internalType":"uint256","name":"amount","type":"uint256"}],"name":"Redeemed","type":"event"},{"constant":true,"inputs":[],"name":"PepemonFactory","outputs":[{"internalType":"contract ERC1155Tradable","name":"","type":"address"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"internalType":"uint256","name":"cardId","type":"uint256"},{"internalType":"uint256","name":"amount","type":"uint256"}],"name":"addCard","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[{"internalType":"uint256","name":"","type":"uint256"}],"name":"cardCosts","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[],"name":"fundAddress","outputs":[{"internalType":"address payable","name":"","type":"address"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[],"name":"isOwner","outputs":[{"internalType":"bool","name":"","type":"bool"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":true,"inputs":[],"name":"owner","outputs":[{"internalType":"address","name":"","type":"address"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"internalType":"uint256","name":"card","type":"uint256"}],"name":"redeem","outputs":[],"payable":true,"stateMutability":"payable","type":"function"},{"constant":false,"inputs":[],"name":"renounceOwnership","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":false,"inputs":[{"internalType":"address payable","name":"_fundAddress","type":"address"}],"name":"setFundAddress","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"totalBNBspend","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[{"internalType":"address","name":"newOwner","type":"address"}],"name":"transferOwnership","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}]
+[
+  {
+    "inputs": [
+      {
+        "internalType": "contract ERC1155Tradable",
+        "name": "_PepemonFactoryAddress",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "card",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "points",
+        "type": "uint256"
+      }
+    ],
+    "name": "CardAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Redeemed",
+    "type": "event"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "PepemonFactory",
+    "outputs": [
+      {
+        "internalType": "contract ERC1155Tradable",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "uint256", "name": "cardId", "type": "uint256" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "addCard",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "name": "cardCosts",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "fundAddress",
+    "outputs": [
+      { "internalType": "address payable", "name": "", "type": "address" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "isOwner",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "owner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "uint256", "name": "card", "type": "uint256" }
+    ],
+    "name": "redeem",
+    "outputs": [],
+    "payable": true,
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address payable",
+        "name": "_fundAddress",
+        "type": "address"
+      }
+    ],
+    "name": "setFundAddress",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "totalBNBspend",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "newOwner", "type": "address" }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/packages/app/src/pepemon/lib/abi/ppblz.json
+++ b/packages/app/src/pepemon/lib/abi/ppblz.json
@@ -1,1 +1,542 @@
-[{"inputs":[{"internalType":"string","name":"name","type":"string"},{"internalType":"string","name":"symbol","type":"string"},{"internalType":"uint8","name":"decimals","type":"uint8"},{"internalType":"uint256","name":"cap","type":"uint256"},{"internalType":"uint256","name":"initialSupply","type":"uint256"},{"internalType":"bool","name":"transferEnabled","type":"bool"},{"internalType":"bool","name":"mintingFinished","type":"bool"}],"stateMutability":"nonpayable","type":"constructor"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"owner","type":"address"},{"indexed":true,"internalType":"address","name":"spender","type":"address"},{"indexed":false,"internalType":"uint256","name":"value","type":"uint256"}],"name":"Approval","type":"event"},{"anonymous":false,"inputs":[],"name":"MintFinished","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"previousOwner","type":"address"},{"indexed":true,"internalType":"address","name":"newOwner","type":"address"}],"name":"OwnershipTransferred","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"bytes32","name":"role","type":"bytes32"},{"indexed":true,"internalType":"bytes32","name":"previousAdminRole","type":"bytes32"},{"indexed":true,"internalType":"bytes32","name":"newAdminRole","type":"bytes32"}],"name":"RoleAdminChanged","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"bytes32","name":"role","type":"bytes32"},{"indexed":true,"internalType":"address","name":"account","type":"address"},{"indexed":true,"internalType":"address","name":"sender","type":"address"}],"name":"RoleGranted","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"bytes32","name":"role","type":"bytes32"},{"indexed":true,"internalType":"address","name":"account","type":"address"},{"indexed":true,"internalType":"address","name":"sender","type":"address"}],"name":"RoleRevoked","type":"event"},{"anonymous":false,"inputs":[{"indexed":true,"internalType":"address","name":"from","type":"address"},{"indexed":true,"internalType":"address","name":"to","type":"address"},{"indexed":false,"internalType":"uint256","name":"value","type":"uint256"}],"name":"Transfer","type":"event"},{"anonymous":false,"inputs":[],"name":"TransferEnabled","type":"event"},{"inputs":[],"name":"DEFAULT_ADMIN_ROLE","outputs":[{"internalType":"bytes32","name":"","type":"bytes32"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"MINTER_ROLE","outputs":[{"internalType":"bytes32","name":"","type":"bytes32"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"OPERATOR_ROLE","outputs":[{"internalType":"bytes32","name":"","type":"bytes32"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"owner","type":"address"},{"internalType":"address","name":"spender","type":"address"}],"name":"allowance","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"spender","type":"address"},{"internalType":"uint256","name":"amount","type":"uint256"}],"name":"approve","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"spender","type":"address"},{"internalType":"uint256","name":"value","type":"uint256"}],"name":"approveAndCall","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"spender","type":"address"},{"internalType":"uint256","name":"value","type":"uint256"},{"internalType":"bytes","name":"data","type":"bytes"}],"name":"approveAndCall","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"account","type":"address"}],"name":"balanceOf","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"uint256","name":"amount","type":"uint256"}],"name":"burn","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"account","type":"address"},{"internalType":"uint256","name":"amount","type":"uint256"}],"name":"burnFrom","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[],"name":"cap","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"decimals","outputs":[{"internalType":"uint8","name":"","type":"uint8"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"spender","type":"address"},{"internalType":"uint256","name":"subtractedValue","type":"uint256"}],"name":"decreaseAllowance","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"nonpayable","type":"function"},{"inputs":[],"name":"enableTransfer","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[],"name":"finishMinting","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[],"name":"generator","outputs":[{"internalType":"string","name":"","type":"string"}],"stateMutability":"pure","type":"function"},{"inputs":[{"internalType":"bytes32","name":"role","type":"bytes32"}],"name":"getRoleAdmin","outputs":[{"internalType":"bytes32","name":"","type":"bytes32"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"bytes32","name":"role","type":"bytes32"},{"internalType":"uint256","name":"index","type":"uint256"}],"name":"getRoleMember","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"bytes32","name":"role","type":"bytes32"}],"name":"getRoleMemberCount","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"bytes32","name":"role","type":"bytes32"},{"internalType":"address","name":"account","type":"address"}],"name":"grantRole","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"bytes32","name":"role","type":"bytes32"},{"internalType":"address","name":"account","type":"address"}],"name":"hasRole","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"spender","type":"address"},{"internalType":"uint256","name":"addedValue","type":"uint256"}],"name":"increaseAllowance","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"to","type":"address"},{"internalType":"uint256","name":"value","type":"uint256"}],"name":"mint","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[],"name":"mintingFinished","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"name","outputs":[{"internalType":"string","name":"","type":"string"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"owner","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"tokenAddress","type":"address"},{"internalType":"uint256","name":"tokenAmount","type":"uint256"}],"name":"recoverERC20","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[],"name":"renounceOwnership","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"bytes32","name":"role","type":"bytes32"},{"internalType":"address","name":"account","type":"address"}],"name":"renounceRole","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"bytes32","name":"role","type":"bytes32"},{"internalType":"address","name":"account","type":"address"}],"name":"revokeRole","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"bytes4","name":"interfaceId","type":"bytes4"}],"name":"supportsInterface","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"symbol","outputs":[{"internalType":"string","name":"","type":"string"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"totalSupply","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"to","type":"address"},{"internalType":"uint256","name":"value","type":"uint256"}],"name":"transfer","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"to","type":"address"},{"internalType":"uint256","name":"value","type":"uint256"}],"name":"transferAndCall","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"to","type":"address"},{"internalType":"uint256","name":"value","type":"uint256"},{"internalType":"bytes","name":"data","type":"bytes"}],"name":"transferAndCall","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"nonpayable","type":"function"},{"inputs":[],"name":"transferEnabled","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"from","type":"address"},{"internalType":"address","name":"to","type":"address"},{"internalType":"uint256","name":"value","type":"uint256"}],"name":"transferFrom","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"from","type":"address"},{"internalType":"address","name":"to","type":"address"},{"internalType":"uint256","name":"value","type":"uint256"},{"internalType":"bytes","name":"data","type":"bytes"}],"name":"transferFromAndCall","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"from","type":"address"},{"internalType":"address","name":"to","type":"address"},{"internalType":"uint256","name":"value","type":"uint256"}],"name":"transferFromAndCall","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"newOwner","type":"address"}],"name":"transferOwnership","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[],"name":"version","outputs":[{"internalType":"string","name":"","type":"string"}],"stateMutability":"pure","type":"function"}]
+[
+  {
+    "inputs": [
+      { "internalType": "string", "name": "name", "type": "string" },
+      { "internalType": "string", "name": "symbol", "type": "string" },
+      { "internalType": "uint8", "name": "decimals", "type": "uint8" },
+      { "internalType": "uint256", "name": "cap", "type": "uint256" },
+      { "internalType": "uint256", "name": "initialSupply", "type": "uint256" },
+      { "internalType": "bool", "name": "transferEnabled", "type": "bool" },
+      { "internalType": "bool", "name": "mintingFinished", "type": "bool" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  { "anonymous": false, "inputs": [], "name": "MintFinished", "type": "event" },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "previousAdminRole",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "newAdminRole",
+        "type": "bytes32"
+      }
+    ],
+    "name": "RoleAdminChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleGranted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleRevoked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [],
+    "name": "TransferEnabled",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "DEFAULT_ADMIN_ROLE",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MINTER_ROLE",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "OPERATOR_ROLE",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "owner", "type": "address" },
+      { "internalType": "address", "name": "spender", "type": "address" }
+    ],
+    "name": "allowance",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "approve",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "value", "type": "uint256" }
+    ],
+    "name": "approveAndCall",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "value", "type": "uint256" },
+      { "internalType": "bytes", "name": "data", "type": "bytes" }
+    ],
+    "name": "approveAndCall",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "balanceOf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "burn",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "account", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "burnFrom",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "cap",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [{ "internalType": "uint8", "name": "", "type": "uint8" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      {
+        "internalType": "uint256",
+        "name": "subtractedValue",
+        "type": "uint256"
+      }
+    ],
+    "name": "decreaseAllowance",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "enableTransfer",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "finishMinting",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "generator",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" }
+    ],
+    "name": "getRoleAdmin",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "uint256", "name": "index", "type": "uint256" }
+    ],
+    "name": "getRoleMember",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" }
+    ],
+    "name": "getRoleMemberCount",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "grantRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "hasRole",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "addedValue", "type": "uint256" }
+    ],
+    "name": "increaseAllowance",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "value", "type": "uint256" }
+    ],
+    "name": "mint",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "mintingFinished",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "tokenAddress", "type": "address" },
+      { "internalType": "uint256", "name": "tokenAmount", "type": "uint256" }
+    ],
+    "name": "recoverERC20",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "renounceRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "revokeRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes4", "name": "interfaceId", "type": "bytes4" }
+    ],
+    "name": "supportsInterface",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "value", "type": "uint256" }
+    ],
+    "name": "transfer",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "value", "type": "uint256" }
+    ],
+    "name": "transferAndCall",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "value", "type": "uint256" },
+      { "internalType": "bytes", "name": "data", "type": "bytes" }
+    ],
+    "name": "transferAndCall",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "transferEnabled",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "from", "type": "address" },
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "value", "type": "uint256" }
+    ],
+    "name": "transferFrom",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "from", "type": "address" },
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "value", "type": "uint256" },
+      { "internalType": "bytes", "name": "data", "type": "bytes" }
+    ],
+    "name": "transferFromAndCall",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "from", "type": "address" },
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "value", "type": "uint256" }
+    ],
+    "name": "transferFromAndCall",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "newOwner", "type": "address" }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "version",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "pure",
+    "type": "function"
+  }
+]

--- a/packages/app/src/pepemon/lib/abi/ppdex.json
+++ b/packages/app/src/pepemon/lib/abi/ppdex.json
@@ -1,680 +1,680 @@
 [
-    {
-        "inputs": [],
-        "stateMutability": "nonpayable",
-        "type": "constructor"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "owner",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "spender",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "value",
-                "type": "uint256"
-            }
-        ],
-        "name": "Approval",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "user",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "totalPpblzStaked",
-                "type": "uint256"
-            }
-        ],
-        "name": "PpblzStaked",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "user",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "PpblzWithdrawn",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "user",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "reward",
-                "type": "uint256"
-            }
-        ],
-        "name": "Rewards",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "from",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "to",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "value",
-                "type": "uint256"
-            }
-        ],
-        "name": "Transfer",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "user",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "totalUniV2Staked",
-                "type": "uint256"
-            }
-        ],
-        "name": "UniV2Staked",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "user",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "UniV2Withdrawn",
-        "type": "event"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "owner",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "spender",
-                "type": "address"
-            }
-        ],
-        "name": "allowance",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "spender",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "approve",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
-        ],
-        "name": "balanceOf",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "decimals",
-        "outputs": [
-            {
-                "internalType": "uint8",
-                "name": "",
-                "type": "uint8"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "spender",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "subtractedValue",
-                "type": "uint256"
-            }
-        ],
-        "name": "decreaseAllowance",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "spender",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "addedValue",
-                "type": "uint256"
-            }
-        ],
-        "name": "increaseAllowance",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "name",
-        "outputs": [
-            {
-                "internalType": "string",
-                "name": "",
-                "type": "string"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "symbol",
-        "outputs": [
-            {
-                "internalType": "string",
-                "name": "",
-                "type": "string"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "totalSupply",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "recipient",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "transfer",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "sender",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "recipient",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "transferFrom",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "uniV2PairAddress",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_ppblzAddress",
-                "type": "address"
-            }
-        ],
-        "name": "setPpblzAddress",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_uniV2PairAddress",
-                "type": "address"
-            }
-        ],
-        "name": "setUniV2PairAddress",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_fundAddress",
-                "type": "address"
-            }
-        ],
-        "name": "setFundAddress",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "setRewardsVar",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "_amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "setLiquidityMultiplier",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "getLiquidityMultiplier",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "getBlockNum",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_account",
-                "type": "address"
-            }
-        ],
-        "name": "getLastBlockCheckedNum",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_account",
-                "type": "address"
-            }
-        ],
-        "name": "getAddressPpblzStakeAmount",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_account",
-                "type": "address"
-            }
-        ],
-        "name": "getAddressUniV2StakeAmount",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "totalStakedSupply",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "totalStakedPpblz",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "totalStakedUniV2",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "account",
-                "type": "address"
-            }
-        ],
-        "name": "myRewardsBalance",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "stakePpblz",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "stakeUniV2",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "withdrawPpblz",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "amount",
-                "type": "uint256"
-            }
-        ],
-        "name": "withdrawUniV2",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "inputs": [],
-        "name": "getReward",
-        "outputs": [],
-        "stateMutability": "nonpayable",
-        "type": "function"
-    }
+  {
+    "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalPpblzStaked",
+        "type": "uint256"
+      }
+    ],
+    "name": "PpblzStaked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "PpblzWithdrawn",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "reward",
+        "type": "uint256"
+      }
+    ],
+    "name": "Rewards",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalUniV2Staked",
+        "type": "uint256"
+      }
+    ],
+    "name": "UniV2Staked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "UniV2Withdrawn",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      }
+    ],
+    "name": "allowance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "approve",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "subtractedValue",
+        "type": "uint256"
+      }
+    ],
+    "name": "decreaseAllowance",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "addedValue",
+        "type": "uint256"
+      }
+    ],
+    "name": "increaseAllowance",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "transfer",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferFrom",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "uniV2PairAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_ppblzAddress",
+        "type": "address"
+      }
+    ],
+    "name": "setPpblzAddress",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_uniV2PairAddress",
+        "type": "address"
+      }
+    ],
+    "name": "setUniV2PairAddress",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_fundAddress",
+        "type": "address"
+      }
+    ],
+    "name": "setFundAddress",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "setRewardsVar",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "setLiquidityMultiplier",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getLiquidityMultiplier",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getBlockNum",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      }
+    ],
+    "name": "getLastBlockCheckedNum",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      }
+    ],
+    "name": "getAddressPpblzStakeAmount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      }
+    ],
+    "name": "getAddressUniV2StakeAmount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalStakedSupply",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalStakedPpblz",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalStakedUniV2",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "myRewardsBalance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "stakePpblz",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "stakeUniV2",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "withdrawPpblz",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "withdrawUniV2",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getReward",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
 ]

--- a/packages/app/src/pepemon/lib/abi/uni_v2_lp.json
+++ b/packages/app/src/pepemon/lib/abi/uni_v2_lp.json
@@ -1,713 +1,713 @@
 [
-    {
-        "inputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "constructor"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "owner",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "spender",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "value",
-                "type": "uint256"
-            }
-        ],
-        "name": "Approval",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "sender",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "amount0",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "amount1",
-                "type": "uint256"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "to",
-                "type": "address"
-            }
-        ],
-        "name": "Burn",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "sender",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "amount0",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "amount1",
-                "type": "uint256"
-            }
-        ],
-        "name": "Mint",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "sender",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "amount0In",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "amount1In",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "amount0Out",
-                "type": "uint256"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "amount1Out",
-                "type": "uint256"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "to",
-                "type": "address"
-            }
-        ],
-        "name": "Swap",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": false,
-                "internalType": "uint112",
-                "name": "reserve0",
-                "type": "uint112"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint112",
-                "name": "reserve1",
-                "type": "uint112"
-            }
-        ],
-        "name": "Sync",
-        "type": "event"
-    },
-    {
-        "anonymous": false,
-        "inputs": [
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "from",
-                "type": "address"
-            },
-            {
-                "indexed": true,
-                "internalType": "address",
-                "name": "to",
-                "type": "address"
-            },
-            {
-                "indexed": false,
-                "internalType": "uint256",
-                "name": "value",
-                "type": "uint256"
-            }
-        ],
-        "name": "Transfer",
-        "type": "event"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "DOMAIN_SEPARATOR",
-        "outputs": [
-            {
-                "internalType": "bytes32",
-                "name": "",
-                "type": "bytes32"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "MINIMUM_LIQUIDITY",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "PERMIT_TYPEHASH",
-        "outputs": [
-            {
-                "internalType": "bytes32",
-                "name": "",
-                "type": "bytes32"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "name": "allowance",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "spender",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "value",
-                "type": "uint256"
-            }
-        ],
-        "name": "approve",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "name": "balanceOf",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "to",
-                "type": "address"
-            }
-        ],
-        "name": "burn",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "amount0",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "amount1",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "decimals",
-        "outputs": [
-            {
-                "internalType": "uint8",
-                "name": "",
-                "type": "uint8"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "factory",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "getReserves",
-        "outputs": [
-            {
-                "internalType": "uint112",
-                "name": "_reserve0",
-                "type": "uint112"
-            },
-            {
-                "internalType": "uint112",
-                "name": "_reserve1",
-                "type": "uint112"
-            },
-            {
-                "internalType": "uint32",
-                "name": "_blockTimestampLast",
-                "type": "uint32"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "_token0",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "_token1",
-                "type": "address"
-            }
-        ],
-        "name": "initialize",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "kLast",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "to",
-                "type": "address"
-            }
-        ],
-        "name": "mint",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "liquidity",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "name",
-        "outputs": [
-            {
-                "internalType": "string",
-                "name": "",
-                "type": "string"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "name": "nonces",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "owner",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "spender",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "value",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "deadline",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint8",
-                "name": "v",
-                "type": "uint8"
-            },
-            {
-                "internalType": "bytes32",
-                "name": "r",
-                "type": "bytes32"
-            },
-            {
-                "internalType": "bytes32",
-                "name": "s",
-                "type": "bytes32"
-            }
-        ],
-        "name": "permit",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "price0CumulativeLast",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "price1CumulativeLast",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "to",
-                "type": "address"
-            }
-        ],
-        "name": "skim",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "uint256",
-                "name": "amount0Out",
-                "type": "uint256"
-            },
-            {
-                "internalType": "uint256",
-                "name": "amount1Out",
-                "type": "uint256"
-            },
-            {
-                "internalType": "address",
-                "name": "to",
-                "type": "address"
-            },
-            {
-                "internalType": "bytes",
-                "name": "data",
-                "type": "bytes"
-            }
-        ],
-        "name": "swap",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "symbol",
-        "outputs": [
-            {
-                "internalType": "string",
-                "name": "",
-                "type": "string"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [],
-        "name": "sync",
-        "outputs": [],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "token0",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "token1",
-        "outputs": [
-            {
-                "internalType": "address",
-                "name": "",
-                "type": "address"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": true,
-        "inputs": [],
-        "name": "totalSupply",
-        "outputs": [
-            {
-                "internalType": "uint256",
-                "name": "",
-                "type": "uint256"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "view",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "to",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "value",
-                "type": "uint256"
-            }
-        ],
-        "name": "transfer",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    },
-    {
-        "constant": false,
-        "inputs": [
-            {
-                "internalType": "address",
-                "name": "from",
-                "type": "address"
-            },
-            {
-                "internalType": "address",
-                "name": "to",
-                "type": "address"
-            },
-            {
-                "internalType": "uint256",
-                "name": "value",
-                "type": "uint256"
-            }
-        ],
-        "name": "transferFrom",
-        "outputs": [
-            {
-                "internalType": "bool",
-                "name": "",
-                "type": "bool"
-            }
-        ],
-        "payable": false,
-        "stateMutability": "nonpayable",
-        "type": "function"
-    }
+  {
+    "inputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "Burn",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      }
+    ],
+    "name": "Mint",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0In",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1In",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0Out",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1Out",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "Swap",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint112",
+        "name": "reserve0",
+        "type": "uint112"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint112",
+        "name": "reserve1",
+        "type": "uint112"
+      }
+    ],
+    "name": "Sync",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "DOMAIN_SEPARATOR",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "MINIMUM_LIQUIDITY",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "PERMIT_TYPEHASH",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "allowance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "approve",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "burn",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "factory",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "getReserves",
+    "outputs": [
+      {
+        "internalType": "uint112",
+        "name": "_reserve0",
+        "type": "uint112"
+      },
+      {
+        "internalType": "uint112",
+        "name": "_reserve1",
+        "type": "uint112"
+      },
+      {
+        "internalType": "uint32",
+        "name": "_blockTimestampLast",
+        "type": "uint32"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token0",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_token1",
+        "type": "address"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "kLast",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "mint",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "liquidity",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "nonces",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "v",
+        "type": "uint8"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "r",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "s",
+        "type": "bytes32"
+      }
+    ],
+    "name": "permit",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "price0CumulativeLast",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "price1CumulativeLast",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "skim",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount0Out",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount1Out",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "swap",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "sync",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "token0",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "token1",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "transfer",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferFrom",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
 ]

--- a/packages/app/src/pepemon/lib/accounts.js
+++ b/packages/app/src/pepemon/lib/accounts.js
@@ -1,12 +1,12 @@
 export class Account {
   constructor(contracts, address) {
-    this.contracts = contracts
-    this.accountInfo = address
-    this.type = ''
-    this.allocation = []
-    this.balances = {}
-    this.status = ''
-    this.approvals = {}
-    this.walletInfo = {}
+    this.contracts = contracts;
+    this.accountInfo = address;
+    this.type = "";
+    this.allocation = [];
+    this.balances = {};
+    this.status = "";
+    this.approvals = {};
+    this.walletInfo = {};
   }
 }

--- a/packages/app/src/pepemon/lib/contracts.js
+++ b/packages/app/src/pepemon/lib/contracts.js
@@ -1,20 +1,20 @@
-import BigNumber from 'bignumber.js';
-import ERC20Abi from './abi/erc20.json';
-import PpdexAbi from './abi/ppdex.json';
-import PpblzAbi from './abi/ppblz.json';
-import UNIV2PairAbi from './abi/uni_v2_lp.json';
-import PepemonStoreAbi from './abi/pepemon_store.json';
-import PepemonStoreNativeAbi from './abi/pepemon_store_native.json';
-import PepemonFactoryAbi from './abi/pepemon_factory.json';
-import PepemonStakeAbi from './abi/pepemon_stake.json';
-import MerkleDistributor from './abi/merkle_distributor.json';
-import MerkleAbi from './abi/merkle.json';
-import MerkleBSCAbi from './abi/merkleBSC.json';
-import LotteryAbi from './abi/pepemon_lottery.json';
-import { Contract } from '@ethersproject/contracts';
+import BigNumber from "bignumber.js";
+import ERC20Abi from "./abi/erc20.json";
+import PpdexAbi from "./abi/ppdex.json";
+import PpblzAbi from "./abi/ppblz.json";
+import UNIV2PairAbi from "./abi/uni_v2_lp.json";
+import PepemonStoreAbi from "./abi/pepemon_store.json";
+import PepemonStoreNativeAbi from "./abi/pepemon_store_native.json";
+import PepemonFactoryAbi from "./abi/pepemon_factory.json";
+import PepemonStakeAbi from "./abi/pepemon_stake.json";
+import MerkleDistributor from "./abi/merkle_distributor.json";
+import MerkleAbi from "./abi/merkle.json";
+import MerkleBSCAbi from "./abi/merkleBSC.json";
+import LotteryAbi from "./abi/pepemon_lottery.json";
+import { Contract } from "@ethersproject/contracts";
 
-import { contractAddresses, SUBTRACT_GAS_LIMIT } from './constants.js'
-import * as Types from './types.js'
+import { contractAddresses, SUBTRACT_GAS_LIMIT } from "./constants.js";
+import * as Types from "./types.js";
 
 export class Contracts {
   constructor(provider, networkId) {
@@ -26,31 +26,96 @@ export class Contracts {
     // this.defaultGas = options.defaultGas
     // this.defaultGasPrice = options.defaultGasPrice
     if (parseFloat(networkId) === 1) {
-		this.merkleDistributor = new Contract(contractAddresses.merkleDistributor[networkId], MerkleDistributor, provider.getSigner())
-	}
-
-    if (parseFloat(networkId) === 1 || parseFloat(networkId) === 4) {
-      this.ppblz = new Contract(contractAddresses.ppblz[networkId], PpblzAbi, provider.getSigner())
-      this.uniV2_ppblz = new Contract(contractAddresses.uniV2_ppblz[networkId], UNIV2PairAbi, provider.getSigner())
-      this.uniV2_ppdex = new Contract(contractAddresses.uniV2_ppdex[networkId], UNIV2PairAbi, provider.getSigner())
-      this.pepemonStake = new Contract(contractAddresses.pepemonStake[networkId], PepemonStakeAbi, provider.getSigner())
-      this.merkle = new Contract(contractAddresses.merkle[networkId], MerkleAbi, provider.getSigner())
-      this.merklePpblz = new Contract(contractAddresses.merklePpblz[networkId], MerkleAbi, provider.getSigner())
-      this.merklePpdex = new Contract(contractAddresses.merklePpdex[networkId], MerkleAbi, provider.getSigner())
-      this.merkleUniV2 = new Contract(contractAddresses.merkleUniV2[networkId], MerkleAbi, provider.getSigner())
-      this.pepemonLottery = new Contract(contractAddresses.pepemonLottery[networkId], LotteryAbi, provider.getSigner())
-      // this.pepemonPromoStore = new Contract(contractAddresses.pepemonPromoToken[networkId],
-      this.pepemonPromoToken = new Contract(contractAddresses.pepemonPromoToken[networkId], ERC20Abi, provider.getSigner())
+      this.merkleDistributor = new Contract(
+        contractAddresses.merkleDistributor[networkId],
+        MerkleDistributor,
+        provider.getSigner()
+      );
     }
 
-    if (parseFloat(networkId) === 1 || parseFloat(networkId) === 4 || parseFloat(networkId) === 56 || parseFloat(networkId) === 137) {
-      this.ppdex = new Contract(contractAddresses.ppdex[networkId], PpdexAbi, provider.getSigner());
-      this.pepemonFactory = new Contract(contractAddresses.pepemonFactory[networkId], PepemonFactoryAbi, provider.getSigner());
-      this.pepemonStore = new Contract(contractAddresses.pepemonStore[networkId], parseFloat(networkId) === 56 ? PepemonStoreNativeAbi : PepemonStoreAbi, provider.getSigner());
+    if (parseFloat(networkId) === 1 || parseFloat(networkId) === 4) {
+      this.ppblz = new Contract(
+        contractAddresses.ppblz[networkId],
+        PpblzAbi,
+        provider.getSigner()
+      );
+      this.uniV2_ppblz = new Contract(
+        contractAddresses.uniV2_ppblz[networkId],
+        UNIV2PairAbi,
+        provider.getSigner()
+      );
+      this.uniV2_ppdex = new Contract(
+        contractAddresses.uniV2_ppdex[networkId],
+        UNIV2PairAbi,
+        provider.getSigner()
+      );
+      this.pepemonStake = new Contract(
+        contractAddresses.pepemonStake[networkId],
+        PepemonStakeAbi,
+        provider.getSigner()
+      );
+      this.merkle = new Contract(
+        contractAddresses.merkle[networkId],
+        MerkleAbi,
+        provider.getSigner()
+      );
+      this.merklePpblz = new Contract(
+        contractAddresses.merklePpblz[networkId],
+        MerkleAbi,
+        provider.getSigner()
+      );
+      this.merklePpdex = new Contract(
+        contractAddresses.merklePpdex[networkId],
+        MerkleAbi,
+        provider.getSigner()
+      );
+      this.merkleUniV2 = new Contract(
+        contractAddresses.merkleUniV2[networkId],
+        MerkleAbi,
+        provider.getSigner()
+      );
+      this.pepemonLottery = new Contract(
+        contractAddresses.pepemonLottery[networkId],
+        LotteryAbi,
+        provider.getSigner()
+      );
+      // this.pepemonPromoStore = new Contract(contractAddresses.pepemonPromoToken[networkId],
+      this.pepemonPromoToken = new Contract(
+        contractAddresses.pepemonPromoToken[networkId],
+        ERC20Abi,
+        provider.getSigner()
+      );
+    }
+
+    if (
+      parseFloat(networkId) === 1 ||
+      parseFloat(networkId) === 4 ||
+      parseFloat(networkId) === 56 ||
+      parseFloat(networkId) === 137
+    ) {
+      this.ppdex = new Contract(
+        contractAddresses.ppdex[networkId],
+        PpdexAbi,
+        provider.getSigner()
+      );
+      this.pepemonFactory = new Contract(
+        contractAddresses.pepemonFactory[networkId],
+        PepemonFactoryAbi,
+        provider.getSigner()
+      );
+      this.pepemonStore = new Contract(
+        contractAddresses.pepemonStore[networkId],
+        parseFloat(networkId) === 56 ? PepemonStoreNativeAbi : PepemonStoreAbi,
+        provider.getSigner()
+      );
     }
 
     if (parseFloat(networkId) === 56) {
-      this.merkleDego = new Contract(contractAddresses.merkleDego[networkId], MerkleBSCAbi, provider.getSigner());
+      this.merkleDego = new Contract(
+        contractAddresses.merkleDego[networkId],
+        MerkleBSCAbi,
+        provider.getSigner()
+      );
     }
     // this.pools = supportedPools.map((pool) =>
     //   Object.assign(pool, {
@@ -67,37 +132,52 @@ export class Contracts {
 
   setProvider(provider, networkId) {
     const setProvider = (contract, address) => {
-      contract.setProvider(provider)
-      if (address) contract.options.address = address
-      else console.error('Contract address not found in network', networkId)
-    }
+      contract.setProvider(provider);
+      if (address) contract.options.address = address;
+      else console.error("Contract address not found in network", networkId);
+    };
 
-	if (networkId === 1) {
-      setProvider(this.merkleDistributor, contractAddresses.merkleDistributor[networkId])
+    if (networkId === 1) {
+      setProvider(
+        this.merkleDistributor,
+        contractAddresses.merkleDistributor[networkId]
+      );
     }
 
     if (networkId === 1 || networkId === 4) {
-      setProvider(this.ppblz, contractAddresses.ppblz[networkId])
-      setProvider(this.weth, contractAddresses.weth[networkId])
-      setProvider(this.uniV2_ppblz, contractAddresses.uniV2_ppblz[networkId])
-      setProvider(this.uniV2_ppdex, contractAddresses.uniV2_ppdex[networkId])
-      setProvider(this.pepemonStake, contractAddresses.pepemonStake[networkId])
-      setProvider(this.merkle, contractAddresses.merkle[networkId])
-      setProvider(this.merklePpblz, contractAddresses.merklePpblz[networkId])
-      setProvider(this.merklePpdex, contractAddresses.merklePpdex[networkId])
-      setProvider(this.merkleUniV2, contractAddresses.merkleUniV2[networkId])
-      setProvider(this.pepemonLottery, contractAddresses.pepemonLottery[networkId])
-      setProvider(this.pepemonPromoStore, contractAddresses.pepemonPromoStore[networkId])
-      setProvider(this.pepemonPromoToken, contractAddresses.pepemonPromoToken[networkId])
+      setProvider(this.ppblz, contractAddresses.ppblz[networkId]);
+      setProvider(this.weth, contractAddresses.weth[networkId]);
+      setProvider(this.uniV2_ppblz, contractAddresses.uniV2_ppblz[networkId]);
+      setProvider(this.uniV2_ppdex, contractAddresses.uniV2_ppdex[networkId]);
+      setProvider(this.pepemonStake, contractAddresses.pepemonStake[networkId]);
+      setProvider(this.merkle, contractAddresses.merkle[networkId]);
+      setProvider(this.merklePpblz, contractAddresses.merklePpblz[networkId]);
+      setProvider(this.merklePpdex, contractAddresses.merklePpdex[networkId]);
+      setProvider(this.merkleUniV2, contractAddresses.merkleUniV2[networkId]);
+      setProvider(
+        this.pepemonLottery,
+        contractAddresses.pepemonLottery[networkId]
+      );
+      setProvider(
+        this.pepemonPromoStore,
+        contractAddresses.pepemonPromoStore[networkId]
+      );
+      setProvider(
+        this.pepemonPromoToken,
+        contractAddresses.pepemonPromoToken[networkId]
+      );
     }
 
     if (networkId === 56) {
-      setProvider(this.merkleDego, contractAddresses.merkleDego[networkId])
+      setProvider(this.merkleDego, contractAddresses.merkleDego[networkId]);
     }
 
-    setProvider(this.ppdex, contractAddresses.ppdex[networkId])
-    setProvider(this.pepemonFactory, contractAddresses.pepemonFactory[networkId])
-    setProvider(this.pepemonStore, contractAddresses.pepemonStore[networkId])
+    setProvider(this.ppdex, contractAddresses.ppdex[networkId]);
+    setProvider(
+      this.pepemonFactory,
+      contractAddresses.pepemonFactory[networkId]
+    );
+    setProvider(this.pepemonStore, contractAddresses.pepemonStore[networkId]);
     // this.pools.forEach(
     //   ({ lpContract, lpAddress, tokenContract, tokenAddress }) => {
     //     setProvider(lpContract, lpAddress)
@@ -107,109 +187,105 @@ export class Contracts {
   }
 
   setDefaultAccount(account) {
-    this.ppblz.options.from = account
-    this.ppdex.options.from = account
+    this.ppblz.options.from = account;
+    this.ppdex.options.from = account;
   }
 
   async callContractFunction(method, options) {
-    const {
-      confirmations,
-      confirmationType,
-      autoGasMultiplier,
-      ...txOptions
-    } = options
+    const { confirmations, confirmationType, autoGasMultiplier, ...txOptions } =
+      options;
 
     if (!this.blockGasLimit) {
-      await this.setGasLimit()
+      await this.setGasLimit();
     }
 
     if (!txOptions.gasPrice && this.defaultGasPrice) {
-      txOptions.gasPrice = this.defaultGasPrice
+      txOptions.gasPrice = this.defaultGasPrice;
     }
 
     if (confirmationType === Types.ConfirmationType.Simulate || !options.gas) {
-      let gasEstimate
+      let gasEstimate;
       if (
         this.defaultGas &&
         confirmationType !== Types.ConfirmationType.Simulate
       ) {
-        txOptions.gas = this.defaultGas
+        txOptions.gas = this.defaultGas;
       } else {
         try {
-          console.log('estimating gas')
-          gasEstimate = await method.estimateGas(txOptions)
+          console.log("estimating gas");
+          gasEstimate = await method.estimateGas(txOptions);
         } catch (error) {
-          const data = method.encodeABI()
-          const { from, value } = options
-          const to = method._parent._address
-          error.transactionData = { from, value, data, to }
-          throw error
+          const data = method.encodeABI();
+          const { from, value } = options;
+          const to = method._parent._address;
+          error.transactionData = { from, value, data, to };
+          throw error;
         }
 
-        const multiplier = autoGasMultiplier || this.autoGasMultiplier
-        const totalGas = Math.floor(gasEstimate * multiplier)
+        const multiplier = autoGasMultiplier || this.autoGasMultiplier;
+        const totalGas = Math.floor(gasEstimate * multiplier);
         txOptions.gas =
-          totalGas < this.blockGasLimit ? totalGas : this.blockGasLimit
+          totalGas < this.blockGasLimit ? totalGas : this.blockGasLimit;
       }
 
       if (confirmationType === Types.ConfirmationType.Simulate) {
-        let g = txOptions.gas
-        return { gasEstimate, g }
+        let g = txOptions.gas;
+        return { gasEstimate, g };
       }
     }
 
     if (txOptions.value) {
-      txOptions.value = new BigNumber(txOptions.value).toFixed(0)
+      txOptions.value = new BigNumber(txOptions.value).toFixed(0);
     } else {
-      txOptions.value = '0'
+      txOptions.value = "0";
     }
 
-    const promi = method.send(txOptions)
+    const promi = method.send(txOptions);
 
     const OUTCOMES = {
       INITIAL: 0,
       RESOLVED: 1,
       REJECTED: 2,
-    }
+    };
 
-    let hashOutcome = OUTCOMES.INITIAL
-    let confirmationOutcome = OUTCOMES.INITIAL
+    let hashOutcome = OUTCOMES.INITIAL;
+    let confirmationOutcome = OUTCOMES.INITIAL;
 
     const t =
-      confirmationType !== undefined ? confirmationType : this.confirmationType
+      confirmationType !== undefined ? confirmationType : this.confirmationType;
 
     if (!Object.values(Types.ConfirmationType).includes(t)) {
-      throw new Error(`Invalid confirmation type: ${t}`)
+      throw new Error(`Invalid confirmation type: ${t}`);
     }
 
-    let hashPromise
-    let confirmationPromise
+    let hashPromise;
+    let confirmationPromise;
 
     if (
       t === Types.ConfirmationType.Hash ||
       t === Types.ConfirmationType.Both
     ) {
       hashPromise = new Promise((resolve, reject) => {
-        promi.on('error', (error) => {
+        promi.on("error", (error) => {
           if (hashOutcome === OUTCOMES.INITIAL) {
-            hashOutcome = OUTCOMES.REJECTED
-            reject(error)
-            const anyPromi = promi
-            anyPromi.off()
+            hashOutcome = OUTCOMES.REJECTED;
+            reject(error);
+            const anyPromi = promi;
+            anyPromi.off();
           }
-        })
+        });
 
-        promi.on('transactionHash', (txHash) => {
+        promi.on("transactionHash", (txHash) => {
           if (hashOutcome === OUTCOMES.INITIAL) {
-            hashOutcome = OUTCOMES.RESOLVED
-            resolve(txHash)
+            hashOutcome = OUTCOMES.RESOLVED;
+            resolve(txHash);
             if (t !== Types.ConfirmationType.Both) {
-              const anyPromi = promi
-              anyPromi.off()
+              const anyPromi = promi;
+              anyPromi.off();
             }
           }
-        })
-      })
+        });
+      });
     }
 
     if (
@@ -217,72 +293,72 @@ export class Contracts {
       t === Types.ConfirmationType.Both
     ) {
       confirmationPromise = new Promise((resolve, reject) => {
-        promi.on('error', (error) => {
+        promi.on("error", (error) => {
           if (
             (t === Types.ConfirmationType.Confirmed ||
               hashOutcome === OUTCOMES.RESOLVED) &&
             confirmationOutcome === OUTCOMES.INITIAL
           ) {
-            confirmationOutcome = OUTCOMES.REJECTED
-            reject(error)
-            const anyPromi = promi
-            anyPromi.off()
+            confirmationOutcome = OUTCOMES.REJECTED;
+            reject(error);
+            const anyPromi = promi;
+            anyPromi.off();
           }
-        })
+        });
 
-        const desiredConf = confirmations || this.defaultConfirmations
+        const desiredConf = confirmations || this.defaultConfirmations;
         if (desiredConf) {
-          promi.on('confirmation', (confNumber, receipt) => {
+          promi.on("confirmation", (confNumber, receipt) => {
             if (confNumber >= desiredConf) {
               if (confirmationOutcome === OUTCOMES.INITIAL) {
-                confirmationOutcome = OUTCOMES.RESOLVED
-                resolve(receipt)
-                const anyPromi = promi
-                anyPromi.off()
+                confirmationOutcome = OUTCOMES.RESOLVED;
+                resolve(receipt);
+                const anyPromi = promi;
+                anyPromi.off();
               }
             }
-          })
+          });
         } else {
-          promi.on('receipt', (receipt) => {
-            confirmationOutcome = OUTCOMES.RESOLVED
-            resolve(receipt)
-            const anyPromi = promi
-            anyPromi.off()
-          })
+          promi.on("receipt", (receipt) => {
+            confirmationOutcome = OUTCOMES.RESOLVED;
+            resolve(receipt);
+            const anyPromi = promi;
+            anyPromi.off();
+          });
         }
-      })
+      });
     }
 
     if (t === Types.ConfirmationType.Hash) {
-      const transactionHash = await hashPromise
+      const transactionHash = await hashPromise;
       if (this.notifier) {
-        this.notifier.hash(transactionHash)
+        this.notifier.hash(transactionHash);
       }
-      return { transactionHash }
+      return { transactionHash };
     }
 
     if (t === Types.ConfirmationType.Confirmed) {
-      return confirmationPromise
+      return confirmationPromise;
     }
 
-    const transactionHash = await hashPromise
+    const transactionHash = await hashPromise;
     if (this.notifier) {
-      this.notifier.hash(transactionHash)
+      this.notifier.hash(transactionHash);
     }
     return {
       transactionHash,
       confirmation: confirmationPromise,
-    }
+    };
   }
 
   async callConstantContractFunction(method, options) {
-    const m2 = method
-    const { blockNumber, ...txOptions } = options
-    return m2.call(txOptions, blockNumber)
+    const m2 = method;
+    const { blockNumber, ...txOptions } = options;
+    return m2.call(txOptions, blockNumber);
   }
 
   async setGasLimit() {
-    const block = await this.web3.eth.getBlock('latest')
-    this.blockGasLimit = block.gasLimit - SUBTRACT_GAS_LIMIT
+    const block = await this.web3.eth.getBlock("latest");
+    this.blockGasLimit = block.gasLimit - SUBTRACT_GAS_LIMIT;
   }
 }

--- a/packages/app/src/pepemon/lib/evm.js
+++ b/packages/app/src/pepemon/lib/evm.js
@@ -16,20 +16,17 @@
 
 */
 
-
-const REQUIRE_MSG = 'Returned error: VM Exception while processing transaction: revert';
-const ASSERT_MSG = 'Returned error: VM Exception while processing transaction: invalid opcode';
+const REQUIRE_MSG =
+  "Returned error: VM Exception while processing transaction: revert";
+const ASSERT_MSG =
+  "Returned error: VM Exception while processing transaction: invalid opcode";
 
 export class EVM {
-  constructor(
-    provider,
-  ) {
+  constructor(provider) {
     this.provider = provider;
   }
 
-  setProvider(
-    provider,
-  ){
+  setProvider(provider) {
     this.provider = provider;
   }
 
@@ -39,7 +36,7 @@ export class EVM {
    * @param provider a valid web3 provider
    * @returns null
    */
-   async resetEVM(resetSnapshotId = '0x1') {
+  async resetEVM(resetSnapshotId = "0x1") {
     const id = await this.snapshot();
 
     if (id !== resetSnapshotId) {
@@ -47,45 +44,45 @@ export class EVM {
     }
   }
 
-   async reset(id) {
+  async reset(id) {
     if (!id) {
-      throw new Error('id must be set');
+      throw new Error("id must be set");
     }
 
-    await this.callJsonrpcMethod('evm_revert', [id]);
+    await this.callJsonrpcMethod("evm_revert", [id]);
 
     return this.snapshot();
   }
 
-   async snapshot() {
-    return this.callJsonrpcMethod('evm_snapshot');
+  async snapshot() {
+    return this.callJsonrpcMethod("evm_snapshot");
   }
 
-   async evmRevert(id) {
-    return this.callJsonrpcMethod('evm_revert', [id]);
+  async evmRevert(id) {
+    return this.callJsonrpcMethod("evm_revert", [id]);
   }
 
-   async stopMining() {
-    return this.callJsonrpcMethod('miner_stop');
+  async stopMining() {
+    return this.callJsonrpcMethod("miner_stop");
   }
 
-   async startMining() {
-    return this.callJsonrpcMethod('miner_start');
+  async startMining() {
+    return this.callJsonrpcMethod("miner_start");
   }
 
-   async mineBlock() {
-    return this.callJsonrpcMethod('evm_mine');
+  async mineBlock() {
+    return this.callJsonrpcMethod("evm_mine");
   }
 
-   async increaseTime(duration) {
-    return this.callJsonrpcMethod('evm_increaseTime', [duration]);
+  async increaseTime(duration) {
+    return this.callJsonrpcMethod("evm_increaseTime", [duration]);
   }
 
-   async callJsonrpcMethod(method, params) {
-    const args= {
+  async callJsonrpcMethod(method, params) {
+    const args = {
       method,
       params,
-      jsonrpc: '2.0',
+      jsonrpc: "2.0",
       id: new Date().getTime(),
     };
 
@@ -94,9 +91,9 @@ export class EVM {
     return response.result;
   }
 
-   async send(args) {
+  async send(args) {
     return new Promise((resolve, reject) => {
-      const callback = (error, val)=> {
+      const callback = (error, val) => {
         if (error) {
           reject(error);
         } else {
@@ -104,10 +101,7 @@ export class EVM {
         }
       };
 
-      this.provider.send(
-        args,
-        callback,
-      );
+      this.provider.send(args, callback);
     });
   }
 
@@ -118,7 +112,10 @@ export class EVM {
     const matchedIndex = message.search(expected_error_msg);
     let matchedString = message;
     if (matchedIndex === 0) {
-      matchedString = message.substring(matchedIndex, matchedIndex + expected_error_msg.length);
+      matchedString = message.substring(
+        matchedIndex,
+        matchedIndex + expected_error_msg.length
+      );
     }
     expect(matchedString).toEqual(expected_error_msg);
   }
@@ -127,10 +124,10 @@ export class EVM {
   async expectThrow(promise, reason) {
     try {
       await promise;
-      throw new Error('Did not throw');
+      throw new Error("Did not throw");
     } catch (e) {
       this.assertCertainError(e, REQUIRE_MSG);
-      if (reason && process.env.COVERAGE !== 'true') {
+      if (reason && process.env.COVERAGE !== "true") {
         this.assertCertainError(e, `${REQUIRE_MSG} ${reason}`);
       }
     }
@@ -140,12 +137,9 @@ export class EVM {
   async expectAssertFailure(promise) {
     try {
       await promise;
-      throw new Error('Did not throw');
+      throw new Error("Did not throw");
     } catch (e) {
       this.assertCertainError(e, ASSERT_MSG);
     }
   }
-
-
-
 }

--- a/packages/app/src/pepemon/lib/types.js
+++ b/packages/app/src/pepemon/lib/types.js
@@ -3,4 +3,4 @@ export const ConfirmationType = {
   Confirmed: 1,
   Both: 2,
   Simulate: 3,
-}
+};

--- a/packages/app/src/pepemon/utils.js
+++ b/packages/app/src/pepemon/utils.js
@@ -1,93 +1,93 @@
-import BigNumber from 'bignumber.js'
-import { ethers } from 'ethers'
+import BigNumber from "bignumber.js";
+import { ethers } from "ethers";
 
 BigNumber.config({
   EXPONENTIAL_AT: 1000,
   DECIMAL_PLACES: 80,
-})
+});
 
 export const getPpdexAddress = (pepemon) => {
-  return pepemon && pepemon.ppdexAddress
-}
+  return pepemon && pepemon.ppdexAddress;
+};
 export const getPpblzAddress = (pepemon) => {
-  return pepemon && pepemon.ppblzAddress
-}
+  return pepemon && pepemon.ppblzAddress;
+};
 export const getPepemonFactoryAddress = (pepemon) => {
-  return pepemon && pepemon.pepemonFactoryAddress
-}
+  return pepemon && pepemon.pepemonFactoryAddress;
+};
 export const getPepemonStoreAddress = (pepemon) => {
-  return pepemon && pepemon.pepemonStoreAddress
-}
+  return pepemon && pepemon.pepemonStoreAddress;
+};
 export const getPepemonStakeAddress = (pepemon) => {
-  return pepemon && pepemon.pepemonStakeAddress
-}
+  return pepemon && pepemon.pepemonStakeAddress;
+};
 export const getMerkleAddress = (pepemon) => {
-  return pepemon && pepemon.merkleAddress
-}
+  return pepemon && pepemon.merkleAddress;
+};
 export const getPepemonLotteryAddress = (pepemon) => {
-  return pepemon && pepemon.pepemonLottery
-}
+  return pepemon && pepemon.pepemonLottery;
+};
 export const getUniV2PpdexAddress = (pepemon) => {
-  return pepemon && pepemon.uniV2PpdexAddress
-}
+  return pepemon && pepemon.uniV2PpdexAddress;
+};
 export const getPepemonPromoStoreAddress = (pepemon) => {
-  return pepemon && pepemon.pepemonPromoStoreAddress
-}
+  return pepemon && pepemon.pepemonPromoStoreAddress;
+};
 export const getPepemonPromoTokenAddress = (pepemon) => {
-  return pepemon && pepemon.pepemonPromoTokenAddress
-}
+  return pepemon && pepemon.pepemonPromoTokenAddress;
+};
 
 export const getWethContract = (pepemon) => {
-  return pepemon && pepemon.contracts && pepemon.contracts.weth
-}
+  return pepemon && pepemon.contracts && pepemon.contracts.weth;
+};
 export const getPpdexContract = (pepemon) => {
-  return pepemon && pepemon.contracts && pepemon.contracts.ppdex
-}
+  return pepemon && pepemon.contracts && pepemon.contracts.ppdex;
+};
 export const getPpblzContract = (pepemon) => {
-  return pepemon && pepemon.contracts && pepemon.contracts.ppblz
-}
+  return pepemon && pepemon.contracts && pepemon.contracts.ppblz;
+};
 export const getPpblzUniv2Contract = (pepemon) => {
-  return pepemon && pepemon.contracts && pepemon.contracts.uniV2_ppblz
-}
+  return pepemon && pepemon.contracts && pepemon.contracts.uniV2_ppblz;
+};
 export const getPpdexUniV2Contract = (pepemon) => {
-  return pepemon && pepemon.contracts && pepemon.contracts.uniV2_ppdex
-}
+  return pepemon && pepemon.contracts && pepemon.contracts.uniV2_ppdex;
+};
 export const getPepemonFactoryContract = (pepemon) => {
-  return pepemon && pepemon.contracts && pepemon.contracts.pepemonFactory
-}
+  return pepemon && pepemon.contracts && pepemon.contracts.pepemonFactory;
+};
 export const getPepemonStoreContract = (pepemon) => {
-  return pepemon && pepemon.contracts && pepemon.contracts.pepemonStore
-}
+  return pepemon && pepemon.contracts && pepemon.contracts.pepemonStore;
+};
 export const getPepemonStakeContract = (pepemon) => {
-  return pepemon && pepemon.contracts && pepemon.contracts.pepemonStake
-}
+  return pepemon && pepemon.contracts && pepemon.contracts.pepemonStake;
+};
 export const getMerkleContract = (pepemon) => {
-  return pepemon && pepemon.contracts && pepemon.contracts.merkle
-}
+  return pepemon && pepemon.contracts && pepemon.contracts.merkle;
+};
 export const getMerklePpblzContract = (pepemon) => {
-  return pepemon && pepemon.contracts && pepemon.contracts.merklePpblz
-}
+  return pepemon && pepemon.contracts && pepemon.contracts.merklePpblz;
+};
 export const getMerklePpdexContract = (pepemon) => {
-  return pepemon && pepemon.contracts && pepemon.contracts.merklePpdex
-}
+  return pepemon && pepemon.contracts && pepemon.contracts.merklePpdex;
+};
 export const getMerkleUniV2Contract = (pepemon) => {
-  return pepemon && pepemon.contracts && pepemon.contracts.merkleUniV2
-}
+  return pepemon && pepemon.contracts && pepemon.contracts.merkleUniV2;
+};
 export const getMerkleDistributor = (pepemon) => {
-  return pepemon && pepemon.contracts && pepemon.contracts.merkleDistributor
-}
+  return pepemon && pepemon.contracts && pepemon.contracts.merkleDistributor;
+};
 export const getPepemonLotteryContract = (pepemon) => {
-  return pepemon && pepemon.contracts && pepemon.contracts.pepemonLottery
-}
+  return pepemon && pepemon.contracts && pepemon.contracts.pepemonLottery;
+};
 export const getPepemonPromoStoreContract = (pepemon) => {
-  return pepemon && pepemon.contracts && pepemon.contracts.pepemonPromoStore
-}
+  return pepemon && pepemon.contracts && pepemon.contracts.pepemonPromoStore;
+};
 export const getPepemonPromoTokenContract = (pepemon) => {
-  return pepemon && pepemon.contracts && pepemon.contracts.pepemonPromoToken
-}
+  return pepemon && pepemon.contracts && pepemon.contracts.pepemonPromoToken;
+};
 export const getMerkleDegoContract = (pepemon) => {
-  return pepemon && pepemon.contracts && pepemon.contracts.merkleDego
-}
+  return pepemon && pepemon.contracts && pepemon.contracts.merkleDego;
+};
 
 export const getFarms = (pepemon) => {
   return pepemon
@@ -112,38 +112,38 @@ export const getFarms = (pepemon) => {
           tokenAddress,
           tokenSymbol,
           tokenContract,
-          earnToken: 'ppblz',
+          earnToken: "ppblz",
           earnTokenAddress: pepemon.contracts.ppblz.options.address,
           icon,
-        }),
+        })
       )
-    : []
-}
+    : [];
+};
 
 export const getPoolWeight = async (ppdexContract, pid) => {
-  const { allocPoint } = await ppdexContract.poolInfo(pid)
-  const totalAllocPoint = await ppdexContract.totalAllocPoint()
-  return new BigNumber(allocPoint).div(new BigNumber(totalAllocPoint))
-}
+  const { allocPoint } = await ppdexContract.poolInfo(pid);
+  const totalAllocPoint = await ppdexContract.totalAllocPoint();
+  return new BigNumber(allocPoint).div(new BigNumber(totalAllocPoint));
+};
 
 export const getEarned = async (ppdexContract, pid, account) => {
   try {
-    const reward = await ppdexContract.myRewardsBalance(account)
-    return new BigNumber(reward)
+    const reward = await ppdexContract.myRewardsBalance(account);
+    return new BigNumber(reward);
   } catch {
-    return new BigNumber(0)
+    return new BigNumber(0);
   }
-}
+};
 
 export const getTotalLPWethValue = async (
   ppdexContract,
   wethContract,
   lpContract,
   tokenContract,
-  pid,
+  pid
 ) => {
-  const tokenAmount = 0
-  const wethAmount = 0
+  const tokenAmount = 0;
+  const wethAmount = 0;
   const totalWethValue = new BigNumber(0);
   const tokenPriceInWeth = 0;
   const poolWeight = 0;
@@ -183,326 +183,389 @@ export const getTotalLPWethValue = async (
     // totalWethValue: totalLpWethValue.div(new BigNumber(10).pow(18)),
     // tokenPriceInWeth: wethAmount.div(tokenAmount),
     // poolWeight: await getPoolWeight(ppdexContract, pid),
-  }
-}
+  };
+};
 
-export const approve = async (provider, approvingContract, toApproveContract) => {
+export const approve = async (
+  provider,
+  approvingContract,
+  toApproveContract
+) => {
   try {
-    const result = await sendTransaction(provider, async () => await approvingContract
-      .approve(toApproveContract.address, ethers.constants.MaxUint256));
+    const result = await sendTransaction(
+      provider,
+      async () =>
+        await approvingContract.approve(
+          toApproveContract.address,
+          ethers.constants.MaxUint256
+        )
+    );
     return result;
   } catch (err) {
-    console.error(err)
+    console.error(err);
   }
-}
+};
 
 export const getPpblzSupply = async (pepemon) => {
   const result = await pepemon.contracts.ppblz.totalSupply();
-  return new BigNumber(result.toString())
-}
+  return new BigNumber(result.toString());
+};
 
 export const getPpdexSupply = async (pepemon) => {
   const result = await pepemon.contracts.ppdex.totalSupply();
   return new BigNumber(result.toString());
-}
+};
 
 export const stake = async (ppdexContract, pid, amount, account) => {
   return ppdexContract.methods
     .deposit(
       pid,
-      new BigNumber(amount).times(new BigNumber(10).pow(18)).toString(),
+      new BigNumber(amount).times(new BigNumber(10).pow(18)).toString()
     )
     .send({ from: account })
-    .on('transactionHash', (tx) => {
-      console.log(tx)
-      return tx.transactionHash
-    })
-}
+    .on("transactionHash", (tx) => {
+      console.log(tx);
+      return tx.transactionHash;
+    });
+};
 
 export const unstake = async (ppdexContract, pid, amount, account) => {
   return ppdexContract.methods
     .withdraw(
       pid,
-      new BigNumber(amount).times(new BigNumber(10).pow(18)).toString(),
+      new BigNumber(amount).times(new BigNumber(10).pow(18)).toString()
     )
     .send({ from: account })
-    .on('transactionHash', (tx) => {
-      console.log(tx)
-      return tx.transactionHash
-    })
-}
+    .on("transactionHash", (tx) => {
+      console.log(tx);
+      return tx.transactionHash;
+    });
+};
 export const harvest = async (ppdexContract, pid, account) => {
   return ppdexContract.methods
-    .deposit(pid, '0')
+    .deposit(pid, "0")
     .send({ from: account })
-    .on('transactionHash', (tx) => {
-      console.log(tx)
-      return tx.transactionHash
-    })
-}
+    .on("transactionHash", (tx) => {
+      console.log(tx);
+      return tx.transactionHash;
+    });
+};
 
 export const getStaked = async (ppdexContract, pid, account) => {
   try {
-    const staked = await ppdexContract.getAddressPpblzStakeAmount(account)
+    const staked = await ppdexContract.getAddressPpblzStakeAmount(account);
     return new BigNumber(staked.toString());
   } catch {
-    return new BigNumber(0)
+    return new BigNumber(0);
   }
-}
+};
 
 export const getTotalPpblzStaked = async (ppdexContract) => {
   try {
-    const ppblzStaked = await ppdexContract.totalStakedPpblz()
-    return new BigNumber(ppblzStaked.toString())
+    const ppblzStaked = await ppdexContract.totalStakedPpblz();
+    return new BigNumber(ppblzStaked.toString());
   } catch {
-    return new BigNumber(0)
+    return new BigNumber(0);
   }
-}
+};
 
 export const getTotalStaked = async (ppdexContract) => {
   try {
-    const staked = await ppdexContract.totalStakedSupply()
-    return new BigNumber(staked.toString())
+    const staked = await ppdexContract.totalStakedSupply();
+    return new BigNumber(staked.toString());
   } catch {
-    return new BigNumber(0)
+    return new BigNumber(0);
   }
-}
+};
 
 export const redeem = async (ppdexContract, account) => {
-  let now = new Date().getTime() / 1000
+  let now = new Date().getTime() / 1000;
   if (now >= 1597172400) {
     return ppdexContract.methods
       .exit()
       .send({ from: account })
-      .on('transactionHash', (tx) => {
-        console.log(tx)
-        return tx.transactionHash
-      })
+      .on("transactionHash", (tx) => {
+        console.log(tx);
+        return tx.transactionHash;
+      });
   } else {
-    alert('pool not active')
+    alert("pool not active");
   }
-}
+};
 
 export const redeemCard = async (provider, contract, tokenId) => {
-  return await sendTransaction(provider, async () => await contract.redeem(tokenId));
-}
+  return await sendTransaction(
+    provider,
+    async () => await contract.redeem(tokenId)
+  );
+};
 
 export const redeemCardNative = async (provider, contract, tokenId, amount) => {
-  return await sendTransaction(provider, async () => await contract.redeem(tokenId, { value: amount }));
-}
+  return await sendTransaction(
+    provider,
+    async () => await contract.redeem(tokenId, { value: amount })
+  );
+};
 
-
-export const getCardPrice = async(contract, tokenId) => {
-  const price = await contract.cardCosts(tokenId)
-  return new BigNumber(price.toString())
-}
+export const getCardPrice = async (contract, tokenId) => {
+  const price = await contract.cardCosts(tokenId);
+  return new BigNumber(price.toString());
+};
 
 export const getTotalSpend = async (storeContract) => {
   try {
-    const spend = await storeContract.totalPPDEXSpend()
-    return new BigNumber(spend.toString())
+    const spend = await storeContract.totalPPDEXSpend();
+    return new BigNumber(spend.toString());
   } catch {
-    return new BigNumber(0)
+    return new BigNumber(0);
   }
-}
+};
 
 export const getTotalSpendBNB = async (storeContract) => {
   try {
-    const spend = await storeContract.totalBNBspend()
-    return new BigNumber(spend.toString())
+    const spend = await storeContract.totalBNBspend();
+    return new BigNumber(spend.toString());
   } catch {
-    return new BigNumber(0)
+    return new BigNumber(0);
   }
-}
+};
 
-export const setApprovalForAll = async (provider, factoryContract, approveAddress) => {
+export const setApprovalForAll = async (
+  provider,
+  factoryContract,
+  approveAddress
+) => {
   try {
-    return await sendTransaction(provider, async () => await factoryContract.setApprovalForAll(approveAddress, true));
+    return await sendTransaction(
+      provider,
+      async () => await factoryContract.setApprovalForAll(approveAddress, true)
+    );
   } catch (e) {
     console.log(`[PepemonFactory, setApprovalForAll] error: ${e}`);
   }
-}
+};
 
-export const getIsApprovedForAll = async (factoryContract, approveAddress, account) => {
+export const getIsApprovedForAll = async (
+  factoryContract,
+  approveAddress,
+  account
+) => {
   try {
-    return factoryContract.isApprovedForAll(account, approveAddress)
+    return factoryContract.isApprovedForAll(account, approveAddress);
   } catch (e) {
     console.log(`[PepemonFactory, isApprovedForAll] error: ${e}`);
   }
-}
+};
 
 export const joinEvent = async (provider, stakeContract, eventId) => {
   try {
-    return await sendTransaction(provider, async () => await stakeContract.stake(eventId));
+    return await sendTransaction(
+      provider,
+      async () => await stakeContract.stake(eventId)
+    );
   } catch (e) {
     console.log(`[PepemonStake, stake] error: ${e}`);
   }
-}
+};
 
 export const claimEvent = async (provider, stakeContract, eventId) => {
   try {
-    return await sendTransaction(provider, async () => await stakeContract.claim(eventId));
+    return await sendTransaction(
+      provider,
+      async () => await stakeContract.claim(eventId)
+    );
   } catch (e) {
     console.log(`[PepemonStake, claim] error: ${e}`);
   }
-}
+};
 
 export const withdrawEvent = async (provider, stakeContract, eventId) => {
   try {
-    return await sendTransaction(provider, async () => await stakeContract.cancel(eventId));
+    return await sendTransaction(
+      provider,
+      async () => await stakeContract.cancel(eventId)
+    );
   } catch (e) {
     console.log(`[PepemonStake, claim] error: ${e}`);
   }
-}
+};
 
 export const getUserProgress = async (stakeContract, eventId, account) => {
   try {
-    const result = await stakeContract.getUserProgress(account, eventId)
+    const result = await stakeContract.getUserProgress(account, eventId);
     return result.toString();
   } catch (e) {
     console.log(`[PepemonStake, getUserProgress] error: ${e}`);
   }
-}
+};
 
 export const getUserEventStatus = async (stakeContract, eventId, account) => {
   try {
-    return stakeContract.userInfo(account, eventId)
+    return stakeContract.userInfo(account, eventId);
   } catch (e) {
     console.log(`[PepemonStake, getUserProgress] error: ${e}`);
   }
-}
+};
 
 export const getActiveEvents = async (stakeContract) => {
   try {
-    return stakeContract.getActiveEvents()
+    return stakeContract.getActiveEvents();
   } catch (e) {
     console.log(`[PepemonStake, getActiveEvents] error: ${e}`);
   }
-}
+};
 
 export const getClosedEvents = async (stakeContract) => {
   try {
-    return stakeContract.getClosedEvents()
+    return stakeContract.getClosedEvents();
   } catch (e) {
     console.log(`[PepemonStake, getClosedEvents] error: ${e}`);
   }
-}
+};
 
-export const merkleIsClaimed = async (merkleContract, index, bsc = false, tokenId = null) => {
+export const merkleIsClaimed = async (
+  merkleContract,
+  index,
+  bsc = false,
+  tokenId = null
+) => {
   try {
     if (!bsc) {
-		if (tokenId) {
-			return merkleContract.isClaimed(tokenId, index);
-		}
-        return merkleContract.isClaimed(index);
+      if (tokenId) {
+        return merkleContract.isClaimed(tokenId, index);
+      }
+      return merkleContract.isClaimed(index);
     }
     //TODO create new function for new variation of merkle contract
     return merkleContract.isAddressClaimed(index);
   } catch (e) {
     console.log(`[merkleContract, isClaimed] error: ${e}`);
   }
-}
+};
 
-export const claimMerkle = async (provider, merkleContract, index, account, amount, proof, tokenId = null) => {
+export const claimMerkle = async (
+  provider,
+  merkleContract,
+  index,
+  account,
+  amount,
+  proof,
+  tokenId = null
+) => {
   try {
-	  if (tokenId) {
-		  return await sendTransaction(provider, async () => await merkleContract.claim(tokenId, index, account, amount, proof));
-	  }
-    return await sendTransaction(provider, async () => await merkleContract.claim(index, account, amount, proof));
+    if (tokenId) {
+      return await sendTransaction(
+        provider,
+        async () =>
+          await merkleContract.claim(tokenId, index, account, amount, proof)
+      );
+    }
+    return await sendTransaction(
+      provider,
+      async () => await merkleContract.claim(index, account, amount, proof)
+    );
   } catch (e) {
     console.log(`[merkleContract, claim] error: ${e}`);
   }
-}
+};
 
 export const getMinLPTokens = async (lotteryContract) => {
   try {
-    const result = await lotteryContract.MinLPTokens()
-    return result.toString()
+    const result = await lotteryContract.MinLPTokens();
+    return result.toString();
   } catch (e) {
     console.log(`[lotteryContract, minLPTokens] error: ${e}`);
   }
-}
+};
 
 export const getLPBalance = async (lotteryContract, address) => {
   try {
-    const result = await lotteryContract.getLPBalance(address)
+    const result = await lotteryContract.getLPBalance(address);
     return result.toString();
   } catch (e) {
     console.log(`[lotteryContract, getLPBalance] error: ${e}`);
   }
-}
+};
 
 export const isUserStaking = async (lotteryContract, address) => {
   try {
-    return lotteryContract.isUserStaking(address)
+    return lotteryContract.isUserStaking(address);
   } catch (e) {
     console.log(`[lotteryContract, isUSerStaking] error: ${e}`);
   }
-}
+};
 
 export const hasUserMinted = async (lotteryContract, address, cardId) => {
   try {
-    return lotteryContract.hasUserMinted(address, cardId)
+    return lotteryContract.hasUserMinted(address, cardId);
   } catch (e) {
     console.log(`[lotteryContract, hasUserMinted] error: ${e}`);
   }
-}
+};
 
 export const getRewardCardId = async (lotteryContract) => {
   try {
-    return lotteryContract.normalID()
+    return lotteryContract.normalID();
   } catch (e) {
     console.log(`[lotteryContract, rewardCard] error: ${e}`);
   }
-}
+};
 
 export const getStakingDeadline = async (lotteryContract) => {
   try {
-    return lotteryContract.stakingDeadline()
+    return lotteryContract.stakingDeadline();
   } catch (e) {
     console.log(`[lotteryContract, stakingDeadline] error: ${e}`);
   }
-}
+};
 
 export const getStakingStart = async (lotteryContract, address) => {
   try {
-    return lotteryContract.getStakingStart(address)
+    return lotteryContract.getStakingStart(address);
   } catch (e) {
     console.log(`[lotteryContract, stakingStart] error: ${e}`);
   }
-}
+};
 
 export const stakeLottery = async (provider, lotteryContract) => {
   try {
-    const result = await sendTransaction(provider, async () => await lotteryContract.stakeForNormalNFT());
+    const result = await sendTransaction(
+      provider,
+      async () => await lotteryContract.stakeForNormalNFT()
+    );
     return result;
   } catch (e) {
     console.log(`[lotteryContract, stakeNormalNFT] error: ${e}`);
   }
-}
+};
 
 export const withdrawLottery = async (provider, lotteryContract) => {
   try {
-    const result = await sendTransaction(provider, async () => await lotteryContract.withdrawLP());
+    const result = await sendTransaction(
+      provider,
+      async () => await lotteryContract.withdrawLP()
+    );
     return result;
   } catch (e) {
     console.log(`[lotteryContract, withdrawLP] error: ${e}`);
   }
-}
+};
 
 export const mintNFTLottery = async (provider, lotteryContract) => {
   try {
-    const result = await sendTransaction(provider, async () => await lotteryContract.mintNFT());
+    const result = await sendTransaction(
+      provider,
+      async () => await lotteryContract.mintNFT()
+    );
     return result;
   } catch (e) {
     console.log(`[lotteryContract, withdrawLP] error: ${e}`);
   }
-}
-
+};
 
 export const sendTransaction = async (provider, callback) => {
   try {
-    const { hash } = await callback()
+    const { hash } = await callback();
     // dispatch({
     //   type: 'transactionPending',
     //   id: hash,
@@ -513,9 +576,9 @@ export const sendTransaction = async (provider, callback) => {
         //   type: 'transactionCompleted',
         // })
         // console.log('COMPLETED', transaction);
-        resolve(hash)
-      })
-    })
+        resolve(hash);
+      });
+    });
   } catch (err) {
     // dispatch({
     //   type: 'transactionError',
@@ -523,4 +586,4 @@ export const sendTransaction = async (provider, callback) => {
     // })
     console.error(err);
   }
-}
+};

--- a/packages/app/src/theme/index.ts
+++ b/packages/app/src/theme/index.ts
@@ -1,1 +1,1 @@
-export { default as theme } from './theme';
+export { default as theme } from "./theme";

--- a/packages/app/src/theme/theme.ts
+++ b/packages/app/src/theme/theme.ts
@@ -1,93 +1,93 @@
 const theme = {
-	borderRadius: 16,
-	breakpoints: {
-		mobileS: '400px',
-		mobile: '576px',
-		tabletP: '768px',
-		tabletL: '880px',
-		desktop: '1024px',
-		wide: '1380px',
-		ultra: '1200px',
-	},
-	color: {
-		transparent: "transparent",
-		white: "#fff",
-		black: "#000",
-		green: {
-			100: "#9feea3",
-			200: "#66d86a"
-		},
-		gray: {
-			100: "#f3f3f3",
-			200: "#f5f7fa",
-			300: "#919191",
-			400: "#757575",
-			500: "#4c525b",
-			600: "#484848",
-		},
-		purple: {
-			100: "#fafffc",
-			200: "#fafbff",
-			300: "#eaecf8",
-			400: "#eeedff",
-			500: "#ccbce9",
-			600: "#713aac",
-			700: "#330366",
-			800: "#220245"
-		},
-		buttonPrimaryDisabled: "rgba(26, 26, 26, 0.5)",
-		buttonSecondaryDefault: "rgb(204, 204, 204)",
-		colorsLayoutBorders: "rgba(214, 214, 214, 0.51)",
-		inputDisabled: "rgba(245, 245, 245, 0.6)",
-		colorsBrandCornflowerBlue: "rgb(142, 201, 230)",
-		colorsInteractionSuccess: "rgb(120, 204, 25)",
-		colorsInteractionDanger: "rgb(255, 0, 0)",
-		colorsBrandPrussianBlue: "rgb(2, 47, 71)",
-		typographyAllTextOnDark: "rgb(255, 255, 255)",
-		iconBackgroundGrey: "rgba(0, 0, 0, 0.05)",
-		layoutPrimary: "rgb(9, 12, 13)",
-		colorsLayoutShadows: "rgb(179, 179, 179)",
-		layoutOverlay: "rgba(0, 0, 0, 0.6)",
-		fsBlack: "rgb(0, 0, 0)",
-		buttonSecondaryDisabled: "rgba(204, 204, 204, 0.5)",
-		colorsBrandBlueGreen: "rgb(35, 159, 188)",
-		inputDefault: "rgb(245, 245, 245)",
-		colorsLayoutPrimaryElements: "rgb(44, 43, 48)",
-		headers: "rgb(26, 26, 26)",
-		colorsTypographyLightParagraphs: "rgb(214, 214, 214)",
-		colorsInteractionLink: "rgb(0, 166, 255)",
-		colorsBrandOrange: "rgb(252, 154, 45)",
-		colorsBrandColumbiaBlue: "rgb(237, 246, 255)",
-		iconBackgroundGrey8: "rgba(0, 0, 0, 0.08)"
-	},
-	font: {
-		spaceMace: "SpaceMace",
-		inter: "Inter",
-		neometric: "Neometric"
-	},
-	siteWidth: 1200,
-	spacing: {
-	1: 4,
-	2: 8,
-	3: 16,
-	4: 24,
-	5: 32,
-	6: 48,
-	7: 64,
-	},
-	topBarSize: 72,
-	sideBar: {
-		width: {
-			closed: 96,
-			opened: 260
-		}
-	},
-	footer: {
-		spaceTop: 250
-	},
-	page: {
-		maxWidth: 1120
-	}
+  borderRadius: 16,
+  breakpoints: {
+    mobileS: "400px",
+    mobile: "576px",
+    tabletP: "768px",
+    tabletL: "880px",
+    desktop: "1024px",
+    wide: "1380px",
+    ultra: "1200px",
+  },
+  color: {
+    transparent: "transparent",
+    white: "#fff",
+    black: "#000",
+    green: {
+      100: "#9feea3",
+      200: "#66d86a",
+    },
+    gray: {
+      100: "#f3f3f3",
+      200: "#f5f7fa",
+      300: "#919191",
+      400: "#757575",
+      500: "#4c525b",
+      600: "#484848",
+    },
+    purple: {
+      100: "#fafffc",
+      200: "#fafbff",
+      300: "#eaecf8",
+      400: "#eeedff",
+      500: "#ccbce9",
+      600: "#713aac",
+      700: "#330366",
+      800: "#220245",
+    },
+    buttonPrimaryDisabled: "rgba(26, 26, 26, 0.5)",
+    buttonSecondaryDefault: "rgb(204, 204, 204)",
+    colorsLayoutBorders: "rgba(214, 214, 214, 0.51)",
+    inputDisabled: "rgba(245, 245, 245, 0.6)",
+    colorsBrandCornflowerBlue: "rgb(142, 201, 230)",
+    colorsInteractionSuccess: "rgb(120, 204, 25)",
+    colorsInteractionDanger: "rgb(255, 0, 0)",
+    colorsBrandPrussianBlue: "rgb(2, 47, 71)",
+    typographyAllTextOnDark: "rgb(255, 255, 255)",
+    iconBackgroundGrey: "rgba(0, 0, 0, 0.05)",
+    layoutPrimary: "rgb(9, 12, 13)",
+    colorsLayoutShadows: "rgb(179, 179, 179)",
+    layoutOverlay: "rgba(0, 0, 0, 0.6)",
+    fsBlack: "rgb(0, 0, 0)",
+    buttonSecondaryDisabled: "rgba(204, 204, 204, 0.5)",
+    colorsBrandBlueGreen: "rgb(35, 159, 188)",
+    inputDefault: "rgb(245, 245, 245)",
+    colorsLayoutPrimaryElements: "rgb(44, 43, 48)",
+    headers: "rgb(26, 26, 26)",
+    colorsTypographyLightParagraphs: "rgb(214, 214, 214)",
+    colorsInteractionLink: "rgb(0, 166, 255)",
+    colorsBrandOrange: "rgb(252, 154, 45)",
+    colorsBrandColumbiaBlue: "rgb(237, 246, 255)",
+    iconBackgroundGrey8: "rgba(0, 0, 0, 0.08)",
+  },
+  font: {
+    spaceMace: "SpaceMace",
+    inter: "Inter",
+    neometric: "Neometric",
+  },
+  siteWidth: 1200,
+  spacing: {
+    1: 4,
+    2: 8,
+    3: 16,
+    4: 24,
+    5: 32,
+    6: 48,
+    7: 64,
+  },
+  topBarSize: 72,
+  sideBar: {
+    width: {
+      closed: 96,
+      opened: 260,
+    },
+  },
+  footer: {
+    spaceTop: 250,
+  },
+  page: {
+    maxWidth: 1120,
+  },
 };
 
 export default theme;

--- a/packages/app/src/utils/calculateApy.ts
+++ b/packages/app/src/utils/calculateApy.ts
@@ -3,15 +3,18 @@
  * @return returns PPBLZ staking APY
  */
 export const calculatePpblzApy = (ppblzPrice: number, ppdexPrice: number) => {
-	const rewardedPerYear = ppdexPrice * 14.25;
-	return rewardedPerYear / ppblzPrice * 100;
-}
+  const rewardedPerYear = ppdexPrice * 14.25;
+  return (rewardedPerYear / ppblzPrice) * 100;
+};
 
 /**
  * @method @dev: https://dune.xyz/queries/21790/44998
  * @return returns PPBLZ-ETH LP staking APY
  */
-export const calculatePpblzEthLpApy = (ppblzPrice: number, ppdexPrice: number) => {
-	const rewardedPerYear = ppdexPrice * 30.5;
-	return rewardedPerYear / ppblzPrice * 50;
-}
+export const calculatePpblzEthLpApy = (
+  ppblzPrice: number,
+  ppdexPrice: number
+) => {
+  const rewardedPerYear = ppdexPrice * 30.5;
+  return (rewardedPerYear / ppblzPrice) * 50;
+};

--- a/packages/app/src/utils/copyText.ts
+++ b/packages/app/src/utils/copyText.ts
@@ -1,10 +1,12 @@
-const useCopyText = async (text: string|number) => {
-	if (typeof text === 'number') { text = text.toString(); }
-	try {
-		await navigator.clipboard.writeText(text);
-	} catch (err) {
-		console.error('Failed to copy: ', err);
-	}
-}
+const useCopyText = async (text: string | number) => {
+  if (typeof text === "number") {
+    text = text.toString();
+  }
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch (err) {
+    console.error("Failed to copy: ", err);
+  }
+};
 
 export default useCopyText;

--- a/packages/app/src/utils/erc1155.ts
+++ b/packages/app/src/utils/erc1155.ts
@@ -1,40 +1,41 @@
-
 export const getBalanceOfBatch = async (
-    contract: any,
-    userAddress: string,
-    tokenIds: number[],
+  contract: any,
+  userAddress: string,
+  tokenIds: number[]
 ): Promise<any[]> => {
-    try {
-		if (tokenIds.length === 0) return;
-        const result = await contract.balanceOfBatch(tokenIds.map(() => userAddress), tokenIds)
-        return result;
-    } catch (e) {
-        console.error(e);
-        return null;
-    }
-}
+  try {
+    if (tokenIds.length === 0) return;
+    const result = await contract.balanceOfBatch(
+      tokenIds.map(() => userAddress),
+      tokenIds
+    );
+    return result;
+  } catch (e) {
+    console.error(e);
+    return null;
+  }
+};
 
 export const getTotalSupply = async (
-    contract: any,
-    tokenId: number,
+  contract: any,
+  tokenId: number
 ): Promise<any> => {
-    try {
-        return await contract.totalSupply(tokenId)
-    } catch (e) {
-        console.error(e);
-        return null;
-    }
-}
+  try {
+    return await contract.totalSupply(tokenId);
+  } catch (e) {
+    console.error(e);
+    return null;
+  }
+};
 
 export const getMaxSupply = async (
-    contract: any,
-    tokenId: number,
+  contract: any,
+  tokenId: number
 ): Promise<any> => {
-    try {
-        return await contract.maxSupply(tokenId)
-    } catch (e) {
-        console.error(e);
-        return null;
-    }
-}
-
+  try {
+    return await contract.maxSupply(tokenId);
+  } catch (e) {
+    console.error(e);
+    return null;
+  }
+};

--- a/packages/app/src/utils/erc20.ts
+++ b/packages/app/src/utils/erc20.ts
@@ -1,64 +1,60 @@
-import ERC20ABI from '../contracts/src/abis/erc20.json'
-import { Contract } from '@ethersproject/contracts';
+import ERC20ABI from "../contracts/src/abis/erc20.json";
+import { Contract } from "@ethersproject/contracts";
 
 export const getContract = (provider: any, address: string) => {
-  const contract = new Contract(
-    address,
-    ERC20ABI.abi,
-    provider,
-  )
-  return contract
-}
+  const contract = new Contract(address, ERC20ABI.abi, provider);
+  return contract;
+};
 
 export const getAllowance = async (
   allowContract: any,
   fromContract: any,
-  account: string,
+  account: string
 ): Promise<string> => {
   try {
     if (!allowContract) {
-      console.log('[getAllowance] no contract found')
+      console.log("[getAllowance] no contract found");
       return;
     }
-    const allowance: string = await allowContract.allowance(account, fromContract.address)
-    return allowance.toString()
+    const allowance: string = await allowContract.allowance(
+      account,
+      fromContract.address
+    );
+    return allowance.toString();
   } catch (e) {
-    return '0'
+    return "0";
   }
-}
+};
 
 export const getNativeToken = (chainId: number) => {
-	return chainId === 56 ? 'BNB' : chainId === 137 ? 'MATIC' : 'ETH'
-}
+  return chainId === 56 ? "BNB" : chainId === 137 ? "MATIC" : "ETH";
+};
 
-export const getNativeBalance = async (
-    provider: any,
-    account: string,
-) => {
+export const getNativeBalance = async (provider: any, account: string) => {
   try {
     const balance = await provider.getBalance(account);
     return balance.toString();
   } catch (e) {
-    console.error('[getNativeBalance] error', e)
-    return '0'
+    console.error("[getNativeBalance] error", e);
+    return "0";
   }
-}
+};
 
 export const getBalance = async (
   provider: any,
   tokenAddress: string,
-  userAddress: string,
+  userAddress: string
 ): Promise<string> => {
   try {
     const contract = new Contract(tokenAddress, ERC20ABI.abi, provider);
     if (!contract) {
-      console.log('[getBalance] no contract found')
+      console.log("[getBalance] no contract found");
       return;
     }
     const balance: string = await contract.balanceOf(userAddress);
-    return balance.toString()
+    return balance.toString();
   } catch (e) {
-    console.error('[getBalance] error', e)
-    return '0'
+    console.error("[getBalance] error", e);
+    return "0";
   }
-}
+};

--- a/packages/app/src/utils/formatAddress.ts
+++ b/packages/app/src/utils/formatAddress.ts
@@ -1,5 +1,5 @@
 const formatAddress = (address: string) => {
-  return address.slice(0, 6) + '...' + address.slice(-6)
-}
+  return address.slice(0, 6) + "..." + address.slice(-6);
+};
 
-export default formatAddress
+export default formatAddress;

--- a/packages/app/src/utils/formatBalance.ts
+++ b/packages/app/src/utils/formatBalance.ts
@@ -1,21 +1,21 @@
-import BigNumber from 'bignumber.js'
+import BigNumber from "bignumber.js";
 
 export const getBalanceNumber = (balance: BigNumber, decimals = 18) => {
-	if (!balance.dividedBy) return;
-	const displayBalance = balance.dividedBy(new BigNumber(10).pow(decimals));
-	return displayBalance.toNumber()
-}
+  if (!balance.dividedBy) return;
+  const displayBalance = balance.dividedBy(new BigNumber(10).pow(decimals));
+  return displayBalance.toNumber();
+};
 
 export const getDisplayBalance = (balance: BigNumber, decimals = 18) => {
-	if (!balance.dividedBy) return;
-	const displayBalance = balance.dividedBy(new BigNumber(10).pow(decimals))
-	if (displayBalance.lt(1)) {
-		return displayBalance.toPrecision(4)
-	} else {
-		return displayBalance.toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ',')
-	}
-}
+  if (!balance.dividedBy) return;
+  const displayBalance = balance.dividedBy(new BigNumber(10).pow(decimals));
+  if (displayBalance.lt(1)) {
+    return displayBalance.toPrecision(4);
+  } else {
+    return displayBalance.toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+  }
+};
 
 export const getFullDisplayBalance = (balance: BigNumber, decimals = 18) => {
-  return balance.dividedBy(new BigNumber(10).pow(decimals)).toFixed()
-}
+  return balance.dividedBy(new BigNumber(10).pow(decimals)).toFixed();
+};

--- a/packages/app/src/utils/index.ts
+++ b/packages/app/src/utils/index.ts
@@ -1,21 +1,31 @@
-import BigNumber from 'bignumber.js'
+import BigNumber from "bignumber.js";
 
-export { calculatePpblzApy, calculatePpblzEthLpApy } from './calculateApy';
-export { default as copyText } from './copyText';
-export { getBalanceOfBatch, getTotalSupply, getMaxSupply } from './erc1155';
-export { getContract, getAllowance, getNativeToken, getNativeBalance, getBalance } from './erc20';
-export { default as formatAddress } from './formatAddress';
-export { getBalanceNumber, getDisplayBalance, getFullDisplayBalance } from './formatBalance';
-export { default as isSupportedChain } from './isSupportedChain';
-export { correctChainIsLoaded } from './network';
-export { getCardInfo } from './nftCards';
+export { calculatePpblzApy, calculatePpblzEthLpApy } from "./calculateApy";
+export { default as copyText } from "./copyText";
+export { getBalanceOfBatch, getTotalSupply, getMaxSupply } from "./erc1155";
+export {
+  getContract,
+  getAllowance,
+  getNativeToken,
+  getNativeBalance,
+  getBalance,
+} from "./erc20";
+export { default as formatAddress } from "./formatAddress";
+export {
+  getBalanceNumber,
+  getDisplayBalance,
+  getFullDisplayBalance,
+} from "./formatBalance";
+export { default as isSupportedChain } from "./isSupportedChain";
+export { correctChainIsLoaded } from "./network";
+export { getCardInfo } from "./nftCards";
 
 export const bnToDec = (bn: BigNumber, decimals = 18): number => {
-  return bn.dividedBy(new BigNumber(10).pow(decimals)).toNumber()
-}
+  return bn.dividedBy(new BigNumber(10).pow(decimals)).toNumber();
+};
 
 export const decToBn = (dec: number, decimals = 18) => {
-  return new BigNumber(dec).multipliedBy(new BigNumber(10).pow(decimals))
-}
+  return new BigNumber(dec).multipliedBy(new BigNumber(10).pow(decimals));
+};
 
-export const oneEther = new BigNumber(10).pow(18)
+export const oneEther = new BigNumber(10).pow(18);

--- a/packages/app/src/utils/isSupportedChain.ts
+++ b/packages/app/src/utils/isSupportedChain.ts
@@ -1,15 +1,16 @@
-
 const isSupportedChain = (chainId: number, pathname: string) => {
-	if(pathname.startsWith('/bridge')) {
-		// return (chainId === 906090 || chainId === 5)
-		// disable withdrawal / deposit within the page if on wrong chain
-		return true
-	}
+  if (pathname.startsWith("/bridge")) {
+    // return (chainId === 906090 || chainId === 5)
+    // disable withdrawal / deposit within the page if on wrong chain
+    return true;
+  }
 
-	if (pathname.startsWith('/store') || pathname === '/') {
-		return (chainId === 1 || chainId === 4 || chainId === 56 || chainId === 84532);
-	}
-	return (chainId === 1 || chainId === 4);
-}
+  if (pathname.startsWith("/store") || pathname === "/") {
+    return (
+      chainId === 1 || chainId === 4 || chainId === 56 || chainId === 84532
+    );
+  }
+  return chainId === 1 || chainId === 4;
+};
 
 export default isSupportedChain;

--- a/packages/app/src/utils/network.ts
+++ b/packages/app/src/utils/network.ts
@@ -1,9 +1,8 @@
-
 export const correctChainIsLoaded = async (pepemon: any) => {
-    if (!pepemon || !pepemon.provider) {
-        return false;
-    }
+  if (!pepemon || !pepemon.provider) {
+    return false;
+  }
 
-    const { chainId } = await pepemon.provider.getNetwork();
-    return pepemon.chainId === parseFloat(chainId);
-}
+  const { chainId } = await pepemon.provider.getNetwork();
+  return pepemon.chainId === parseFloat(chainId);
+};

--- a/packages/app/src/utils/nftCards.ts
+++ b/packages/app/src/utils/nftCards.ts
@@ -164,466 +164,466 @@
  */
 
 export const getCardInfo = (cardId: number, chainId?: number) => {
-    if (chainId === 56) {
-        switch(cardId) {
-            case 0:
-                return {
-                    title: 'Pepemon Cardback',
-                    img: 'cardbackImg',
-                };
-            case 1:
-                return {
-                    title: 'CZmon',
-                    img: 'czmonImg',
-                };
-            case 2:
-                return {
-                    title: 'Never to be released',
-                    img: 'cardbackGoldImg',
-                }
-            case 3:
-                return {
-                    title: 'Pepesaur',
-                    img: 'bscPepesaurImg',
-                }
-            case 4:
-                return {
-                    title: 'Pepemander',
-                    img: 'bscPepemanderImg',
-                }
-            case 5:
-                return {
-                    title: 'Pepertle',
-                    img: 'bscPepertleImg',
-                }
-            case 6:
-                return {
-                    title: 'Pivysaur',
-                    img: 'bscPivysaurImg',
-                }
-            case 7:
-                return {
-                    title: 'Pemeleon',
-                    img: 'bscPemeleonImg',
-                }
-            case 8:
-                return {
-                    title: 'Warpertle',
-                    img: 'bscWarpertleImg',
-                }
-            case 9:
-                return {
-                    title: 'Degochu',
-                    img: 'degochuImg',
-                }
-            case 10:
-                return {
-                    title: 'Dumpesaur',
-                    img: 'bscDumpesaurImg',
-                }
-            case 11:
-                return {
-                    title: 'Fudizard',
-                    img: 'bscFudizardImg',
-                }
-            case 12:
-                return {
-                    title: 'Rektoise',
-                    img: 'bscRektoiseImg',
-                }
-        }
+  if (chainId === 56) {
+    switch (cardId) {
+      case 0:
+        return {
+          title: "Pepemon Cardback",
+          img: "cardbackImg",
+        };
+      case 1:
+        return {
+          title: "CZmon",
+          img: "czmonImg",
+        };
+      case 2:
+        return {
+          title: "Never to be released",
+          img: "cardbackGoldImg",
+        };
+      case 3:
+        return {
+          title: "Pepesaur",
+          img: "bscPepesaurImg",
+        };
+      case 4:
+        return {
+          title: "Pepemander",
+          img: "bscPepemanderImg",
+        };
+      case 5:
+        return {
+          title: "Pepertle",
+          img: "bscPepertleImg",
+        };
+      case 6:
+        return {
+          title: "Pivysaur",
+          img: "bscPivysaurImg",
+        };
+      case 7:
+        return {
+          title: "Pemeleon",
+          img: "bscPemeleonImg",
+        };
+      case 8:
+        return {
+          title: "Warpertle",
+          img: "bscWarpertleImg",
+        };
+      case 9:
+        return {
+          title: "Degochu",
+          img: "degochuImg",
+        };
+      case 10:
+        return {
+          title: "Dumpesaur",
+          img: "bscDumpesaurImg",
+        };
+      case 11:
+        return {
+          title: "Fudizard",
+          img: "bscFudizardImg",
+        };
+      case 12:
+        return {
+          title: "Rektoise",
+          img: "bscRektoiseImg",
+        };
     }
+  }
 
-    if (chainId === 137) {
-        switch(cardId) {
-            case 1:
-                return {
-                    title: 'Polymon',
-                    img: 'polymonImg',
-                };
-            case 2:
-                return {
-                    title: 'To be never released',
-                    img: 'cardbackGoldImg',
-                }
-        }
+  if (chainId === 137) {
+    switch (cardId) {
+      case 1:
+        return {
+          title: "Polymon",
+          img: "polymonImg",
+        };
+      case 2:
+        return {
+          title: "To be never released",
+          img: "cardbackGoldImg",
+        };
     }
+  }
 
-    switch(cardId) {
-        case 0:
-            return {
-                title: 'Pepemon Cardback',
-                img: 'cardbackImg',
-            };
-        case 1:
-            return {
-                title: 'Pepemander',
-                img: 'pepemanderImg',
-            };
-        case 2:
-            return {
-                title: 'Pepertle',
-                img: 'pepertleImg',
-            };
-        case 3:
-            return {
-                title: 'Pepesaur',
-                img: 'pepesaurImg',
-            };
-        case 4:
-            return {
-                title: 'Pepechu',
-                img: 'pepechuImg',
-            };
-        case 5:
-            return {
-                title: 'Golden Pepemander',
-                img: 'goldenPepemanderImg',
-            };
-        case 6:
-            return {
-                title: 'Golden Pepesaur',
-                img: 'goldenPepesaurImg',
-            };
-        case 7:
-            return {
-                title: 'Golden Pepertle',
-                img: 'goldenPepertleImg',
-            };
-        case 8:
-            return {
-                title: 'Golden Pepechu',
-                img: 'goldenPepechuImg',
-            };
-        case 9:
-            return {
-                title: 'Pepe Ketchum',
-                img: 'pepeKetchumImg',
-            };
-        case 10:
-            return {
-                title: 'Wisty',
-                img: 'wistyImg',
-            };
-        case 11:
-            return {
-                title: 'Bobo Rock',
-                img: 'boboRockImg',
-            };
-        case 12:
-            return {
-                title: 'Professor Pedo',
-                img: 'professorPedoImg',
-            };
-        case 13:
-            return {
-                title: 'Pigglypuff',
-                img: 'pigglypuffImg',
-            };
-        case 14:
-            return {
-                title: 'Pigglytuff',
-                img: 'pigglytuffImg',
-            };
-        case 15:
-            return {
-                title: 'Poffing',
-                img: 'poffingImg',
-            };
-        case 16:
-            return {
-                title: 'Peezing',
-                img: 'peezingImg',
-            };
-        case 17:
-            return {
-                title: 'Evolution Qube',
-                img: 'evoqubeImg',
-            };
-        case 18:
-            return {
-                title: 'Golden Evolution Qube',
-                img: 'goldenEvoqubeImg',
-            };
-        case 19:
-            return {
-                title: 'Golden Microchip',
-                img: 'goldenMicrochipImg',
-            };
-        case 20:
-            return {
-                title: 'Golden Pepeketchum',
-                img: 'goldenPepeketchumImg',
-            };
-        case 21:
-            return {
-                title: 'Pemeleon',
-                img: 'pemeleonImg',
-            };
-        case 22:
-            return {
-                title: 'Golden Pemeleon',
-                img: 'goldenPemeleonImg',
-            };
-        case 23:
-            return {
-                title: 'Warpertle',
-                img: 'warpertleImg',
-            };
-        case 24:
-            return {
-                title: 'Golden Warpertle',
-                img: 'goldenWarpertleImg',
-            };
-        case 25:
-            return {
-                title: 'Pastry',
-                img: 'pastryImg',
-            };
-        case 26:
-            return {
-                title: 'Cerbery',
-                img: 'cerberyImg',
-            };
-        case 27:
-            return {
-                title: 'Primariny',
-                img: 'primarinyImg',
-            };
-        case 28:
-            return {
-                title: 'Unifairy',
-                img: 'unifairyImg',
-            };
-        case 29:
-            return {
-                title: 'Witchenry',
-                img: 'witchenryImg',
-            };
-        case 30:
-            return {
-                title: 'Cosmony',
-                img: 'cosmonyImg',
-            };
-        case 31:
-            return {
-                title: 'Pivysaur',
-                img: 'pivysaurImg',
-            };
-        case 32:
-            return {
-                title: 'Golden Pivysaur',
-                img: 'goldenPivysaurImg',
-            };
-        case 33:
-            return {
-                title: 'Pepekarp',
-                img: 'pepekarpImg',
-            };
-        case 34:
-            return {
-                title: 'Druky',
-                img: 'drukyChristmasImg',
-            };
-        case 35:
-            return {
-                title: 'Fafny',
-                img: 'fafnyChristmasImg',
-            };
-        case 36:
-            return {
-                title: 'Sairy',
-                img: 'sairyChristmasImg',
-            };
-        case 37:
-            return {
-                title: 'Pyarados',
-                img: 'pyaradosImg',
-            };
-        case 38:
-            return {
-                title: 'Fafny',
-                img: 'fafnyImg',
-            };
-        case 39:
-            return {
-                title: 'Druky',
-                img: 'drukyImg',
-            };
-        case 40:
-            return {
-                title: 'Sairy',
-                img: 'sairyImg',
-            };
-        case 41:
-            return {
-                title: 'Venumu',
-                img: 'venumuImg',
-            };
-        case 42:
-            return {
-                title: 'Kirimu',
-                img: 'kirimuImg',
-            };
-        case 43:
-            return {
-                title: 'Shapu',
-                img: 'shapuImg',
-            };
-        case 44:
-            return {
-                title: 'Legendary Pepeketchum',
-                img: 'legendaryPepeketchumImg',
-            };
-        case 45:
-            return {
-                title: 'Fudizard',
-                img: 'fudizardImg',
-            };
-        case 46:
-            return {
-                title: 'Golden Fudizard',
-                img: 'goldenFudizardImg',
-            };
-        case 47:
-            return {
-                title: 'Moltry',
-                img: 'moltryImg',
-            }
-        case 48:
-            return {
-                title: 'Rektoise',
-                img: 'rektoiseImg',
-            };
-        case 49:
-            return {
-                title: 'Golden Rektoise',
-                img: 'goldenRektoiseImg',
-            };
-        case 50:
-            return {
-                title: 'PepeStreetBets',
-                img: 'pepeStreetBetsImg',
-            }
-        case 51:
-            return {
-                title: 'Pastry',
-                img: 'pastryPixelImg',
-            };
-        case 52:
-            return {
-                title: 'Cerbery',
-                img: 'cerberyPixelImg',
-            };
-        case 53:
-            return {
-                title: 'Primariny',
-                img: 'primarinyPixelImg',
-            };
-        case 54:
-            return {
-                title: 'Unifairy',
-                img: 'unifairyPixelImg',
-            };
-        case 55:
-            return {
-                title: 'Dumpesaur',
-                img: 'dumpesaurImg',
-            };
-        case 56:
-            return {
-                title: 'Golden Dumpesaur',
-                img: 'goldenDumpesaurImg',
-            };
-        case 57:
-            return {
-                title: 'PyepeDDos',
-                img: 'pyepeddosImg',
-            };
-        case 58:
-            return {
-                title: 'Witchenry',
-                img: 'witchenryPixelImg'
-            };
-        case 59:
-            return {
-                title: 'Fomochu',
-                img: 'fomochuImg'
-            };
-        case 60:
-            return {
-                title: 'Golden Fomochu',
-                img: 'goldenFomochuImg'
-            };
-        case 61:
-            return {
-                title: 'Pepelon',
-                img: 'pepelonImg',
-            };
-        case 62:
-            return {
-                title: 'Pishy',
-                img: 'pishyImg'
-            };
-        case 63:
-            return {
-                title: 'Mermy',
-                img: 'mermyImg'
-            };
-        case 64:
-            return {
-                title: 'Metaphy',
-                img: 'metaphyImg',
-            };
-        case 65:
-            return {
-                title: 'Zaptry',
-                img: 'zaptryImg',
-            }
-        case 66:
-            return {
-                title: 'Yugipepe',
-                img: 'yugipepeImg',
-            }
-        case 67:
-            return {
-                title: 'Zaptry',
-                img: 'zaptryImg',
-            }
-        case 68:
-            return {
-                title: "Cosmony", //pixel
-                img: 'cosmonyPixelImg',
-            }
-        case 69:
-            return {
-                title: "Nioctib Yub",
-                img: 'nioctibYubImg',
-            }
-        case 70:
-            return {
-                title: "Zhu Rong",
-                img: 'zhuRongImg',
-            }
-        case 71:
-            return {
-                title: "Golden Nioctib Yub",
-                img: 'goldenNioctibYubImg',
-            }
-        case 72:
-            return {
-                title: "Dianmu",
-                img: 'dianmuImg',
-            }
-        case 73:
-            return {
-                title: "Golden Zhu Rong",
-                img: 'goldenZhuRongImg',
-            }
-        case 74:
-            return {
-                title: "Augencore",
-                img: 'augencoreImg',
-            }
-    }
-}
+  switch (cardId) {
+    case 0:
+      return {
+        title: "Pepemon Cardback",
+        img: "cardbackImg",
+      };
+    case 1:
+      return {
+        title: "Pepemander",
+        img: "pepemanderImg",
+      };
+    case 2:
+      return {
+        title: "Pepertle",
+        img: "pepertleImg",
+      };
+    case 3:
+      return {
+        title: "Pepesaur",
+        img: "pepesaurImg",
+      };
+    case 4:
+      return {
+        title: "Pepechu",
+        img: "pepechuImg",
+      };
+    case 5:
+      return {
+        title: "Golden Pepemander",
+        img: "goldenPepemanderImg",
+      };
+    case 6:
+      return {
+        title: "Golden Pepesaur",
+        img: "goldenPepesaurImg",
+      };
+    case 7:
+      return {
+        title: "Golden Pepertle",
+        img: "goldenPepertleImg",
+      };
+    case 8:
+      return {
+        title: "Golden Pepechu",
+        img: "goldenPepechuImg",
+      };
+    case 9:
+      return {
+        title: "Pepe Ketchum",
+        img: "pepeKetchumImg",
+      };
+    case 10:
+      return {
+        title: "Wisty",
+        img: "wistyImg",
+      };
+    case 11:
+      return {
+        title: "Bobo Rock",
+        img: "boboRockImg",
+      };
+    case 12:
+      return {
+        title: "Professor Pedo",
+        img: "professorPedoImg",
+      };
+    case 13:
+      return {
+        title: "Pigglypuff",
+        img: "pigglypuffImg",
+      };
+    case 14:
+      return {
+        title: "Pigglytuff",
+        img: "pigglytuffImg",
+      };
+    case 15:
+      return {
+        title: "Poffing",
+        img: "poffingImg",
+      };
+    case 16:
+      return {
+        title: "Peezing",
+        img: "peezingImg",
+      };
+    case 17:
+      return {
+        title: "Evolution Qube",
+        img: "evoqubeImg",
+      };
+    case 18:
+      return {
+        title: "Golden Evolution Qube",
+        img: "goldenEvoqubeImg",
+      };
+    case 19:
+      return {
+        title: "Golden Microchip",
+        img: "goldenMicrochipImg",
+      };
+    case 20:
+      return {
+        title: "Golden Pepeketchum",
+        img: "goldenPepeketchumImg",
+      };
+    case 21:
+      return {
+        title: "Pemeleon",
+        img: "pemeleonImg",
+      };
+    case 22:
+      return {
+        title: "Golden Pemeleon",
+        img: "goldenPemeleonImg",
+      };
+    case 23:
+      return {
+        title: "Warpertle",
+        img: "warpertleImg",
+      };
+    case 24:
+      return {
+        title: "Golden Warpertle",
+        img: "goldenWarpertleImg",
+      };
+    case 25:
+      return {
+        title: "Pastry",
+        img: "pastryImg",
+      };
+    case 26:
+      return {
+        title: "Cerbery",
+        img: "cerberyImg",
+      };
+    case 27:
+      return {
+        title: "Primariny",
+        img: "primarinyImg",
+      };
+    case 28:
+      return {
+        title: "Unifairy",
+        img: "unifairyImg",
+      };
+    case 29:
+      return {
+        title: "Witchenry",
+        img: "witchenryImg",
+      };
+    case 30:
+      return {
+        title: "Cosmony",
+        img: "cosmonyImg",
+      };
+    case 31:
+      return {
+        title: "Pivysaur",
+        img: "pivysaurImg",
+      };
+    case 32:
+      return {
+        title: "Golden Pivysaur",
+        img: "goldenPivysaurImg",
+      };
+    case 33:
+      return {
+        title: "Pepekarp",
+        img: "pepekarpImg",
+      };
+    case 34:
+      return {
+        title: "Druky",
+        img: "drukyChristmasImg",
+      };
+    case 35:
+      return {
+        title: "Fafny",
+        img: "fafnyChristmasImg",
+      };
+    case 36:
+      return {
+        title: "Sairy",
+        img: "sairyChristmasImg",
+      };
+    case 37:
+      return {
+        title: "Pyarados",
+        img: "pyaradosImg",
+      };
+    case 38:
+      return {
+        title: "Fafny",
+        img: "fafnyImg",
+      };
+    case 39:
+      return {
+        title: "Druky",
+        img: "drukyImg",
+      };
+    case 40:
+      return {
+        title: "Sairy",
+        img: "sairyImg",
+      };
+    case 41:
+      return {
+        title: "Venumu",
+        img: "venumuImg",
+      };
+    case 42:
+      return {
+        title: "Kirimu",
+        img: "kirimuImg",
+      };
+    case 43:
+      return {
+        title: "Shapu",
+        img: "shapuImg",
+      };
+    case 44:
+      return {
+        title: "Legendary Pepeketchum",
+        img: "legendaryPepeketchumImg",
+      };
+    case 45:
+      return {
+        title: "Fudizard",
+        img: "fudizardImg",
+      };
+    case 46:
+      return {
+        title: "Golden Fudizard",
+        img: "goldenFudizardImg",
+      };
+    case 47:
+      return {
+        title: "Moltry",
+        img: "moltryImg",
+      };
+    case 48:
+      return {
+        title: "Rektoise",
+        img: "rektoiseImg",
+      };
+    case 49:
+      return {
+        title: "Golden Rektoise",
+        img: "goldenRektoiseImg",
+      };
+    case 50:
+      return {
+        title: "PepeStreetBets",
+        img: "pepeStreetBetsImg",
+      };
+    case 51:
+      return {
+        title: "Pastry",
+        img: "pastryPixelImg",
+      };
+    case 52:
+      return {
+        title: "Cerbery",
+        img: "cerberyPixelImg",
+      };
+    case 53:
+      return {
+        title: "Primariny",
+        img: "primarinyPixelImg",
+      };
+    case 54:
+      return {
+        title: "Unifairy",
+        img: "unifairyPixelImg",
+      };
+    case 55:
+      return {
+        title: "Dumpesaur",
+        img: "dumpesaurImg",
+      };
+    case 56:
+      return {
+        title: "Golden Dumpesaur",
+        img: "goldenDumpesaurImg",
+      };
+    case 57:
+      return {
+        title: "PyepeDDos",
+        img: "pyepeddosImg",
+      };
+    case 58:
+      return {
+        title: "Witchenry",
+        img: "witchenryPixelImg",
+      };
+    case 59:
+      return {
+        title: "Fomochu",
+        img: "fomochuImg",
+      };
+    case 60:
+      return {
+        title: "Golden Fomochu",
+        img: "goldenFomochuImg",
+      };
+    case 61:
+      return {
+        title: "Pepelon",
+        img: "pepelonImg",
+      };
+    case 62:
+      return {
+        title: "Pishy",
+        img: "pishyImg",
+      };
+    case 63:
+      return {
+        title: "Mermy",
+        img: "mermyImg",
+      };
+    case 64:
+      return {
+        title: "Metaphy",
+        img: "metaphyImg",
+      };
+    case 65:
+      return {
+        title: "Zaptry",
+        img: "zaptryImg",
+      };
+    case 66:
+      return {
+        title: "Yugipepe",
+        img: "yugipepeImg",
+      };
+    case 67:
+      return {
+        title: "Zaptry",
+        img: "zaptryImg",
+      };
+    case 68:
+      return {
+        title: "Cosmony", //pixel
+        img: "cosmonyPixelImg",
+      };
+    case 69:
+      return {
+        title: "Nioctib Yub",
+        img: "nioctibYubImg",
+      };
+    case 70:
+      return {
+        title: "Zhu Rong",
+        img: "zhuRongImg",
+      };
+    case 71:
+      return {
+        title: "Golden Nioctib Yub",
+        img: "goldenNioctibYubImg",
+      };
+    case 72:
+      return {
+        title: "Dianmu",
+        img: "dianmuImg",
+      };
+    case 73:
+      return {
+        title: "Golden Zhu Rong",
+        img: "goldenZhuRongImg",
+      };
+    case 74:
+      return {
+        title: "Augencore",
+        img: "augencoreImg",
+      };
+  }
+};

--- a/packages/app/src/utils/providers.ts
+++ b/packages/app/src/utils/providers.ts
@@ -1,18 +1,18 @@
-import {ethers} from "ethers";
-import {BaseProvider} from "@ethersproject/providers";
+import { ethers } from "ethers";
+import { BaseProvider } from "@ethersproject/providers";
 
 export const PepemonChain: BaseProvider = ethers.providers.getDefaultProvider(
-    "https://l2-pepechain-testnet-8uk55qlld4.t.conduit.xyz",
-    {
-        name: "pepechain-testnet",
-        chainId: 906090,
-    }
+  "https://l2-pepechain-testnet-8uk55qlld4.t.conduit.xyz",
+  {
+    name: "pepechain-testnet",
+    chainId: 906090,
+  }
 );
 
 export const Goerli: BaseProvider = ethers.providers.getDefaultProvider(
-    "goerli",
-    {
-        name: "goerli",
-        chainId: 5
-    }
+  "goerli",
+  {
+    name: "goerli",
+    chainId: 5,
+  }
 );

--- a/packages/app/src/views/Bridge/components/BridgeSubview.tsx
+++ b/packages/app/src/views/Bridge/components/BridgeSubview.tsx
@@ -39,7 +39,7 @@ const BridgeSubview: React.FC<any> = () => {
 
   const { Layer1, Layer2, depositFunds, withdrawFunds } = useBridge();
 
-  let horzScroll: any = useRef(null);
+  const horzScroll: any = useRef(null);
   useHorizontalScroll(horzScroll);
 
   return (
@@ -85,9 +85,7 @@ const BridgeSubview: React.FC<any> = () => {
           placeholder="0.00"
           value={l1NativeBalanceToBridge}
           onChange={(event) =>
-            setL1NativeBalanceToBridge(
-              cleanNumberInput(event.target.value, 18)
-            )
+            setL1NativeBalanceToBridge(cleanNumberInput(event.target.value, 18))
           }
           min="0.00"
           type={"number"}
@@ -174,9 +172,7 @@ const BridgeSubview: React.FC<any> = () => {
           placeholder="0.00"
           value={l2NativeBalanceToBridge}
           onChange={(event) =>
-            setL2NativeBalanceToBridge(
-              cleanNumberInput(event.target.value, 18)
-            )
+            setL2NativeBalanceToBridge(cleanNumberInput(event.target.value, 18))
           }
           min="0.00"
           type={"number"}

--- a/packages/app/src/views/Bridge/index.ts
+++ b/packages/app/src/views/Bridge/index.ts
@@ -1,1 +1,1 @@
-export { default, bridgeMeta } from './Bridge'
+export { default, bridgeMeta } from "./Bridge";

--- a/packages/app/src/views/Error404/Error404.tsx
+++ b/packages/app/src/views/Error404/Error404.tsx
@@ -1,29 +1,51 @@
 import React from "react";
-import { ButtonLink, ContentCentered, Head, Text, Title, Spacer } from "../../components";
+import {
+  ButtonLink,
+  ContentCentered,
+  Head,
+  Text,
+  Title,
+  Spacer,
+} from "../../components";
 import { LoadingPage } from "../../views";
 import { theme } from "../../theme";
 
 interface Error404Props {
-	title?: string,
-	text?: string,
+  title?: string;
+  text?: string;
 }
 
-const Error404: React.FC<Error404Props> = ({title, text}) => {
-	return (
-		<LoadingPage>
-			<Head title={`Pepemon - ${ title ? title : 'Error 404' }`}
-				description={text ? text : 'Stay tuned for the latest news and subscribe to the our newsletter!'}
-				index={title ? true : false} follow={title ? true : false}/>
-			<ContentCentered style={{ maxWidth: theme.breakpoints.mobile }}>
-				<Title as="h1" size='l'>{ title ? title : 'Error 404: Page not found' }</Title>
-				<Text>{ text ? text : 'Stay tuned for the latest news and subscribe to the our newsletter!' }</Text>
-				<Spacer size="md"/>
-				<ButtonLink to='/#newsletter'>Subscribe to the Newsletter</ButtonLink>
-				<Spacer size="md"/>
-				<ButtonLink to="/" light='true'>Return home</ButtonLink>
-			</ContentCentered>
-		</LoadingPage>
-	)
-}
+const Error404: React.FC<Error404Props> = ({ title, text }) => {
+  return (
+    <LoadingPage>
+      <Head
+        title={`Pepemon - ${title ? title : "Error 404"}`}
+        description={
+          text
+            ? text
+            : "Stay tuned for the latest news and subscribe to the our newsletter!"
+        }
+        index={title ? true : false}
+        follow={title ? true : false}
+      />
+      <ContentCentered style={{ maxWidth: theme.breakpoints.mobile }}>
+        <Title as="h1" size="l">
+          {title ? title : "Error 404: Page not found"}
+        </Title>
+        <Text>
+          {text
+            ? text
+            : "Stay tuned for the latest news and subscribe to the our newsletter!"}
+        </Text>
+        <Spacer size="md" />
+        <ButtonLink to="/#newsletter">Subscribe to the Newsletter</ButtonLink>
+        <Spacer size="md" />
+        <ButtonLink to="/" light="true">
+          Return home
+        </ButtonLink>
+      </ContentCentered>
+    </LoadingPage>
+  );
+};
 
 export default Error404;

--- a/packages/app/src/views/Error404/index.ts
+++ b/packages/app/src/views/Error404/index.ts
@@ -1,1 +1,1 @@
-export { default } from './Error404';
+export { default } from "./Error404";

--- a/packages/app/src/views/Home/Home.tsx
+++ b/packages/app/src/views/Home/Home.tsx
@@ -169,7 +169,6 @@ const Home: React.FC<any> = () => {
         </ContentColumns>
       </StyledSection>
 
-
       <StyledSection
         bgColor={theme.color.purple[200]}
         style={{ paddingTop: "3.75em", paddingBottom: theme.footer.spaceTop }}

--- a/packages/app/src/views/Home/components/Balances.tsx
+++ b/packages/app/src/views/Home/components/Balances.tsx
@@ -17,8 +17,8 @@ const Balances: React.FC = () => {
     <div>
       <CustomContentBoxGrid>
         <WalkingPepemon src={walk1} delay="0s" duration="10.5s" />
-		<WalkingPepemon src={walk2} delay="-3.5s" duration="13.2s" />
-		<WalkingPepemon src={walk3} delay="-8.2s" duration="11.1s"/>
+        <WalkingPepemon src={walk2} delay="-3.5s" duration="13.2s" />
+        <WalkingPepemon src={walk3} delay="-8.2s" duration="11.1s" />
         <CustomContentBox style={{ gridArea: "box1" }}>
           <Text as="p" align="center">
             Total PPBLZ value locked
@@ -136,7 +136,8 @@ const WalkingPepemon = styled.img<WalkingPepemonProps>`
   left: -96px;
   width: 96px;
   height: 96px;
-  animation: walk-pepemon-balances ${(props) => props.duration || "12s"} linear infinite;
+  animation: walk-pepemon-balances ${(props) => props.duration || "12s"} linear
+    infinite;
   animation-delay: ${(props) => props.delay || "0s"};
   z-index: 1;
 

--- a/packages/app/src/views/Home/index.ts
+++ b/packages/app/src/views/Home/index.ts
@@ -1,1 +1,1 @@
-export { default } from './Home';
+export { default } from "./Home";

--- a/packages/app/src/views/LoadingPage/LoadingPage.tsx
+++ b/packages/app/src/views/LoadingPage/LoadingPage.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 import { DefaultPage, Loading } from "../../components";
 
-const LoadingPage: React.FC<any> = ({children}) => {
-	return (
-		<DefaultPage>
-			{children}
-			<Loading/>
-		</DefaultPage>
-	)
-}
+const LoadingPage: React.FC<any> = ({ children }) => {
+  return (
+    <DefaultPage>
+      {children}
+      <Loading />
+    </DefaultPage>
+  );
+};
 
 export default LoadingPage;

--- a/packages/app/src/views/LoadingPage/index.ts
+++ b/packages/app/src/views/LoadingPage/index.ts
@@ -1,1 +1,1 @@
-export { default } from './LoadingPage';
+export { default } from "./LoadingPage";

--- a/packages/app/src/views/PrivacyPolicy/PrivacyPolicy.tsx
+++ b/packages/app/src/views/PrivacyPolicy/PrivacyPolicy.tsx
@@ -1,54 +1,160 @@
-import React from 'react'
-import { Link } from 'react-router-dom';
-import { Head, PlainText, DefaultPage } from '../../components';
+import React from "react";
+import { Link } from "react-router-dom";
+import { Head, PlainText, DefaultPage } from "../../components";
 
 const TermsOfService: React.FC<any> = () => {
-	return (
-		<DefaultPage title='Privacy Policy for pepemon'>
-			<Head title='Pepemon - Privacy Policy'
-				description="Please read the privacy policy carefully before using Our Service."
-				index={false} follow={false}/>
-			<PlainText>
-				<p>At pepemon.world, accessible from <Link to="/" rel="external nofollow noopener" target="_blank">https://pepemon.world</Link>, one of our main priorities is the privacy of our visitors. This Privacy Policy document contains types of information that is collected and recorded by pepemon.world and how we use it. If you have additional questions or require more information about our Privacy Policy, do not hesitate to contact us. This Privacy Policy applies only to our online activities and is valid for visitors to our website with regards to the information that they shared and/or collect in pepemon.world. This policy is not applicable to any information collected offline or via channels other than this website. Our Privacy Policy was created with the help of the Free Privacy Policy Generator.</p>
+  return (
+    <DefaultPage title="Privacy Policy for pepemon">
+      <Head
+        title="Pepemon - Privacy Policy"
+        description="Please read the privacy policy carefully before using Our Service."
+        index={false}
+        follow={false}
+      />
+      <PlainText>
+        <p>
+          At pepemon.world, accessible from{" "}
+          <Link to="/" rel="external nofollow noopener" target="_blank">
+            https://pepemon.world
+          </Link>
+          , one of our main priorities is the privacy of our visitors. This
+          Privacy Policy document contains types of information that is
+          collected and recorded by pepemon.world and how we use it. If you have
+          additional questions or require more information about our Privacy
+          Policy, do not hesitate to contact us. This Privacy Policy applies
+          only to our online activities and is valid for visitors to our website
+          with regards to the information that they shared and/or collect in
+          pepemon.world. This policy is not applicable to any information
+          collected offline or via channels other than this website. Our Privacy
+          Policy was created with the help of the Free Privacy Policy Generator.
+        </p>
 
-				<h2>Consent</h2>
-				<p>By using our website, you hereby consent to our Privacy Policy and agree to its terms.</p>
+        <h2>Consent</h2>
+        <p>
+          By using our website, you hereby consent to our Privacy Policy and
+          agree to its terms.
+        </p>
 
-				<h2>Information we collect</h2>
-				<p>The personal information that you are asked to provide, and the reasons why you are asked to provide it, will be made clear to you at the point we ask you to provide your personal information. If you contact us directly, we may receive additional information about you such as your name, email address, phone number, the contents of the message and/or attachments you may send us, and any other information you may choose to provide. When you register for an Account, we may ask for your contact information, including items such as name, company name, address, email address, and telephone number.</p>
+        <h2>Information we collect</h2>
+        <p>
+          The personal information that you are asked to provide, and the
+          reasons why you are asked to provide it, will be made clear to you at
+          the point we ask you to provide your personal information. If you
+          contact us directly, we may receive additional information about you
+          such as your name, email address, phone number, the contents of the
+          message and/or attachments you may send us, and any other information
+          you may choose to provide. When you register for an Account, we may
+          ask for your contact information, including items such as name,
+          company name, address, email address, and telephone number.
+        </p>
 
-				<h2>How we use your information</h2>
-				<p>We use the information we collect in various ways, including to:</p>
-				<ul>
-					<li>Provide, operate, and maintain our website</li>
-					<li>Improve, personalize, and expand our website</li>
-					<li>Understand and analyze how you use our website</li>
-					<li>Develop new products, services, features, and functionality</li>
-					<li>Communicate with you, either directly or through one of our partners, including for customer service, to provide you with updates and other information relating to the website, and for marketing and promotional purposes</li>
-					<li>Send you emails</li>
-					<li>Find and prevent fraud</li>
-				</ul>
+        <h2>How we use your information</h2>
+        <p>We use the information we collect in various ways, including to:</p>
+        <ul>
+          <li>Provide, operate, and maintain our website</li>
+          <li>Improve, personalize, and expand our website</li>
+          <li>Understand and analyze how you use our website</li>
+          <li>Develop new products, services, features, and functionality</li>
+          <li>
+            Communicate with you, either directly or through one of our
+            partners, including for customer service, to provide you with
+            updates and other information relating to the website, and for
+            marketing and promotional purposes
+          </li>
+          <li>Send you emails</li>
+          <li>Find and prevent fraud</li>
+        </ul>
 
-				<h2>Log Files</h2>
-				<p>pepemon.world follows a standard procedure of using log files. These files log visitors when they visit websites. All hosting companies do this and a part of hosting services' analytics. The information collected by log files include internet protocol (IP) addresses, browser type, Internet Service Provider (ISP), date and time stamp, referring/exit pages, and possibly the number of clicks. These are not linked to any information that is personally identifiable. The purpose of the information is for analyzing trends, administering the site, tracking users' movement on the website, and gathering demographic information.</p>
+        <h2>Log Files</h2>
+        <p>
+          pepemon.world follows a standard procedure of using log files. These
+          files log visitors when they visit websites. All hosting companies do
+          this and a part of hosting services' analytics. The information
+          collected by log files include internet protocol (IP) addresses,
+          browser type, Internet Service Provider (ISP), date and time stamp,
+          referring/exit pages, and possibly the number of clicks. These are not
+          linked to any information that is personally identifiable. The purpose
+          of the information is for analyzing trends, administering the site,
+          tracking users' movement on the website, and gathering demographic
+          information.
+        </p>
 
-				<h2>Advertising Partners Privacy Policies</h2>
-				<p>You may consult this list to find the Privacy Policy for each of the advertising partners of pepemon.world. Third-party ad servers or ad networks uses technologies like cookies, JavaScript, or Web Beacons that are used in their respective advertisements and links that appear on pepemon.world, which are sent directly to users' browser. They automatically receive your IP address when this occurs. These technologies are used to measure the effectiveness of their advertising campaigns and/or to personalize the advertising content that you see on websites that you visit. Note that pepemon.world has no access to or control over these cookies that are used by third-party advertisers.</p>
+        <h2>Advertising Partners Privacy Policies</h2>
+        <p>
+          You may consult this list to find the Privacy Policy for each of the
+          advertising partners of pepemon.world. Third-party ad servers or ad
+          networks uses technologies like cookies, JavaScript, or Web Beacons
+          that are used in their respective advertisements and links that appear
+          on pepemon.world, which are sent directly to users' browser. They
+          automatically receive your IP address when this occurs. These
+          technologies are used to measure the effectiveness of their
+          advertising campaigns and/or to personalize the advertising content
+          that you see on websites that you visit. Note that pepemon.world has
+          no access to or control over these cookies that are used by
+          third-party advertisers.
+        </p>
 
-				<h2>Third Party Privacy Policies</h2>
-				<p>pepemon.world's Privacy Policy does not apply to other advertisers or websites. Thus, we are advising you to consult the respective Privacy Policies of these third-party ad servers for more detailed information. It may include their practices and instructions about how to opt-out of certain options. You can choose to disable cookies through your individual browser options. To know more detailed information about cookie management with specific web browsers, it can be found at the browsers' respective websites.</p>
+        <h2>Third Party Privacy Policies</h2>
+        <p>
+          pepemon.world's Privacy Policy does not apply to other advertisers or
+          websites. Thus, we are advising you to consult the respective Privacy
+          Policies of these third-party ad servers for more detailed
+          information. It may include their practices and instructions about how
+          to opt-out of certain options. You can choose to disable cookies
+          through your individual browser options. To know more detailed
+          information about cookie management with specific web browsers, it can
+          be found at the browsers' respective websites.
+        </p>
 
-				<h2>CCPA Privacy Rights (Do Not Sell My Personal Information)</h2>
-				<p>Under the CCPA, among other rights, California consumers have the right to: Request that a business that collects a consumer's personal data disclose the categories and specific pieces of personal data that a business has collected about consumers. Request that a business delete any personal data about the consumer that a business has collected. Request that a business that sells a consumer's personal data, not sell the consumer's personal data. If you make a request, we have one month to respond to you. If you would like to exercise any of these rights, please contact us.</p>
+        <h2>CCPA Privacy Rights (Do Not Sell My Personal Information)</h2>
+        <p>
+          Under the CCPA, among other rights, California consumers have the
+          right to: Request that a business that collects a consumer's personal
+          data disclose the categories and specific pieces of personal data that
+          a business has collected about consumers. Request that a business
+          delete any personal data about the consumer that a business has
+          collected. Request that a business that sells a consumer's personal
+          data, not sell the consumer's personal data. If you make a request, we
+          have one month to respond to you. If you would like to exercise any of
+          these rights, please contact us.
+        </p>
 
-				<h2>GDPR Data Protection Rights</h2>
-				<p>We would like to make sure you are fully aware of all of your data protection rights. Every user is entitled to the following: The right to access – You have the right to request copies of your personal data. We may charge you a small fee for this service. The right to rectification – You have the right to request that we correct any information you believe is inaccurate. You also have the right to request that we complete the information you believe is incomplete. The right to erasure – You have the right to request that we erase your personal data, under certain conditions. The right to restrict processing – You have the right to request that we restrict the processing of your personal data, under certain conditions. The right to object to processing – You have the right to object to our processing of your personal data, under certain conditions. The right to data portability – You have the right to request that we transfer the data that we have collected to another organization, or directly to you, under certain conditions. If you make a request, we have one month to respond to you. If you would like to exercise any of these rights, please contact us.</p>
+        <h2>GDPR Data Protection Rights</h2>
+        <p>
+          We would like to make sure you are fully aware of all of your data
+          protection rights. Every user is entitled to the following: The right
+          to access – You have the right to request copies of your personal
+          data. We may charge you a small fee for this service. The right to
+          rectification – You have the right to request that we correct any
+          information you believe is inaccurate. You also have the right to
+          request that we complete the information you believe is incomplete.
+          The right to erasure – You have the right to request that we erase
+          your personal data, under certain conditions. The right to restrict
+          processing – You have the right to request that we restrict the
+          processing of your personal data, under certain conditions. The right
+          to object to processing – You have the right to object to our
+          processing of your personal data, under certain conditions. The right
+          to data portability – You have the right to request that we transfer
+          the data that we have collected to another organization, or directly
+          to you, under certain conditions. If you make a request, we have one
+          month to respond to you. If you would like to exercise any of these
+          rights, please contact us.
+        </p>
 
-				<h2>Children's Information</h2>
-				<p>Another part of our priority is adding protection for children while using the internet. We encourage parents and guardians to observe, participate in, and/or monitor and guide their online activity. pepemon.world does not knowingly collect any Personal Identifiable Information from children under the age of 13. If you think that your child provided this kind of information on our website, we strongly encourage you to contact us immediately and we will do our best efforts to promptly remove such information from our records.</p>
-			</PlainText>
-		</DefaultPage>
-	)
-}
+        <h2>Children's Information</h2>
+        <p>
+          Another part of our priority is adding protection for children while
+          using the internet. We encourage parents and guardians to observe,
+          participate in, and/or monitor and guide their online activity.
+          pepemon.world does not knowingly collect any Personal Identifiable
+          Information from children under the age of 13. If you think that your
+          child provided this kind of information on our website, we strongly
+          encourage you to contact us immediately and we will do our best
+          efforts to promptly remove such information from our records.
+        </p>
+      </PlainText>
+    </DefaultPage>
+  );
+};
 
 export default TermsOfService;

--- a/packages/app/src/views/PrivacyPolicy/index.ts
+++ b/packages/app/src/views/PrivacyPolicy/index.ts
@@ -1,1 +1,1 @@
-export { default } from './PrivacyPolicy';
+export { default } from "./PrivacyPolicy";

--- a/packages/app/src/views/Staking/Staking.tsx
+++ b/packages/app/src/views/Staking/Staking.tsx
@@ -1,18 +1,19 @@
-import React from 'react';
-import { DefaultPage } from '../../components';
-import StakeCard from './components/StakeCard';
+import React from "react";
+import { DefaultPage } from "../../components";
+import StakeCard from "./components/StakeCard";
 
 export const stakingMeta = {
-	title: 'Pepemon! Earn',
-	description: 'Users have the choice of earning with PPBLZ on our platform for a basic APY, or earn with PPBLZ-ETH LP tokens for double the rewards in PPDEX. Collect fees and help other Pepemon trainers get in the game.'
-}
+  title: "Pepemon! Earn",
+  description:
+    "Users have the choice of earning with PPBLZ on our platform for a basic APY, or earn with PPBLZ-ETH LP tokens for double the rewards in PPDEX. Collect fees and help other Pepemon trainers get in the game.",
+};
 
 const Staking: React.FC<any> = () => {
-	return (
-		<DefaultPage title='Staking'>
-			<StakeCard/>
-		</DefaultPage>
-	)
-}
+  return (
+    <DefaultPage title="Staking">
+      <StakeCard />
+    </DefaultPage>
+  );
+};
 
 export default Staking;

--- a/packages/app/src/views/Staking/components/StakeCard.tsx
+++ b/packages/app/src/views/Staking/components/StakeCard.tsx
@@ -1,865 +1,1204 @@
 // StakeCard.tsx
 
-import React, { useCallback, useEffect, useState, useRef, useContext } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useState,
+  useRef,
+  useContext,
+} from "react";
 import styled from "styled-components";
-import { ethers } from 'ethers';
-import { Spacer, Button, Title, IButtonPopover, Text, ContentCentered } from '../../../components';
-import { PepemonProviderContext } from '../../../contexts';
-import { useTokenPrices, useHorizontalScroll, useWeb3Modal } from '../../../hooks';
-import { calculatePpblzApy, calculatePpblzEthLpApy, correctChainIsLoaded } from '../../../utils';
-import { pepeball, uniswap, ppdexLogo } from '../../../assets';
-import { theme } from '../../../theme';
-import { sendTransaction } from '../../../pepemon/utils';
+import { ethers } from "ethers";
+import {
+  Spacer,
+  Button,
+  Title,
+  IButtonPopover,
+  Text,
+  ContentCentered,
+} from "../../../components";
+import { PepemonProviderContext } from "../../../contexts";
+import {
+  useTokenPrices,
+  useHorizontalScroll,
+  useWeb3Modal,
+} from "../../../hooks";
+import {
+  calculatePpblzApy,
+  calculatePpblzEthLpApy,
+  correctChainIsLoaded,
+} from "../../../utils";
+import { pepeball, uniswap, ppdexLogo } from "../../../assets";
+import { theme } from "../../../theme";
+import { sendTransaction } from "../../../pepemon/utils";
 
 const StakeCard: React.FC<any> = () => {
-    const [ppblzStakeAmount, setPpblzStakeAmount] = useState<string | null>(null);
-    const [ppblzStakedAmount, setPpblzStakedAmount] = useState<number>(0);
-    const [uniV2PpblzStakeAmount, setUniV2PpblzStakeAmount] = useState<string | null>(null);
-    const [uniV2PpblzStakedAmount, setUniV2PpblzStakedAmount] = useState<number>(0);
-    const [isApprovedPpblz, setIsApprovedPpblz] = useState<boolean>(false);
-    const [isApprovingPpblz, setIsApprovingPpblz] = useState<boolean>(false);
-    const [isApprovedUniV2Ppblz, setIsApprovedUniV2Ppblz] = useState<boolean>(false);
-    const [isApprovingUniV2Ppblz, setIsApprovingUniV2Ppblz] = useState<boolean>(false);
-    const [isStakingPpblz, setIsStakingPpblz] = useState<boolean>(false);
-    const [isWithdrawingPpblz, setIsWithdrawingPpblz] = useState<boolean>(false);
-    const [isStakingUniV2Ppblz, setIsStakingUniV2Ppblz] = useState<boolean>(false);
-    const [isWithdrawingUniV2Ppblz, setIsWithdrawingUniV2Ppblz] = useState<boolean>(false);
-    const [isClaiming, setIsClaiming] = useState<boolean>(false);
-    const [isUpdatingRewards, setIsUpdatingRewards] = useState<boolean>(false);
-    const [ppdexRewards, setPpdexRewards] = useState<number>(0);
-    const [totalPpblzSupply, setTotalPpblzSupply] = useState<number>(0);
-    const [totalUniV2PpblzSupply, setTotalUniV2PpblzSupply] = useState<number>(0);
-    const [ppblzAllowance, setPpblzAllowance] = useState<number>(0);
-    const [uniV2PpblAllowance, setUniV2PpblzAllowance] = useState<number>(0);
-    const [ppblzBalance, setPpblzBalance] = useState<number>(0);
-    const [uniV2PpblzBalance, setUniV2PpblzBalance] = useState<number>(0);
-    const [ppdexBalance, setPpdexBalance] = useState<number>(0);
-    const [transactionFinished, setTransactionFinished] = useState<number>(0);
-    const [ppblzStakeAdd, setPpblzStakeAdd] = useState<boolean>(false);
-    const [ppblzStakeSub, setPpblzStakeSub] = useState<boolean>(false);
-    const [uniV2PpblzStakeAdd, setUniV2PpblzStakeAdd] = useState<boolean>(false);
-    const [uniV2PpblzStakeSub, setUniV2PpblzStakeSub] = useState<boolean>(false);
+  const [ppblzStakeAmount, setPpblzStakeAmount] = useState<string | null>(null);
+  const [ppblzStakedAmount, setPpblzStakedAmount] = useState<number>(0);
+  const [uniV2PpblzStakeAmount, setUniV2PpblzStakeAmount] = useState<
+    string | null
+  >(null);
+  const [uniV2PpblzStakedAmount, setUniV2PpblzStakedAmount] =
+    useState<number>(0);
+  const [isApprovedPpblz, setIsApprovedPpblz] = useState<boolean>(false);
+  const [isApprovingPpblz, setIsApprovingPpblz] = useState<boolean>(false);
+  const [isApprovedUniV2Ppblz, setIsApprovedUniV2Ppblz] =
+    useState<boolean>(false);
+  const [isApprovingUniV2Ppblz, setIsApprovingUniV2Ppblz] =
+    useState<boolean>(false);
+  const [isStakingPpblz, setIsStakingPpblz] = useState<boolean>(false);
+  const [isWithdrawingPpblz, setIsWithdrawingPpblz] = useState<boolean>(false);
+  const [isStakingUniV2Ppblz, setIsStakingUniV2Ppblz] =
+    useState<boolean>(false);
+  const [isWithdrawingUniV2Ppblz, setIsWithdrawingUniV2Ppblz] =
+    useState<boolean>(false);
+  const [isClaiming, setIsClaiming] = useState<boolean>(false);
+  const [isUpdatingRewards, setIsUpdatingRewards] = useState<boolean>(false);
+  const [ppdexRewards, setPpdexRewards] = useState<number>(0);
+  const [totalPpblzSupply, setTotalPpblzSupply] = useState<number>(0);
+  const [totalUniV2PpblzSupply, setTotalUniV2PpblzSupply] = useState<number>(0);
+  const [ppblzAllowance, setPpblzAllowance] = useState<number>(0);
+  const [uniV2PpblAllowance, setUniV2PpblzAllowance] = useState<number>(0);
+  const [ppblzBalance, setPpblzBalance] = useState<number>(0);
+  const [uniV2PpblzBalance, setUniV2PpblzBalance] = useState<number>(0);
+  const [ppdexBalance, setPpdexBalance] = useState<number>(0);
+  const [transactionFinished, setTransactionFinished] = useState<number>(0);
+  const [ppblzStakeAdd, setPpblzStakeAdd] = useState<boolean>(false);
+  const [ppblzStakeSub, setPpblzStakeSub] = useState<boolean>(false);
+  const [uniV2PpblzStakeAdd, setUniV2PpblzStakeAdd] = useState<boolean>(false);
+  const [uniV2PpblzStakeSub, setUniV2PpblzStakeSub] = useState<boolean>(false);
 
-    const [pepemon] = useContext(PepemonProviderContext);
-    const { account, contracts, provider } = pepemon;
-    const [, loadWeb3Modal] = useWeb3Modal();
+  const [pepemon] = useContext(PepemonProviderContext);
+  const { account, contracts, provider } = pepemon;
+  const [, loadWeb3Modal] = useWeb3Modal();
 
-    const { ppblzPrice, ppdexPrice } = useTokenPrices();
-    const ppblzApy = calculatePpblzApy(ppblzPrice, ppdexPrice);
-    const ppblzEthLpApy = calculatePpblzEthLpApy(ppblzPrice, ppdexPrice);
+  const { ppblzPrice, ppdexPrice } = useTokenPrices();
+  const ppblzApy = calculatePpblzApy(ppblzPrice, ppdexPrice);
+  const ppblzEthLpApy = calculatePpblzEthLpApy(ppblzPrice, ppdexPrice);
 
-    const timer: any = useRef(null);
-    const horzScroll: any = useRef(null);
-    useHorizontalScroll(horzScroll);
+  const timer: any = useRef(null);
+  const horzScroll: any = useRef(null);
+  useHorizontalScroll(horzScroll);
 
-    useEffect(() => {
-        return () => timer && clearTimeout(timer);
-    }, [timer]);
+  useEffect(() => {
+    return () => timer && clearTimeout(timer);
+  }, [timer]);
 
-    const resetToInitialStateOnReject = async () => {
-        setIsStakingPpblz(false);
-        setIsApprovingPpblz(false);
-        setIsWithdrawingPpblz(false);
-        setIsStakingUniV2Ppblz(false);
-        setIsApprovingUniV2Ppblz(false);
-        setIsWithdrawingUniV2Ppblz(false);
-        setIsClaiming(false);
-    };
+  const resetToInitialStateOnReject = async () => {
+    setIsStakingPpblz(false);
+    setIsApprovingPpblz(false);
+    setIsWithdrawingPpblz(false);
+    setIsStakingUniV2Ppblz(false);
+    setIsApprovingUniV2Ppblz(false);
+    setIsWithdrawingUniV2Ppblz(false);
+    setIsClaiming(false);
+  };
 
-    const safeFromWei = (value: ethers.BigNumber | string) => {
-        try {
-            if (typeof value !== 'string') {
-                value = value.toString();
-            }
-            return parseFloat(ethers.utils.formatUnits(value, 'ether'));
-        } catch (error) {
-            console.error('Error in safeFromWei:', error);
-            return 0;
-        }
-    };
+  const safeFromWei = (value: ethers.BigNumber | string) => {
+    try {
+      if (typeof value !== "string") {
+        value = value.toString();
+      }
+      return parseFloat(ethers.utils.formatUnits(value, "ether"));
+    } catch (error) {
+      console.error("Error in safeFromWei:", error);
+      return 0;
+    }
+  };
 
-    const getPpblzAllowance = useCallback(async () => {
-        try {
-            const _ppblzAllowance = await contracts.ppblz.allowance(account, contracts.ppdex.address);
-            setPpblzAllowance(safeFromWei(_ppblzAllowance));
-            setIsApprovedPpblz(_ppblzAllowance.gt(ethers.BigNumber.from('0')));
-        } catch (error) {
-            console.error('Error in getPpblzAllowance:', error);
-        }
-    }, [setPpblzAllowance, account, contracts?.ppblz, contracts?.ppdex?.address]);
-
-    const getUniV2PpblzAllowance = useCallback(async () => {
-        try {
-            const _uniV2PpblzAllowance = await contracts.uniV2_ppblz.allowance(account, contracts.ppdex.address);
-            setUniV2PpblzAllowance(safeFromWei(_uniV2PpblzAllowance));
-            setIsApprovedUniV2Ppblz(_uniV2PpblzAllowance.gt(ethers.BigNumber.from('0')));
-        } catch (error) {
-            console.error('Error in getUniV2PpblzAllowance:', error);
-        }
-    }, [contracts?.uniV2_ppblz, contracts?.ppdex?.address, setUniV2PpblzAllowance, account]);
-
-    const getPpblzBalance = useCallback(async () => {
-        try {
-            const _ppblzBalance = await contracts.ppblz.balanceOf(account);
-            setPpblzBalance(safeFromWei(_ppblzBalance));
-        } catch (error) {
-            console.error('Error in getPpblzBalance:', error);
-        }
-    }, [contracts.ppblz, setPpblzBalance, account]);
-
-    const getUniV2PpblzBalance = useCallback(async () => {
-        try {
-            const _uniV2PpblzBalance = await contracts.uniV2_ppblz.balanceOf(account);
-            setUniV2PpblzBalance(safeFromWei(_uniV2PpblzBalance));
-        } catch (error) {
-            console.error('Error in getUniV2PpblzBalance:', error);
-        }
-    }, [contracts.uniV2_ppblz, setUniV2PpblzBalance, account]);
-
-    const getPpdexBalance = useCallback(async () => {
-        try {
-            const _ppdexBalance = await contracts.ppdex.balanceOf(account);
-            setPpdexBalance(safeFromWei(_ppdexBalance));
-        } catch (error) {
-            console.error('Error in getPpdexBalance:', error);
-        }
-    }, [contracts.ppdex, setPpdexBalance, account]);
-
-    const getPpblzSupply = useCallback(async () => {
-        try {
-            const _ppblzSupply = await contracts.ppblz.totalSupply();
-            setTotalPpblzSupply(safeFromWei(_ppblzSupply));
-        } catch (error) {
-            console.error('Error in getPpblzSupply:', error);
-        }
-    }, [contracts.ppblz, setTotalPpblzSupply]);
-
-    const getUniV2PpblzSupply = useCallback(async () => {
-        try {
-            const _ppblzSupply = await contracts.uniV2_ppblz.totalSupply();
-            setTotalUniV2PpblzSupply(safeFromWei(_ppblzSupply));
-        } catch (error) {
-            console.error('Error in getUniV2PpblzSupply:', error);
-        }
-    }, [contracts.uniV2_ppblz, setTotalUniV2PpblzSupply]);
-
-    const getMyPpblzStakeAmount = useCallback(async () => {
-        try {
-            const stakeA = await contracts.ppdex.getAddressPpblzStakeAmount(account);
-            setPpblzStakedAmount(safeFromWei(stakeA));
-        } catch (error) {
-            console.error('Error in getMyPpblzStakeAmount:', error);
-        }
-    }, [contracts.ppdex, setPpblzStakedAmount, account]);
-
-    const getMyUniV2PpblzStakeAmount = useCallback(async () => {
-        try {
-            const stakeA = await contracts.ppdex.getAddressUniV2StakeAmount(account);
-            setUniV2PpblzStakedAmount(safeFromWei(stakeA));
-        } catch (error) {
-            console.error('Error in getMyUniV2PpblzStakeAmount:', error);
-        }
-    }, [contracts.ppdex, setUniV2PpblzStakedAmount, account]);
-
-    const getPpdexRewards = useCallback(async () => {
-        setIsUpdatingRewards(true);
-        try {
-            const cRewards = await contracts.ppdex.myRewardsBalance(account);
-            const ppblzStaked = await contracts.ppdex.getAddressPpblzStakeAmount(account);
-            const uniV2Staked = await contracts.ppdex.getAddressUniV2StakeAmount(account);
-
-            let rewardsToSet = cRewards;
-
-            if (ppblzStaked.gt(ethers.BigNumber.from('0')) && uniV2Staked.gt(ethers.BigNumber.from('0'))) {
-                const lastRewardBlock = await contracts.ppdex.getLastBlockCheckedNum(account);
-                const currentBlock = await contracts.ppdex.getBlockNum();
-                const liquidityMultiplier = await contracts.ppdex.getLiquidityMultiplier();
-                const rewardsVar = ethers.BigNumber.from('100000');
-
-                const blockDiff = currentBlock.sub(lastRewardBlock);
-                const ppblzRewardBalance = ppblzStaked.mul(blockDiff).div(rewardsVar);
-                const uniV2RewardsBalance = uniV2Staked.mul(blockDiff).mul(liquidityMultiplier).div(rewardsVar);
-
-                const totalRewards = ppblzRewardBalance.add(uniV2RewardsBalance);
-
-                if (cRewards.gt(ethers.BigNumber.from('10000'))) {
-                    const originalReward = cRewards.sub(totalRewards);
-                    rewardsToSet = originalReward.div(ethers.BigNumber.from('2')).add(totalRewards);
-                }
-            }
-
-            setPpdexRewards(safeFromWei(rewardsToSet));
-        } catch (error) {
-            console.error('Error in getPpdexRewards:', error);
-        } finally {
-            setTimeout(() => {
-                setIsUpdatingRewards(false);
-                if (timer.current) {
-                    clearTimeout(timer.current);
-                }
-            }, 2000);
-        }
-    }, [account, contracts.ppdex]);
-
-    const stakePpblz = async () => {
-        if ((isStakingPpblz || !ppblzStakeAmount || parseFloat(ppblzStakeAmount) === 0) || (parseFloat(ppblzStakeAmount) > ppblzBalance)) {
-            return;
-        }
-
-        setIsStakingPpblz(true);
-        try {
-            const amount = ethers.utils.parseUnits(ppblzStakeAmount.toString(), 'ether');
-            const stakeRes = await sendTransaction(provider,
-                async () => await contracts.ppdex.stakePpblz(amount, { gasLimit: 200000 })
-            );
-
-            if (stakeRes) {
-                setIsStakingPpblz(false);
-                setPpblzStakeAmount(null);
-                setPpblzStakeAdd(false);
-                await getMyPpblzStakeAmount();
-                await getPpblzBalance();
-                await getPpblzAllowance();
-                await getPpdexRewards();
-            }
-            setTransactionFinished(prev => prev + 1);
-        } catch (error) {
-            console.error('Error in stakePpblz:', error);
-            await resetToInitialStateOnReject();
-        }
-    };
-
-    const stakeUniV2Ppblz = async () => {
-        if ((isStakingUniV2Ppblz || !uniV2PpblzStakeAmount || parseFloat(uniV2PpblzStakeAmount) === 0) || (parseFloat(uniV2PpblzStakeAmount) > uniV2PpblzBalance)) {
-            return;
-        }
-
-        setIsStakingUniV2Ppblz(true);
-        try {
-            const amount = ethers.utils.parseUnits(uniV2PpblzStakeAmount.toString(), 'ether');
-            let stakeRes = await sendTransaction(provider, async () => await contracts.ppdex.stakeUniV2(amount, { gasLimit: 200000 }));
-            if (stakeRes) {
-                setIsStakingUniV2Ppblz(false);
-                setUniV2PpblzStakeAmount(null);
-                setUniV2PpblzStakeAdd(false);
-                await getMyUniV2PpblzStakeAmount();
-                await getUniV2PpblzBalance();
-                await getUniV2PpblzAllowance();
-                await getPpdexRewards();
-            }
-            setTransactionFinished(prev => prev + 1);
-        } catch (error) {
-            console.log(error);
-            await resetToInitialStateOnReject();
-        }
-    };
-
-    const withdrawPpblz = async () => {
-        if (isWithdrawingPpblz || ppblzStakeAmount === null || parseFloat(ppblzStakeAmount) === 0) {
-            return;
-        }
-        setIsWithdrawingPpblz(true);
-        try {
-            const amount = ethers.utils.parseUnits(ppblzStakeAmount.toString(), 'ether');
-            let unstakeRes = await sendTransaction(provider, async () => await contracts.ppdex.withdrawPpblz(amount, { gasLimit: 200000 }));
-
-            if (unstakeRes) {
-                setIsWithdrawingPpblz(false);
-                setPpblzStakeAmount(null);
-                setPpblzStakeSub(false);
-                await getMyPpblzStakeAmount();
-                await getPpblzBalance();
-                await getPpblzAllowance();
-                await getPpdexRewards();
-            } else {
-                setIsWithdrawingPpblz(false);
-            }
-
-            setTransactionFinished(prev => prev + 1);
-        } catch (error) {
-            console.log(error);
-            await resetToInitialStateOnReject();
-        }
-    };
-
-    const withdrawUniV2Ppblz = async () => {
-        if (isWithdrawingUniV2Ppblz || uniV2PpblzStakeAmount === null || parseFloat(uniV2PpblzStakeAmount) === 0) {
-            return;
-        }
-        setIsWithdrawingUniV2Ppblz(true);
-        try {
-            const amount = ethers.utils.parseUnits(uniV2PpblzStakeAmount.toString(), 'ether');
-            let unstakeRes = await sendTransaction(provider, async () => await contracts.ppdex.withdrawUniV2(amount, { gasLimit: 200000 }));
-
-            if (unstakeRes) {
-                setIsWithdrawingUniV2Ppblz(false);
-                setUniV2PpblzStakeAmount(null);
-                setUniV2PpblzStakeSub(false);
-                await getMyUniV2PpblzStakeAmount();
-                await getUniV2PpblzBalance();
-                await getUniV2PpblzAllowance();
-                await getPpdexRewards();
-            } else {
-                setIsWithdrawingUniV2Ppblz(false);
-            }
-
-            setTransactionFinished(prev => prev + 1);
-        } catch (error) {
-            console.log(error);
-            await resetToInitialStateOnReject();
-        }
-    };
-
-    const approvePpblz = async () => {
-        if (isApprovingPpblz) {
-            return;
-        }
-        setIsApprovingPpblz(true);
-
-        try {
-            const approveAmount = ppblzStakeAmount && parseFloat(ppblzStakeAmount) > 0
-                ? ethers.utils.parseUnits(ppblzStakeAmount.toString(), 'ether')
-                : ethers.utils.parseUnits(ppblzBalance.toString(), 'ether');
-            let approveStaking = await sendTransaction(provider, async () => await contracts.ppblz.approve(
-                contracts.ppdex.address,
-                approveAmount
-            ));
-
-            await getPpblzAllowance();
-
-            if (approveStaking) {
-                setIsApprovingPpblz(false);
-                setIsApprovedPpblz(true);
-                if (ppblzStakeAmount && parseFloat(ppblzStakeAmount) > 0 && parseFloat(ppblzStakeAmount) <= ppblzBalance) {
-                    await stakePpblz();
-                }
-            } else {
-                setIsApprovingPpblz(false);
-            }
-
-            setTransactionFinished(prev => prev + 1);
-        } catch (error) {
-            console.log(error);
-            await resetToInitialStateOnReject();
-        }
-    };
-
-    const approveUniV2Ppblz = async () => {
-        if (isApprovingUniV2Ppblz) {
-            return;
-        }
-        setIsApprovingUniV2Ppblz(true);
-
-        try {
-            const approveAmount = uniV2PpblzStakeAmount && parseFloat(uniV2PpblzStakeAmount) > 0
-                ? ethers.utils.parseUnits(uniV2PpblzStakeAmount.toString(), 'ether')
-                : ethers.utils.parseUnits(uniV2PpblzBalance.toString(), 'ether');
-            let approveStaking = await sendTransaction(provider, async () => await contracts.uniV2_ppblz.approve(
-                contracts.ppdex.address,
-                approveAmount
-            ));
-            await getUniV2PpblzAllowance();
-
-            if (approveStaking) {
-                setIsApprovingUniV2Ppblz(false);
-                setIsApprovedUniV2Ppblz(true);
-                if (uniV2PpblzStakeAmount && parseFloat(uniV2PpblzStakeAmount) > 0 && parseFloat(uniV2PpblzStakeAmount) <= uniV2PpblzBalance) {
-                    await stakeUniV2Ppblz();
-                }
-            } else {
-                setIsApprovingUniV2Ppblz(false);
-            }
-
-            setTransactionFinished(prev => prev + 1);
-        } catch (error) {
-            console.log(error);
-            await resetToInitialStateOnReject();
-        }
-    };
-
-    const cleanNumberInput = (value: string, maxDecimals: number) => {
-        if (value[0] === '0' && (value[1] && value[1] !== '.')) {
-            return value[1];
-        }
-        if (value.slice(-2) === '..') {
-            return value.slice(0, -1);
-        }
-        if (value.split('.').length > 1 && value.split('.')[1].length > maxDecimals) {
-            return `${value.split('.')[0]}.${value.split('.')[1].slice(0, maxDecimals)}`;
-        }
-        return value;
-    };
-
-    const isInvalidInput = (value: string) =>
-        !Number(value) &&
-        value !== '' &&
-        parseFloat(value) !== 0 &&
-        value.slice(-1) !== '.' &&
-        value.slice(-2) !== '.0';
-
-    /** setters & modifiers */
-    const updatePpblzStakingInput = (e: React.ChangeEvent<HTMLInputElement>) => {
-        if (isInvalidInput(e.target.value)) {
-            return;
-        }
-        setPpblzStakeAmount(cleanNumberInput(e.target.value, 18));
-    };
-
-    const updateUniV2PpblzStakingInput = (e: React.ChangeEvent<HTMLInputElement>) => {
-        if (isInvalidInput(e.target.value)) {
-            return;
-        }
-        setUniV2PpblzStakeAmount(cleanNumberInput(e.target.value, 18));
-    };
-
-    const setPpblzInputField = () => {
-        if (ppblzStakeAmount !== null) {
-            return ppblzStakeAmount;
-        } else {
-            return '';
-        }
-    };
-
-    const setUniV2PpblzInputField = () => {
-        if (uniV2PpblzStakeAmount !== null) {
-            return uniV2PpblzStakeAmount;
-        } else {
-            return '';
-        }
-    };
-
-    const setMaxPpblz = () => {
-        if (ppblzStakeSub) {
-            return setPpblzStakeAmount(ppblzStakedAmount.toString());
-        }
-        return setPpblzStakeAmount(ppblzBalance.toString());
-    };
-
-    const setMaxUniV2Ppblz = () => {
-        if (uniV2PpblzStakeSub) {
-            return setUniV2PpblzStakeAmount(uniV2PpblzStakedAmount.toString());
-        }
-        return setUniV2PpblzStakeAmount(uniV2PpblzBalance.toString());
-    };
-
-    const claimRewards = async () => {
-        if (isClaiming) {
-            return;
-        }
-
-        if (ppdexRewards > 0) {
-            setIsClaiming(true);
-            try {
-                await sendTransaction(provider, async () => await contracts.ppdex.getReward());
-
-                await getPpdexRewards();
-                setTransactionFinished(prev => prev + 1);
-            } catch (error) {
-                console.log(error);
-                await resetToInitialStateOnReject();
-            }
-        }
-        setIsClaiming(false);
-    };
-
-    useEffect(() => {
-        if (!pepemon || !contracts) {
-            return;
-        }
-        correctChainIsLoaded(pepemon).then(correct => {
-            if (!correct) {
-                return;
-            }
-
-            try {
-                getPpblzAllowance();
-                getPpblzSupply();
-                getPpblzBalance();
-                getMyPpblzStakeAmount();
-                getUniV2PpblzAllowance();
-                getUniV2PpblzSupply();
-                getUniV2PpblzBalance();
-                getMyUniV2PpblzStakeAmount();
-                getPpdexBalance();
-                getPpdexRewards();
-                setIsApprovedPpblz(false);
-                setIsApprovedUniV2Ppblz(false);
-            } catch (error) {
-                alert(`Failed to load web3, accounts, or contract. Check console for details.`);
-                console.error(error);
-            }
-        });
-    }, [
+  const getPpblzAllowance = useCallback(async () => {
+    try {
+      const _ppblzAllowance = await contracts.ppblz.allowance(
         account,
-        pepemon,
-        contracts,
+        contracts.ppdex.address
+      );
+      setPpblzAllowance(safeFromWei(_ppblzAllowance));
+      setIsApprovedPpblz(_ppblzAllowance.gt(ethers.BigNumber.from("0")));
+    } catch (error) {
+      console.error("Error in getPpblzAllowance:", error);
+    }
+  }, [setPpblzAllowance, account, contracts?.ppblz, contracts?.ppdex?.address]);
+
+  const getUniV2PpblzAllowance = useCallback(async () => {
+    try {
+      const _uniV2PpblzAllowance = await contracts.uniV2_ppblz.allowance(
+        account,
+        contracts.ppdex.address
+      );
+      setUniV2PpblzAllowance(safeFromWei(_uniV2PpblzAllowance));
+      setIsApprovedUniV2Ppblz(
+        _uniV2PpblzAllowance.gt(ethers.BigNumber.from("0"))
+      );
+    } catch (error) {
+      console.error("Error in getUniV2PpblzAllowance:", error);
+    }
+  }, [
+    contracts?.uniV2_ppblz,
+    contracts?.ppdex?.address,
+    setUniV2PpblzAllowance,
+    account,
+  ]);
+
+  const getPpblzBalance = useCallback(async () => {
+    try {
+      const _ppblzBalance = await contracts.ppblz.balanceOf(account);
+      setPpblzBalance(safeFromWei(_ppblzBalance));
+    } catch (error) {
+      console.error("Error in getPpblzBalance:", error);
+    }
+  }, [contracts.ppblz, setPpblzBalance, account]);
+
+  const getUniV2PpblzBalance = useCallback(async () => {
+    try {
+      const _uniV2PpblzBalance = await contracts.uniV2_ppblz.balanceOf(account);
+      setUniV2PpblzBalance(safeFromWei(_uniV2PpblzBalance));
+    } catch (error) {
+      console.error("Error in getUniV2PpblzBalance:", error);
+    }
+  }, [contracts.uniV2_ppblz, setUniV2PpblzBalance, account]);
+
+  const getPpdexBalance = useCallback(async () => {
+    try {
+      const _ppdexBalance = await contracts.ppdex.balanceOf(account);
+      setPpdexBalance(safeFromWei(_ppdexBalance));
+    } catch (error) {
+      console.error("Error in getPpdexBalance:", error);
+    }
+  }, [contracts.ppdex, setPpdexBalance, account]);
+
+  const getPpblzSupply = useCallback(async () => {
+    try {
+      const _ppblzSupply = await contracts.ppblz.totalSupply();
+      setTotalPpblzSupply(safeFromWei(_ppblzSupply));
+    } catch (error) {
+      console.error("Error in getPpblzSupply:", error);
+    }
+  }, [contracts.ppblz, setTotalPpblzSupply]);
+
+  const getUniV2PpblzSupply = useCallback(async () => {
+    try {
+      const _ppblzSupply = await contracts.uniV2_ppblz.totalSupply();
+      setTotalUniV2PpblzSupply(safeFromWei(_ppblzSupply));
+    } catch (error) {
+      console.error("Error in getUniV2PpblzSupply:", error);
+    }
+  }, [contracts.uniV2_ppblz, setTotalUniV2PpblzSupply]);
+
+  const getMyPpblzStakeAmount = useCallback(async () => {
+    try {
+      const stakeA = await contracts.ppdex.getAddressPpblzStakeAmount(account);
+      setPpblzStakedAmount(safeFromWei(stakeA));
+    } catch (error) {
+      console.error("Error in getMyPpblzStakeAmount:", error);
+    }
+  }, [contracts.ppdex, setPpblzStakedAmount, account]);
+
+  const getMyUniV2PpblzStakeAmount = useCallback(async () => {
+    try {
+      const stakeA = await contracts.ppdex.getAddressUniV2StakeAmount(account);
+      setUniV2PpblzStakedAmount(safeFromWei(stakeA));
+    } catch (error) {
+      console.error("Error in getMyUniV2PpblzStakeAmount:", error);
+    }
+  }, [contracts.ppdex, setUniV2PpblzStakedAmount, account]);
+
+  const getPpdexRewards = useCallback(async () => {
+    setIsUpdatingRewards(true);
+    try {
+      const cRewards = await contracts.ppdex.myRewardsBalance(account);
+      const ppblzStaked = await contracts.ppdex.getAddressPpblzStakeAmount(
+        account
+      );
+      const uniV2Staked = await contracts.ppdex.getAddressUniV2StakeAmount(
+        account
+      );
+
+      let rewardsToSet = cRewards;
+
+      if (
+        ppblzStaked.gt(ethers.BigNumber.from("0")) &&
+        uniV2Staked.gt(ethers.BigNumber.from("0"))
+      ) {
+        const lastRewardBlock = await contracts.ppdex.getLastBlockCheckedNum(
+          account
+        );
+        const currentBlock = await contracts.ppdex.getBlockNum();
+        const liquidityMultiplier =
+          await contracts.ppdex.getLiquidityMultiplier();
+        const rewardsVar = ethers.BigNumber.from("100000");
+
+        const blockDiff = currentBlock.sub(lastRewardBlock);
+        const ppblzRewardBalance = ppblzStaked.mul(blockDiff).div(rewardsVar);
+        const uniV2RewardsBalance = uniV2Staked
+          .mul(blockDiff)
+          .mul(liquidityMultiplier)
+          .div(rewardsVar);
+
+        const totalRewards = ppblzRewardBalance.add(uniV2RewardsBalance);
+
+        if (cRewards.gt(ethers.BigNumber.from("10000"))) {
+          const originalReward = cRewards.sub(totalRewards);
+          rewardsToSet = originalReward
+            .div(ethers.BigNumber.from("2"))
+            .add(totalRewards);
+        }
+      }
+
+      setPpdexRewards(safeFromWei(rewardsToSet));
+    } catch (error) {
+      console.error("Error in getPpdexRewards:", error);
+    } finally {
+      setTimeout(() => {
+        setIsUpdatingRewards(false);
+        if (timer.current) {
+          clearTimeout(timer.current);
+        }
+      }, 2000);
+    }
+  }, [account, contracts.ppdex]);
+
+  const stakePpblz = async () => {
+    if (
+      isStakingPpblz ||
+      !ppblzStakeAmount ||
+      parseFloat(ppblzStakeAmount) === 0 ||
+      parseFloat(ppblzStakeAmount) > ppblzBalance
+    ) {
+      return;
+    }
+
+    setIsStakingPpblz(true);
+    try {
+      const amount = ethers.utils.parseUnits(
+        ppblzStakeAmount.toString(),
+        "ether"
+      );
+      const stakeRes = await sendTransaction(
         provider,
-        transactionFinished,
-        getMyPpblzStakeAmount,
-        getMyUniV2PpblzStakeAmount,
-        getPpblzAllowance,
-        getPpblzBalance,
-        getPpblzSupply,
-        getPpdexBalance,
-        getPpdexRewards,
-        getUniV2PpblzAllowance,
-        getUniV2PpblzBalance,
-        getUniV2PpblzSupply,
-    ]);
+        async () =>
+          await contracts.ppdex.stakePpblz(amount, { gasLimit: 200000 })
+      );
 
-    return (
-        <StakeGrid>
-            <StakeGridTop ref={horzScroll}>
-                {/* PPBLZ Staking Section */}
-                <StakeGridArea>
-                    <StakeGridAreaHeader>
-                        <StakeGridAreaHeaderTitle>
-                            <img loading="lazy" src={pepeball} alt="Pepeball"/>
-                            <Spacer size="sm"/>
-                            <Title as="h2" size='m' color={theme.color.white} font={theme.font.neometric} weight={900}>Earn with PPBLZ</Title>
-                        </StakeGridAreaHeaderTitle>
-                        <StakeGridAreaHeaderMeta>
-                            <span>{ppblzApy.toFixed(0)}% APY</span>
-                            <IButtonPopover cursor={'pointer'} heading="APY staking PPBLZ"
-                                apy={ppblzApy}
-                                ppdexPrice={ppdexPrice}
-                                button={{ href:"https://app.uniswap.org/#/swap?outputCurrency=0x4d2ee5dae46c86da2ff521f7657dad98834f97b8", text: 'Buy PPBLZ' }}/>
-                        </StakeGridAreaHeaderMeta>
-                    </StakeGridAreaHeader>
-                    <StakeGridAreaBody>
-                        <DataColumns>
-                            <DataColumn>
-                                <Text as="p" size="m" font={theme.font.inter}>PPBLZ balance</Text>
-                                <Spacer size="sm"/>
-                                <Text as="p" font={theme.font.neometric} weight={900} size='xl'>{parseFloat(ppblzBalance.toString()).toFixed(2)}</Text>
-                            </DataColumn>
-                            <DataColumn>
-                                <Text as="p" size="m" font={theme.font.inter}>PPBLZ staked</Text>
-                                <Spacer size="sm"/>
-                                <Text as="p" font={theme.font.neometric} weight={900} size='xl'>{parseFloat(ppblzStakedAmount.toString()).toFixed(2)}</Text>
-                            </DataColumn>
-                        </DataColumns>
-                        <div style={{ marginTop: "auto" }}>
-                            {!account &&
-                                <Button styling="purple" onClick={loadWeb3Modal} width="100%">Connect wallet</Button>
-                            }
-                            {account && !ppblzStakeAdd && !ppblzStakeSub &&
-                                <ContentCentered
-                                    style={{
-                                    display: "flex",
-                                    flexDirection: "row",
-                                    justifyContent: "center",
-                                    }}
-                                >
-                                    <Button styling="white" onClick={() => {
-                                        setPpblzStakeSub(true);
-                                        setPpblzStakeAdd(false);
-                                    }} width="20%" symbol aria-label="withdraw"
-                                        {...(ppblzStakedAmount <= 0 && {disabled: true})}
-                                    >-</Button>
-                                    <Spacer size="sm"/>
-                                    <Button styling="purple" onClick={() => {
-                                        setPpblzStakeSub(false);
-                                        setPpblzStakeAdd(true);
-                                    }} width="80%" symbol aria-label="stake"
-                                    {...(ppblzBalance <= 0 && {disabled: true})}
-                                    >+</Button>
-                                </ContentCentered>
-                            }
-                            {account &&
-                            (ppblzStakeAdd || ppblzStakeSub) &&
-                            !isStakingPpblz &&
-                            !isWithdrawingPpblz &&
-                            !isApprovingPpblz &&
-                                <ContentCentered direction="row" bgColor={theme.color.white} style={{ borderRadius: "8px", border: `1px solid ${theme.color.purple[700]}`, padding: ".1em .1em .1em 0.75em" }}>
-                                    <StyledInput
-                                        placeholder="0.00"
-                                        value={setPpblzInputField() || ""}
-                                        onChange={(event) => updatePpblzStakingInput(event) }
-                                        min="0.00"
-                                        step="1"
-                                        autoFocus={true} />
-                                    <Button styling="link" onClick={setMaxPpblz}>Max</Button>
-                                    {(ppblzAllowance <= 0 || ppblzAllowance < parseFloat(ppblzStakeAmount || '0')) && !ppblzStakeSub
-                                        ? <Button styling="purple"
-                                            onClick={approvePpblz}
-                                            disabled={!ppblzStakeAmount || parseFloat(ppblzStakeAmount) <= 0 || isUpdatingRewards}
-                                          >Enable</Button>
-                                        : ppblzStakeSub && !ppblzStakeAdd
-                                            ? <Button styling="purple"
-                                                onClick={withdrawPpblz}
-                                                disabled={!(parseFloat(ppblzStakeAmount || '0') > 0 && parseFloat(ppblzStakeAmount || '0') <= ppblzStakedAmount) || isWithdrawingPpblz}
-                                              >Withdraw</Button>
-                                            : <Button styling="purple"
-                                                onClick={stakePpblz}
-                                                disabled={!(parseFloat(ppblzStakeAmount || '0') > 0 && parseFloat(ppblzStakeAmount || '0') <= ppblzBalance) || isStakingPpblz}
-                                              >Stake</Button>
-                                    }
-                                </ContentCentered>
-                            }
-                            {account && (isApprovingPpblz || isStakingPpblz || isWithdrawingPpblz) &&
-                                <Button styling="purple" width="100%" disabled>
-                                    {isApprovingPpblz && "Enabling"}
-                                    {isStakingPpblz && "Staking"}
-                                    {isWithdrawingPpblz && "Withdrawing"}
-                                ...</Button>
-                            }
-                        </div>
-                    </StakeGridAreaBody>
-                </StakeGridArea>
+      if (stakeRes) {
+        setIsStakingPpblz(false);
+        setPpblzStakeAmount(null);
+        setPpblzStakeAdd(false);
+        await getMyPpblzStakeAmount();
+        await getPpblzBalance();
+        await getPpblzAllowance();
+        await getPpdexRewards();
+      }
+      setTransactionFinished((prev) => prev + 1);
+    } catch (error) {
+      console.error("Error in stakePpblz:", error);
+      await resetToInitialStateOnReject();
+    }
+  };
 
-                {/* UniV2PPBLZ LP Staking Section */}
-                <StakeGridArea>
-                    <StakeGridAreaHeader>
-                        <StakeGridAreaHeaderTitle>
-                            <img loading="lazy" src={uniswap} alt="Uniswap"/>
-                            <Spacer size="sm"/>
-                            <Title as="h2" size='m' color={theme.color.white} font={theme.font.neometric} weight={900}>Earn with PPBLZ LP</Title>
-                        </StakeGridAreaHeaderTitle>
-                        <StakeGridAreaHeaderMeta>
-                            <span>{ppblzEthLpApy.toFixed(0)}% APY</span>
-                            <IButtonPopover cursor={'pointer'} heading="APY staking PPBLZ LP"
-                                apy={ppblzEthLpApy}
-                                ppdexPrice={ppdexPrice}
-                                button={{ href: "https://app.uniswap.org/#/add/0x4D2eE5DAe46C86DA2FF521F7657dad98834f97b8/ETH", text: 'Add PPBLZ LP' }}/>
-                        </StakeGridAreaHeaderMeta>
-                    </StakeGridAreaHeader>
-                    <StakeGridAreaBody>
-                        <DataColumns>
-                            <DataColumn>
-                                <Text as="p" size="m" font={theme.font.inter}>PPBLZ LP balance</Text>
-                                <Spacer size="sm"/>
-                                <Text as="p" font={theme.font.neometric} weight={900} size='xl'>{parseFloat(uniV2PpblzBalance.toString()).toFixed(2)}</Text>
-                            </DataColumn>
-                            <DataColumn>
-                                <Text as="p" size="m" font={theme.font.inter}>PPBLZ LP staked</Text>
-                                <Spacer size="sm"/>
-                                <Text as="p" font={theme.font.neometric} weight={900} size='xl'>{parseFloat(uniV2PpblzStakedAmount.toString()).toFixed(2)}</Text>
-                            </DataColumn>
-                        </DataColumns>
-                        <div style={{ marginTop: "auto" }}>
-                            {!account &&
-                                <Button styling="purple" onClick={loadWeb3Modal} width="100%">Connect wallet</Button>
-                            }
-                            {account && !uniV2PpblzStakeAdd && !uniV2PpblzStakeSub &&
-                                <ContentCentered
-                                    style={{
-                                    display: "flex",
-                                    flexDirection: "row",
-                                    justifyContent: "center",
-                                    }}
-                                >
-                                    <Button styling="white" onClick={() => {
-                                        setUniV2PpblzStakeSub(true);
-                                        setUniV2PpblzStakeAdd(false);
-                                    }} width="20%" symbol aria-label="withdraw"
-                                    {...(uniV2PpblzStakedAmount <= 0 && {disabled: true})}
-                                    >-</Button>
-                                    <Spacer size="sm"/>
-                                    <Button styling="purple" onClick={() => {
-                                        setUniV2PpblzStakeSub(false);
-                                        setUniV2PpblzStakeAdd(true);
-                                    }} width="80%" symbol aria-label="stake"
-                                    {...(uniV2PpblzBalance <= 0 && {disabled: true})}
-                                    >+</Button>
-                                </ContentCentered>
-                            }
-                            {account &&
-                            (uniV2PpblzStakeAdd || uniV2PpblzStakeSub) &&
-                            !isStakingUniV2Ppblz &&
-                            !isWithdrawingUniV2Ppblz &&
-                            !isApprovingUniV2Ppblz &&
-                                <ContentCentered direction="row" bgColor={theme.color.white} style={{ borderRadius: "8px", border: `1px solid ${theme.color.purple[700]}`, padding: ".1em .1em .1em 0.75em" }}>
-                                    <StyledInput
-                                        placeholder="0.00"
-                                        value={setUniV2PpblzInputField() || ""}
-                                        onChange={(event) => updateUniV2PpblzStakingInput(event) }
-                                        min="0.00"
-                                        step="1"
-                                        autoFocus={true} />
-                                    <Button styling="link" onClick={setMaxUniV2Ppblz}>Max</Button>
-                                    {(uniV2PpblAllowance <= 0 || uniV2PpblAllowance < parseFloat(uniV2PpblzStakeAmount || '0')) && !uniV2PpblzStakeSub
-                                        ? <Button styling="purple"
-                                            onClick={approveUniV2Ppblz}
-                                            disabled={!uniV2PpblzStakeAmount || parseFloat(uniV2PpblzStakeAmount) <= 0 || isUpdatingRewards}
-                                          >Enable</Button>
-                                        : uniV2PpblzStakeSub && !uniV2PpblzStakeAdd
-                                            ? <Button styling="purple"
-                                                onClick={withdrawUniV2Ppblz}
-                                                disabled={!(parseFloat(uniV2PpblzStakeAmount || '0') > 0 && parseFloat(uniV2PpblzStakeAmount || '0') <= uniV2PpblzStakedAmount) || isWithdrawingUniV2Ppblz}
-                                              >Withdraw</Button>
-                                            : <Button styling="purple"
-                                                onClick={stakeUniV2Ppblz}
-                                                disabled={!(parseFloat(uniV2PpblzStakeAmount || '0') > 0 && parseFloat(uniV2PpblzStakeAmount || '0') <= uniV2PpblzBalance) || isStakingUniV2Ppblz}
-                                              >Stake</Button>
-                                    }
-                                </ContentCentered>
-                            }
-                            {account && (isApprovingUniV2Ppblz || isStakingUniV2Ppblz || isWithdrawingUniV2Ppblz) &&
-                                <Button styling="purple" width="100%" disabled>
-                                    {isApprovingUniV2Ppblz && "Enabling"}
-                                    {isStakingUniV2Ppblz && "Staking"}
-                                    {isWithdrawingUniV2Ppblz && "Withdrawing"}
-                                ...</Button>
-                            }
-                        </div>
-                    </StakeGridAreaBody>
-                </StakeGridArea>
-            </StakeGridTop>
+  const stakeUniV2Ppblz = async () => {
+    if (
+      isStakingUniV2Ppblz ||
+      !uniV2PpblzStakeAmount ||
+      parseFloat(uniV2PpblzStakeAmount) === 0 ||
+      parseFloat(uniV2PpblzStakeAmount) > uniV2PpblzBalance
+    ) {
+      return;
+    }
 
-            {/* PPDEX Earned Section */}
-            <StakeGridArea>
-                <StakeGridAreaHeader wide>
-                    <StakeGridAreaHeaderTitle>
-                        <img loading="lazy" src={ppdexLogo} alt="PPDEX"/>
-                        <Spacer size="sm"/>
-                        <Title as="h2" size='m' color={theme.color.white} font={theme.font.neometric} weight={900}>PPDEX Earned</Title>
-                    </StakeGridAreaHeaderTitle>
-                </StakeGridAreaHeader>
-                <StakeGridAreaBody>
-                    <ClaimGrid>
-                        <Text style={{ gridArea: 'area0' }} as="p" font={theme.font.neometric} weight={900} size='xl'>
-                            {parseFloat(ppdexBalance.toString()).toFixed(2)} $PPDEX
-                        </Text>
+    setIsStakingUniV2Ppblz(true);
+    try {
+      const amount = ethers.utils.parseUnits(
+        uniV2PpblzStakeAmount.toString(),
+        "ether"
+      );
+      const stakeRes = await sendTransaction(
+        provider,
+        async () =>
+          await contracts.ppdex.stakeUniV2(amount, { gasLimit: 200000 })
+      );
+      if (stakeRes) {
+        setIsStakingUniV2Ppblz(false);
+        setUniV2PpblzStakeAmount(null);
+        setUniV2PpblzStakeAdd(false);
+        await getMyUniV2PpblzStakeAmount();
+        await getUniV2PpblzBalance();
+        await getUniV2PpblzAllowance();
+        await getPpdexRewards();
+      }
+      setTransactionFinished((prev) => prev + 1);
+    } catch (error) {
+      console.log(error);
+      await resetToInitialStateOnReject();
+    }
+  };
 
-                        <Text style={{ gridArea: 'area1' }} as="p" font={theme.font.inter}>
-                            Total value: $ {((parseFloat(ppdexBalance.toString()) * ppdexPrice) + (ppdexRewards * ppdexPrice)).toFixed(2)}
-                        </Text>
+  const withdrawPpblz = async () => {
+    if (
+      isWithdrawingPpblz ||
+      ppblzStakeAmount === null ||
+      parseFloat(ppblzStakeAmount) === 0
+    ) {
+      return;
+    }
+    setIsWithdrawingPpblz(true);
+    try {
+      const amount = ethers.utils.parseUnits(
+        ppblzStakeAmount.toString(),
+        "ether"
+      );
+      const unstakeRes = await sendTransaction(
+        provider,
+        async () =>
+          await contracts.ppdex.withdrawPpblz(amount, { gasLimit: 200000 })
+      );
 
-                        <UpdateButton style={{ gridArea: 'area2' }} styling="link" onClick={() => !isUpdatingRewards && getPpdexRewards()} {...(isUpdatingRewards && {disabled: true})}>
-                            {isUpdatingRewards ? "UPDATING..." : "UPDATE"}
-                        </UpdateButton>
+      if (unstakeRes) {
+        setIsWithdrawingPpblz(false);
+        setPpblzStakeAmount(null);
+        setPpblzStakeSub(false);
+        await getMyPpblzStakeAmount();
+        await getPpblzBalance();
+        await getPpblzAllowance();
+        await getPpdexRewards();
+      } else {
+        setIsWithdrawingPpblz(false);
+      }
 
-                        <Button style={{ gridArea: 'area3' }} styling="purple" disabled={!account ? false : (isStakingPpblz || isWithdrawingPpblz) || isUpdatingRewards || (!(ppblzStakedAmount > 0) && (!(ppdexRewards > 0.1) || isClaiming))} onClick={!account ? loadWeb3Modal : claimRewards} width="clamp(100px, 18em, 100%)">{!account ? "Connect wallet" : (isStakingPpblz || isWithdrawingPpblz || isUpdatingRewards) ? "Updating..." : isClaiming ? "Claiming..." : `${ppdexRewards.toFixed(2)} PPDEX to claim`}</Button>
-                    </ClaimGrid>
-                </StakeGridAreaBody>
-            </StakeGridArea>
-        </StakeGrid>
-    );
+      setTransactionFinished((prev) => prev + 1);
+    } catch (error) {
+      console.log(error);
+      await resetToInitialStateOnReject();
+    }
+  };
+
+  const withdrawUniV2Ppblz = async () => {
+    if (
+      isWithdrawingUniV2Ppblz ||
+      uniV2PpblzStakeAmount === null ||
+      parseFloat(uniV2PpblzStakeAmount) === 0
+    ) {
+      return;
+    }
+    setIsWithdrawingUniV2Ppblz(true);
+    try {
+      const amount = ethers.utils.parseUnits(
+        uniV2PpblzStakeAmount.toString(),
+        "ether"
+      );
+      const unstakeRes = await sendTransaction(
+        provider,
+        async () =>
+          await contracts.ppdex.withdrawUniV2(amount, { gasLimit: 200000 })
+      );
+
+      if (unstakeRes) {
+        setIsWithdrawingUniV2Ppblz(false);
+        setUniV2PpblzStakeAmount(null);
+        setUniV2PpblzStakeSub(false);
+        await getMyUniV2PpblzStakeAmount();
+        await getUniV2PpblzBalance();
+        await getUniV2PpblzAllowance();
+        await getPpdexRewards();
+      } else {
+        setIsWithdrawingUniV2Ppblz(false);
+      }
+
+      setTransactionFinished((prev) => prev + 1);
+    } catch (error) {
+      console.log(error);
+      await resetToInitialStateOnReject();
+    }
+  };
+
+  const approvePpblz = async () => {
+    if (isApprovingPpblz) {
+      return;
+    }
+    setIsApprovingPpblz(true);
+
+    try {
+      const approveAmount =
+        ppblzStakeAmount && parseFloat(ppblzStakeAmount) > 0
+          ? ethers.utils.parseUnits(ppblzStakeAmount.toString(), "ether")
+          : ethers.utils.parseUnits(ppblzBalance.toString(), "ether");
+      const approveStaking = await sendTransaction(
+        provider,
+        async () =>
+          await contracts.ppblz.approve(contracts.ppdex.address, approveAmount)
+      );
+
+      await getPpblzAllowance();
+
+      if (approveStaking) {
+        setIsApprovingPpblz(false);
+        setIsApprovedPpblz(true);
+        if (
+          ppblzStakeAmount &&
+          parseFloat(ppblzStakeAmount) > 0 &&
+          parseFloat(ppblzStakeAmount) <= ppblzBalance
+        ) {
+          await stakePpblz();
+        }
+      } else {
+        setIsApprovingPpblz(false);
+      }
+
+      setTransactionFinished((prev) => prev + 1);
+    } catch (error) {
+      console.log(error);
+      await resetToInitialStateOnReject();
+    }
+  };
+
+  const approveUniV2Ppblz = async () => {
+    if (isApprovingUniV2Ppblz) {
+      return;
+    }
+    setIsApprovingUniV2Ppblz(true);
+
+    try {
+      const approveAmount =
+        uniV2PpblzStakeAmount && parseFloat(uniV2PpblzStakeAmount) > 0
+          ? ethers.utils.parseUnits(uniV2PpblzStakeAmount.toString(), "ether")
+          : ethers.utils.parseUnits(uniV2PpblzBalance.toString(), "ether");
+      const approveStaking = await sendTransaction(
+        provider,
+        async () =>
+          await contracts.uniV2_ppblz.approve(
+            contracts.ppdex.address,
+            approveAmount
+          )
+      );
+      await getUniV2PpblzAllowance();
+
+      if (approveStaking) {
+        setIsApprovingUniV2Ppblz(false);
+        setIsApprovedUniV2Ppblz(true);
+        if (
+          uniV2PpblzStakeAmount &&
+          parseFloat(uniV2PpblzStakeAmount) > 0 &&
+          parseFloat(uniV2PpblzStakeAmount) <= uniV2PpblzBalance
+        ) {
+          await stakeUniV2Ppblz();
+        }
+      } else {
+        setIsApprovingUniV2Ppblz(false);
+      }
+
+      setTransactionFinished((prev) => prev + 1);
+    } catch (error) {
+      console.log(error);
+      await resetToInitialStateOnReject();
+    }
+  };
+
+  const cleanNumberInput = (value: string, maxDecimals: number) => {
+    if (value[0] === "0" && value[1] && value[1] !== ".") {
+      return value[1];
+    }
+    if (value.slice(-2) === "..") {
+      return value.slice(0, -1);
+    }
+    if (
+      value.split(".").length > 1 &&
+      value.split(".")[1].length > maxDecimals
+    ) {
+      return `${value.split(".")[0]}.${value
+        .split(".")[1]
+        .slice(0, maxDecimals)}`;
+    }
+    return value;
+  };
+
+  const isInvalidInput = (value: string) =>
+    !Number(value) &&
+    value !== "" &&
+    parseFloat(value) !== 0 &&
+    value.slice(-1) !== "." &&
+    value.slice(-2) !== ".0";
+
+  /** setters & modifiers */
+  const updatePpblzStakingInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (isInvalidInput(e.target.value)) {
+      return;
+    }
+    setPpblzStakeAmount(cleanNumberInput(e.target.value, 18));
+  };
+
+  const updateUniV2PpblzStakingInput = (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    if (isInvalidInput(e.target.value)) {
+      return;
+    }
+    setUniV2PpblzStakeAmount(cleanNumberInput(e.target.value, 18));
+  };
+
+  const setPpblzInputField = () => {
+    if (ppblzStakeAmount !== null) {
+      return ppblzStakeAmount;
+    } else {
+      return "";
+    }
+  };
+
+  const setUniV2PpblzInputField = () => {
+    if (uniV2PpblzStakeAmount !== null) {
+      return uniV2PpblzStakeAmount;
+    } else {
+      return "";
+    }
+  };
+
+  const setMaxPpblz = () => {
+    if (ppblzStakeSub) {
+      return setPpblzStakeAmount(ppblzStakedAmount.toString());
+    }
+    return setPpblzStakeAmount(ppblzBalance.toString());
+  };
+
+  const setMaxUniV2Ppblz = () => {
+    if (uniV2PpblzStakeSub) {
+      return setUniV2PpblzStakeAmount(uniV2PpblzStakedAmount.toString());
+    }
+    return setUniV2PpblzStakeAmount(uniV2PpblzBalance.toString());
+  };
+
+  const claimRewards = async () => {
+    if (isClaiming) {
+      return;
+    }
+
+    if (ppdexRewards > 0) {
+      setIsClaiming(true);
+      try {
+        await sendTransaction(
+          provider,
+          async () => await contracts.ppdex.getReward()
+        );
+
+        await getPpdexRewards();
+        setTransactionFinished((prev) => prev + 1);
+      } catch (error) {
+        console.log(error);
+        await resetToInitialStateOnReject();
+      }
+    }
+    setIsClaiming(false);
+  };
+
+  useEffect(() => {
+    if (!pepemon || !contracts) {
+      return;
+    }
+    correctChainIsLoaded(pepemon).then((correct) => {
+      if (!correct) {
+        return;
+      }
+
+      try {
+        getPpblzAllowance();
+        getPpblzSupply();
+        getPpblzBalance();
+        getMyPpblzStakeAmount();
+        getUniV2PpblzAllowance();
+        getUniV2PpblzSupply();
+        getUniV2PpblzBalance();
+        getMyUniV2PpblzStakeAmount();
+        getPpdexBalance();
+        getPpdexRewards();
+        setIsApprovedPpblz(false);
+        setIsApprovedUniV2Ppblz(false);
+      } catch (error) {
+        alert(
+          `Failed to load web3, accounts, or contract. Check console for details.`
+        );
+        console.error(error);
+      }
+    });
+  }, [
+    account,
+    pepemon,
+    contracts,
+    provider,
+    transactionFinished,
+    getMyPpblzStakeAmount,
+    getMyUniV2PpblzStakeAmount,
+    getPpblzAllowance,
+    getPpblzBalance,
+    getPpblzSupply,
+    getPpdexBalance,
+    getPpdexRewards,
+    getUniV2PpblzAllowance,
+    getUniV2PpblzBalance,
+    getUniV2PpblzSupply,
+  ]);
+
+  return (
+    <StakeGrid>
+      <StakeGridTop ref={horzScroll}>
+        {/* PPBLZ Staking Section */}
+        <StakeGridArea>
+          <StakeGridAreaHeader>
+            <StakeGridAreaHeaderTitle>
+              <img loading="lazy" src={pepeball} alt="Pepeball" />
+              <Spacer size="sm" />
+              <Title
+                as="h2"
+                size="m"
+                color={theme.color.white}
+                font={theme.font.neometric}
+                weight={900}
+              >
+                Earn with PPBLZ
+              </Title>
+            </StakeGridAreaHeaderTitle>
+            <StakeGridAreaHeaderMeta>
+              <span>{ppblzApy.toFixed(0)}% APY</span>
+              <IButtonPopover
+                cursor={"pointer"}
+                heading="APY staking PPBLZ"
+                apy={ppblzApy}
+                ppdexPrice={ppdexPrice}
+                button={{
+                  href: "https://app.uniswap.org/#/swap?outputCurrency=0x4d2ee5dae46c86da2ff521f7657dad98834f97b8",
+                  text: "Buy PPBLZ",
+                }}
+              />
+            </StakeGridAreaHeaderMeta>
+          </StakeGridAreaHeader>
+          <StakeGridAreaBody>
+            <DataColumns>
+              <DataColumn>
+                <Text as="p" size="m" font={theme.font.inter}>
+                  PPBLZ balance
+                </Text>
+                <Spacer size="sm" />
+                <Text as="p" font={theme.font.neometric} weight={900} size="xl">
+                  {parseFloat(ppblzBalance.toString()).toFixed(2)}
+                </Text>
+              </DataColumn>
+              <DataColumn>
+                <Text as="p" size="m" font={theme.font.inter}>
+                  PPBLZ staked
+                </Text>
+                <Spacer size="sm" />
+                <Text as="p" font={theme.font.neometric} weight={900} size="xl">
+                  {parseFloat(ppblzStakedAmount.toString()).toFixed(2)}
+                </Text>
+              </DataColumn>
+            </DataColumns>
+            <div style={{ marginTop: "auto" }}>
+              {!account && (
+                <Button styling="purple" onClick={loadWeb3Modal} width="100%">
+                  Connect wallet
+                </Button>
+              )}
+              {account && !ppblzStakeAdd && !ppblzStakeSub && (
+                <ContentCentered
+                  style={{
+                    display: "flex",
+                    flexDirection: "row",
+                    justifyContent: "center",
+                  }}
+                >
+                  <Button
+                    styling="white"
+                    onClick={() => {
+                      setPpblzStakeSub(true);
+                      setPpblzStakeAdd(false);
+                    }}
+                    width="20%"
+                    symbol
+                    aria-label="withdraw"
+                    {...(ppblzStakedAmount <= 0 && { disabled: true })}
+                  >
+                    -
+                  </Button>
+                  <Spacer size="sm" />
+                  <Button
+                    styling="purple"
+                    onClick={() => {
+                      setPpblzStakeSub(false);
+                      setPpblzStakeAdd(true);
+                    }}
+                    width="80%"
+                    symbol
+                    aria-label="stake"
+                    {...(ppblzBalance <= 0 && { disabled: true })}
+                  >
+                    +
+                  </Button>
+                </ContentCentered>
+              )}
+              {account &&
+                (ppblzStakeAdd || ppblzStakeSub) &&
+                !isStakingPpblz &&
+                !isWithdrawingPpblz &&
+                !isApprovingPpblz && (
+                  <ContentCentered
+                    direction="row"
+                    bgColor={theme.color.white}
+                    style={{
+                      borderRadius: "8px",
+                      border: `1px solid ${theme.color.purple[700]}`,
+                      padding: ".1em .1em .1em 0.75em",
+                    }}
+                  >
+                    <StyledInput
+                      placeholder="0.00"
+                      value={setPpblzInputField() || ""}
+                      onChange={(event) => updatePpblzStakingInput(event)}
+                      min="0.00"
+                      step="1"
+                      autoFocus={true}
+                    />
+                    <Button styling="link" onClick={setMaxPpblz}>
+                      Max
+                    </Button>
+                    {(ppblzAllowance <= 0 ||
+                      ppblzAllowance < parseFloat(ppblzStakeAmount || "0")) &&
+                    !ppblzStakeSub ? (
+                      <Button
+                        styling="purple"
+                        onClick={approvePpblz}
+                        disabled={
+                          !ppblzStakeAmount ||
+                          parseFloat(ppblzStakeAmount) <= 0 ||
+                          isUpdatingRewards
+                        }
+                      >
+                        Enable
+                      </Button>
+                    ) : ppblzStakeSub && !ppblzStakeAdd ? (
+                      <Button
+                        styling="purple"
+                        onClick={withdrawPpblz}
+                        disabled={
+                          !(
+                            parseFloat(ppblzStakeAmount || "0") > 0 &&
+                            parseFloat(ppblzStakeAmount || "0") <=
+                              ppblzStakedAmount
+                          ) || isWithdrawingPpblz
+                        }
+                      >
+                        Withdraw
+                      </Button>
+                    ) : (
+                      <Button
+                        styling="purple"
+                        onClick={stakePpblz}
+                        disabled={
+                          !(
+                            parseFloat(ppblzStakeAmount || "0") > 0 &&
+                            parseFloat(ppblzStakeAmount || "0") <= ppblzBalance
+                          ) || isStakingPpblz
+                        }
+                      >
+                        Stake
+                      </Button>
+                    )}
+                  </ContentCentered>
+                )}
+              {account &&
+                (isApprovingPpblz || isStakingPpblz || isWithdrawingPpblz) && (
+                  <Button styling="purple" width="100%" disabled>
+                    {isApprovingPpblz && "Enabling"}
+                    {isStakingPpblz && "Staking"}
+                    {isWithdrawingPpblz && "Withdrawing"}
+                    ...
+                  </Button>
+                )}
+            </div>
+          </StakeGridAreaBody>
+        </StakeGridArea>
+
+        {/* UniV2PPBLZ LP Staking Section */}
+        <StakeGridArea>
+          <StakeGridAreaHeader>
+            <StakeGridAreaHeaderTitle>
+              <img loading="lazy" src={uniswap} alt="Uniswap" />
+              <Spacer size="sm" />
+              <Title
+                as="h2"
+                size="m"
+                color={theme.color.white}
+                font={theme.font.neometric}
+                weight={900}
+              >
+                Earn with PPBLZ LP
+              </Title>
+            </StakeGridAreaHeaderTitle>
+            <StakeGridAreaHeaderMeta>
+              <span>{ppblzEthLpApy.toFixed(0)}% APY</span>
+              <IButtonPopover
+                cursor={"pointer"}
+                heading="APY staking PPBLZ LP"
+                apy={ppblzEthLpApy}
+                ppdexPrice={ppdexPrice}
+                button={{
+                  href: "https://app.uniswap.org/#/add/0x4D2eE5DAe46C86DA2FF521F7657dad98834f97b8/ETH",
+                  text: "Add PPBLZ LP",
+                }}
+              />
+            </StakeGridAreaHeaderMeta>
+          </StakeGridAreaHeader>
+          <StakeGridAreaBody>
+            <DataColumns>
+              <DataColumn>
+                <Text as="p" size="m" font={theme.font.inter}>
+                  PPBLZ LP balance
+                </Text>
+                <Spacer size="sm" />
+                <Text as="p" font={theme.font.neometric} weight={900} size="xl">
+                  {parseFloat(uniV2PpblzBalance.toString()).toFixed(2)}
+                </Text>
+              </DataColumn>
+              <DataColumn>
+                <Text as="p" size="m" font={theme.font.inter}>
+                  PPBLZ LP staked
+                </Text>
+                <Spacer size="sm" />
+                <Text as="p" font={theme.font.neometric} weight={900} size="xl">
+                  {parseFloat(uniV2PpblzStakedAmount.toString()).toFixed(2)}
+                </Text>
+              </DataColumn>
+            </DataColumns>
+            <div style={{ marginTop: "auto" }}>
+              {!account && (
+                <Button styling="purple" onClick={loadWeb3Modal} width="100%">
+                  Connect wallet
+                </Button>
+              )}
+              {account && !uniV2PpblzStakeAdd && !uniV2PpblzStakeSub && (
+                <ContentCentered
+                  style={{
+                    display: "flex",
+                    flexDirection: "row",
+                    justifyContent: "center",
+                  }}
+                >
+                  <Button
+                    styling="white"
+                    onClick={() => {
+                      setUniV2PpblzStakeSub(true);
+                      setUniV2PpblzStakeAdd(false);
+                    }}
+                    width="20%"
+                    symbol
+                    aria-label="withdraw"
+                    {...(uniV2PpblzStakedAmount <= 0 && { disabled: true })}
+                  >
+                    -
+                  </Button>
+                  <Spacer size="sm" />
+                  <Button
+                    styling="purple"
+                    onClick={() => {
+                      setUniV2PpblzStakeSub(false);
+                      setUniV2PpblzStakeAdd(true);
+                    }}
+                    width="80%"
+                    symbol
+                    aria-label="stake"
+                    {...(uniV2PpblzBalance <= 0 && { disabled: true })}
+                  >
+                    +
+                  </Button>
+                </ContentCentered>
+              )}
+              {account &&
+                (uniV2PpblzStakeAdd || uniV2PpblzStakeSub) &&
+                !isStakingUniV2Ppblz &&
+                !isWithdrawingUniV2Ppblz &&
+                !isApprovingUniV2Ppblz && (
+                  <ContentCentered
+                    direction="row"
+                    bgColor={theme.color.white}
+                    style={{
+                      borderRadius: "8px",
+                      border: `1px solid ${theme.color.purple[700]}`,
+                      padding: ".1em .1em .1em 0.75em",
+                    }}
+                  >
+                    <StyledInput
+                      placeholder="0.00"
+                      value={setUniV2PpblzInputField() || ""}
+                      onChange={(event) => updateUniV2PpblzStakingInput(event)}
+                      min="0.00"
+                      step="1"
+                      autoFocus={true}
+                    />
+                    <Button styling="link" onClick={setMaxUniV2Ppblz}>
+                      Max
+                    </Button>
+                    {(uniV2PpblAllowance <= 0 ||
+                      uniV2PpblAllowance <
+                        parseFloat(uniV2PpblzStakeAmount || "0")) &&
+                    !uniV2PpblzStakeSub ? (
+                      <Button
+                        styling="purple"
+                        onClick={approveUniV2Ppblz}
+                        disabled={
+                          !uniV2PpblzStakeAmount ||
+                          parseFloat(uniV2PpblzStakeAmount) <= 0 ||
+                          isUpdatingRewards
+                        }
+                      >
+                        Enable
+                      </Button>
+                    ) : uniV2PpblzStakeSub && !uniV2PpblzStakeAdd ? (
+                      <Button
+                        styling="purple"
+                        onClick={withdrawUniV2Ppblz}
+                        disabled={
+                          !(
+                            parseFloat(uniV2PpblzStakeAmount || "0") > 0 &&
+                            parseFloat(uniV2PpblzStakeAmount || "0") <=
+                              uniV2PpblzStakedAmount
+                          ) || isWithdrawingUniV2Ppblz
+                        }
+                      >
+                        Withdraw
+                      </Button>
+                    ) : (
+                      <Button
+                        styling="purple"
+                        onClick={stakeUniV2Ppblz}
+                        disabled={
+                          !(
+                            parseFloat(uniV2PpblzStakeAmount || "0") > 0 &&
+                            parseFloat(uniV2PpblzStakeAmount || "0") <=
+                              uniV2PpblzBalance
+                          ) || isStakingUniV2Ppblz
+                        }
+                      >
+                        Stake
+                      </Button>
+                    )}
+                  </ContentCentered>
+                )}
+              {account &&
+                (isApprovingUniV2Ppblz ||
+                  isStakingUniV2Ppblz ||
+                  isWithdrawingUniV2Ppblz) && (
+                  <Button styling="purple" width="100%" disabled>
+                    {isApprovingUniV2Ppblz && "Enabling"}
+                    {isStakingUniV2Ppblz && "Staking"}
+                    {isWithdrawingUniV2Ppblz && "Withdrawing"}
+                    ...
+                  </Button>
+                )}
+            </div>
+          </StakeGridAreaBody>
+        </StakeGridArea>
+      </StakeGridTop>
+
+      {/* PPDEX Earned Section */}
+      <StakeGridArea>
+        <StakeGridAreaHeader wide>
+          <StakeGridAreaHeaderTitle>
+            <img loading="lazy" src={ppdexLogo} alt="PPDEX" />
+            <Spacer size="sm" />
+            <Title
+              as="h2"
+              size="m"
+              color={theme.color.white}
+              font={theme.font.neometric}
+              weight={900}
+            >
+              PPDEX Earned
+            </Title>
+          </StakeGridAreaHeaderTitle>
+        </StakeGridAreaHeader>
+        <StakeGridAreaBody>
+          <ClaimGrid>
+            <Text
+              style={{ gridArea: "area0" }}
+              as="p"
+              font={theme.font.neometric}
+              weight={900}
+              size="xl"
+            >
+              {parseFloat(ppdexBalance.toString()).toFixed(2)} $PPDEX
+            </Text>
+
+            <Text style={{ gridArea: "area1" }} as="p" font={theme.font.inter}>
+              Total value: ${" "}
+              {(
+                parseFloat(ppdexBalance.toString()) * ppdexPrice +
+                ppdexRewards * ppdexPrice
+              ).toFixed(2)}
+            </Text>
+
+            <UpdateButton
+              style={{ gridArea: "area2" }}
+              styling="link"
+              onClick={() => !isUpdatingRewards && getPpdexRewards()}
+              {...(isUpdatingRewards && { disabled: true })}
+            >
+              {isUpdatingRewards ? "UPDATING..." : "UPDATE"}
+            </UpdateButton>
+
+            <Button
+              style={{ gridArea: "area3" }}
+              styling="purple"
+              disabled={
+                !account
+                  ? false
+                  : isStakingPpblz ||
+                    isWithdrawingPpblz ||
+                    isUpdatingRewards ||
+                    (!(ppblzStakedAmount > 0) &&
+                      (!(ppdexRewards > 0.1) || isClaiming))
+              }
+              onClick={!account ? loadWeb3Modal : claimRewards}
+              width="clamp(100px, 18em, 100%)"
+            >
+              {!account
+                ? "Connect wallet"
+                : isStakingPpblz || isWithdrawingPpblz || isUpdatingRewards
+                ? "Updating..."
+                : isClaiming
+                ? "Claiming..."
+                : `${ppdexRewards.toFixed(2)} PPDEX to claim`}
+            </Button>
+          </ClaimGrid>
+        </StakeGridAreaBody>
+      </StakeGridArea>
+    </StakeGrid>
+  );
 };
 
 // Styled components
 const StakeGrid = styled.section``;
 
-const StakeGridArea = styled.div<{area?: string}>`
-    background-color: ${theme.color.purple[800]};
-    border-radius: ${theme.borderRadius}px;
-    display: flex;
-    flex-direction: column;
-    grid-area: ${props => props.area};
-    margin-bottom: 1em;
-    min-width: 0px;
-    overflow: hidden;
-`
+const StakeGridArea = styled.div<{ area?: string }>`
+  background-color: ${theme.color.purple[800]};
+  border-radius: ${theme.borderRadius}px;
+  display: flex;
+  flex-direction: column;
+  grid-area: ${(props) => props.area};
+  margin-bottom: 1em;
+  min-width: 0px;
+  overflow: hidden;
+`;
 
 const StakeGridTop = styled.div`
-    display: flex;
-    justify-content: space-between;
-    overflow: auto;
+  display: flex;
+  justify-content: space-between;
+  overflow: auto;
 
-    @media (min-width: ${theme.breakpoints.mobile}) and (max-width: ${theme.breakpoints.tabletL}) {
-        flex-wrap: wrap;
-    }
-
-    ${StakeGridArea} {
-        min-width: min(400px, 90%);
-        width: 100%;
-
-        &:not(:first-child) {
-            margin-left: 1.25em;
-
-            @media (min-width: ${theme.breakpoints.mobile}) and (max-width: ${theme.breakpoints.tabletL}) {
-                margin-left: 0;
-            }
-        }
-    }
-`
-
-const StakeGridAreaHeader = styled.div<{wide?: boolean}>`
-    align-items: center;
-    display: flex;
+  @media (min-width: ${theme.breakpoints.mobile}) and (max-width: ${theme
+      .breakpoints.tabletL}) {
     flex-wrap: wrap;
-    justify-content: space-between;
-    padding: clamp(1.125em, 3.75vw, 1.2em) clamp(.8em, 2.65vw, 2em);
+  }
 
-    ${({wide}) => wide && `
+  ${StakeGridArea} {
+    min-width: min(400px, 90%);
+    width: 100%;
+
+    &:not(:first-child) {
+      margin-left: 1.25em;
+
+      @media (min-width: ${theme.breakpoints.mobile}) and (max-width: ${theme
+          .breakpoints.tabletL}) {
+        margin-left: 0;
+      }
+    }
+  }
+`;
+
+const StakeGridAreaHeader = styled.div<{ wide?: boolean }>`
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  padding: clamp(1.125em, 3.75vw, 1.2em) clamp(0.8em, 2.65vw, 2em);
+
+  ${({ wide }) =>
+    wide &&
+    `
         @media (min-width: ${theme.breakpoints.tabletL}) {
             justify-content: center;
         }
     `}
-`
+`;
 
 const StakeGridAreaHeaderTitle = styled.div`
-    align-items: center;
-    display: flex;
+  align-items: center;
+  display: flex;
 
-    img { width: 2.5em; }
-`
+  img {
+    width: 2.5em;
+  }
+`;
 
 const StakeGridAreaHeaderMeta = styled.div`
-    &{
-        display: flex;
-        align-items: center;
-    }
+  & {
+    display: flex;
+    align-items: center;
+  }
 
-    span {
-        margin-right: .67em;
-        color: ${props => props.theme.color.white};
-        font-family: ${props => props.theme.font.neometric};
-        font-size: .75rem;
-        font-weight: 900;
-    }
-`
+  span {
+    margin-right: 0.67em;
+    color: ${(props) => props.theme.color.white};
+    font-family: ${(props) => props.theme.font.neometric};
+    font-size: 0.75rem;
+    font-weight: 900;
+  }
+`;
 
 const StakeGridAreaBody = styled.div`
-    background-color: ${props => props.theme.color.white};
-    display: flex;
-    flex-direction: column;
-    padding: clamp(1.125em,3.75vw,1.2em) clamp(.8em,2.65vw,2em) clamp(.8em,2.65vw,2em);
-    flex: 1 0 auto;
-`
+  background-color: ${(props) => props.theme.color.white};
+  display: flex;
+  flex-direction: column;
+  padding: clamp(1.125em, 3.75vw, 1.2em) clamp(0.8em, 2.65vw, 2em)
+    clamp(0.8em, 2.65vw, 2em);
+  flex: 1 0 auto;
+`;
 
 const ClaimGrid = styled.div`
-    display: grid;
-    grid-template-areas: "area0 area2" "area1 area1" "area3 area3";
-    grid-column-gap: 1.25em;
-    grid-row-gap: 1.25em;
+  display: grid;
+  grid-template-areas: "area0 area2" "area1 area1" "area3 area3";
+  grid-column-gap: 1.25em;
+  grid-row-gap: 1.25em;
 
-    @media (min-width: ${theme.breakpoints.tabletL}) {
-        grid-template-areas: "area0 area0" "area1 area2" "area3 area3";
-        justify-content: center;
-    }
-`
+  @media (min-width: ${theme.breakpoints.tabletL}) {
+    grid-template-areas: "area0 area0" "area1 area2" "area3 area3";
+    justify-content: center;
+  }
+`;
 
 const UpdateButton = styled(Button)`
-    text-align: right;
-    padding: 0;
+  text-align: right;
+  padding: 0;
 
-    @media (min-width: ${theme.breakpoints.tabletL}) {
-        text-align: left;
-    }
-`
+  @media (min-width: ${theme.breakpoints.tabletL}) {
+    text-align: left;
+  }
+`;
 
 const DataColumns = styled.div`
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    margin-bottom: 1.5em;
-`
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  margin-bottom: 1.5em;
+`;
 
 const DataColumn = styled.div`
-    flex: 1 0 auto;
-`
+  flex: 1 0 auto;
+`;
 
 const StyledInput = styled.input`
-    border: none;
-    font-size: 1rem;
-    flex: 1 1 auto;
-    min-width: 0;
+  border: none;
+  font-size: 1rem;
+  flex: 1 1 auto;
+  min-width: 0;
 
-    &:focus-within {
-        outline : none;
-    }
-`
+  &:focus-within {
+    outline: none;
+  }
+`;
 
 export default StakeCard;

--- a/packages/app/src/views/Staking/index.ts
+++ b/packages/app/src/views/Staking/index.ts
@@ -1,1 +1,1 @@
-export { default, stakingMeta } from './Staking'
+export { default, stakingMeta } from "./Staking";

--- a/packages/app/src/views/Store/Store.tsx
+++ b/packages/app/src/views/Store/Store.tsx
@@ -1,18 +1,19 @@
-import React from 'react';
-import { DefaultPage } from '../../components';
-import { StoreCard } from './components';
+import React from "react";
+import { DefaultPage } from "../../components";
+import { StoreCard } from "./components";
 
 export const storeMeta = {
-	title: 'Pepemon! Store',
-	description: 'Use PPDEX to mint Pepemon NFT cards. All the cards are created by upcoming artists all over the world. You can become the very best by dueling with your NFTs in a web3 card game!'
-}
+  title: "Pepemon! Store",
+  description:
+    "Use PPDEX to mint Pepemon NFT cards. All the cards are created by upcoming artists all over the world. You can become the very best by dueling with your NFTs in a web3 card game!",
+};
 
 const Store: React.FC<any> = () => {
-	return (
-		<DefaultPage title='Store'>
-			<StoreCard/>
-		</DefaultPage>
-	)
-}
+  return (
+    <DefaultPage title="Store">
+      <StoreCard />
+    </DefaultPage>
+  );
+};
 
-export default Store
+export default Store;

--- a/packages/app/src/views/Store/components/CardSingle.tsx
+++ b/packages/app/src/views/Store/components/CardSingle.tsx
@@ -87,7 +87,7 @@ const CardSingle: React.FC<any> = ({ cardId, selectedCard, selectCard }) => {
     );
   }, [cardMeta, daysForSale, isReleasingSoon]);
 
-  const countdown = (pre: string = " ", after: string = "") => {
+  const countdown = (pre = " ", after = "") => {
     const timeLeft = calculateTimeLeft();
 
     const days = timeLeft / (60 * 60 * 24);
@@ -129,11 +129,17 @@ const CardSingle: React.FC<any> = ({ cardId, selectedCard, selectCard }) => {
     const live = countdown();
     if (live) return live;
     if (!isLoaded) return "loading";
-    const birthdayMeta = cardMeta?.attributes?.find((a: any) => a.trait_type === "birthday");
+    const birthdayMeta = cardMeta?.attributes?.find(
+      (a: any) => a.trait_type === "birthday"
+    );
     const birthday = parseFloat(birthdayMeta?.value);
     if (!birthday || birthday === 0) return "—";
     const saleEnd = new Date((birthday + daysForSale() * 86400) * 1000);
-    return `Ended ${saleEnd.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}`;
+    return `Ended ${saleEnd.toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    })}`;
   };
 
   const self = {
@@ -154,7 +160,9 @@ const CardSingle: React.FC<any> = ({ cardId, selectedCard, selectCard }) => {
         <img loading="lazy" src={coin} alt="coin" />
         {cardPrice
           ? `${priceOfCard} ${chainId === 56 ? "BNB" : "PPDEX"}`
-          : isLoaded ? "—" : "loading"}
+          : isLoaded
+          ? "—"
+          : "loading"}
       </StyledPepemonCardPrice>
       <div>
         <StyledPepemonCardImage
@@ -173,7 +181,9 @@ const CardSingle: React.FC<any> = ({ cardId, selectedCard, selectCard }) => {
           <dt>Minted</dt>
           <dd>
             {!cardBalance?.[0]
-              ? isLoaded ? "—" : "loading"
+              ? isLoaded
+                ? "—"
+                : "loading"
               : `${parseFloat(cardBalance[0]?.totalSupply)} / ${
                   parseFloat(cardBalance[0]?.maxSupply) > 10000
                     ? "♾️"

--- a/packages/app/src/views/Store/components/PackSingle.tsx
+++ b/packages/app/src/views/Store/components/PackSingle.tsx
@@ -1,29 +1,43 @@
 import React from "react";
 import styled from "styled-components";
 // import { coin } from "../../../assets";
-import { Title,
-	// Spacer,
-	// StyledSpacer
+import {
+  Title,
+  // Spacer,
+  // StyledSpacer
 } from "../../../components";
 import {
-	// StyledPepemonCardMeta,
-	StyledPepemonCardPrice } from "../components";
+  // StyledPepemonCardMeta,
+  StyledPepemonCardPrice,
+} from "../components";
 import { theme } from "../../../theme";
 
-const PackSingle : React.FC<any> = ({packId, selectedPack, selectPack, chainId, packMeta}) => {
-
-	return (
-		<StyledPepemonCard>
-			<StyledPepemonCardPrice>
-				{/*<img loading="lazy" src={coin} alt="coin"/>
+const PackSingle: React.FC<any> = ({
+  packId,
+  selectedPack,
+  selectPack,
+  chainId,
+  packMeta,
+}) => {
+  return (
+    <StyledPepemonCard>
+      <StyledPepemonCardPrice>
+        {/*<img loading="lazy" src={coin} alt="coin"/>
 				{packMeta.price} {chainId === 56 ? 'BNB' : 'PPDEX'}*/}
-				coming soon
-			</StyledPepemonCardPrice>
-			<div>
-				<StyledPepemonCardImage loading="lazy" active={packMeta === selectedPack} src={packMeta.url} alt={packMeta.name}
-					onClick={() => selectPack(packMeta)}/>
-				<Title as="h4" font={theme.font.neometric}>{packMeta.name}</Title>
-				{/*<StyledSpacer bg={theme.color.gray[100]} size={2}/>
+        coming soon
+      </StyledPepemonCardPrice>
+      <div>
+        <StyledPepemonCardImage
+          loading="lazy"
+          active={packMeta === selectedPack}
+          src={packMeta.url}
+          alt={packMeta.name}
+          onClick={() => selectPack(packMeta)}
+        />
+        <Title as="h4" font={theme.font.neometric}>
+          {packMeta.name}
+        </Title>
+        {/*<StyledSpacer bg={theme.color.gray[100]} size={2}/>
 				<Spacer size="sm"/>
 				<StyledPepemonCardMeta>
 					<dt>Minted</dt>
@@ -33,38 +47,40 @@ const PackSingle : React.FC<any> = ({packId, selectedPack, selectPack, chainId, 
 					<dt>Time</dt>
 					<dd>{packMeta.time}</dd>
 				</StyledPepemonCardMeta>*/}
-			</div>
-		</StyledPepemonCard>
-	)
-}
+      </div>
+    </StyledPepemonCard>
+  );
+};
 
 const StyledPepemonCard = styled.div`
-	display: flex;
-	justify-content: center;
-	flex-direction: column;
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
 
-	&:hover {
-		cursor: pointer;
-	}
-`
+  &:hover {
+    cursor: pointer;
+  }
+`;
 
-export const StyledPepemonCardImage = styled.img<{active?: boolean}>`
-	filter: drop-shadow(0 4px 8px rgba(0, 0, 0, 0.12));
-	height: auto;
-	max-width: 25em;
-	position: relative;
-	width: 100%;
-	z-index: 0;
+export const StyledPepemonCardImage = styled.img<{ active?: boolean }>`
+  filter: drop-shadow(0 4px 8px rgba(0, 0, 0, 0.12));
+  height: auto;
+  max-width: 25em;
+  position: relative;
+  width: 100%;
+  z-index: 0;
 
-	&:hover {
-		cusror: pointer;
-	}
+  &:hover {
+    cusror: pointer;
+  }
 
-	${({ active }) => active && `
+  ${({ active }) =>
+    active &&
+    `
 		&{
 			filter: drop-shadow(0 0 50px #894fbe);
 		}
 	`}
-`
+`;
 
 export default PackSingle;

--- a/packages/app/src/views/Store/components/PromoStoreCard.tsx
+++ b/packages/app/src/views/Store/components/PromoStoreCard.tsx
@@ -1,129 +1,157 @@
-import React, {useRef, useState} from 'react';
-import BigNumber from 'bignumber.js';
-import styled from 'styled-components';
-import { PepemonCard, Card, Spacer, Button } from '../../../components';
-import { CardMetadata, CardBalances, CardPrice, useRedeemCard, useOutsideClick }  from '../../../hooks';
-import { getDisplayBalance } from '../../../utils';
-import { getPepemonPromoStoreContract } from '../../../pepemon/utils';
+import React, { useRef, useState } from "react";
+import BigNumber from "bignumber.js";
+import styled from "styled-components";
+import { PepemonCard, Card, Spacer, Button } from "../../../components";
+import {
+  CardMetadata,
+  CardBalances,
+  CardPrice,
+  useRedeemCard,
+  useOutsideClick,
+} from "../../../hooks";
+import { getDisplayBalance } from "../../../utils";
+import { getPepemonPromoStoreContract } from "../../../pepemon/utils";
 
 interface StakeCardProps {
-    pepemon: any,
-    promoBalance: any;
-    cardsMetadata: CardMetadata[],
-    cardsBalances: CardBalances[],
-    cardsPrice: CardPrice[],
-    allowance: any,
-    onApprove(): Promise<any>,
-    isApproving: boolean,
-    transactions: number;
-    setTransactions: any;
-    promo: any,
+  pepemon: any;
+  promoBalance: any;
+  cardsMetadata: CardMetadata[];
+  cardsBalances: CardBalances[];
+  cardsPrice: CardPrice[];
+  allowance: any;
+  onApprove(): Promise<any>;
+  isApproving: boolean;
+  transactions: number;
+  setTransactions: any;
+  promo: any;
 }
 
 const PromoStoreCard: React.FC<StakeCardProps> = ({
-                                                 pepemon,
-                                                 promoBalance,
-                                                 cardsMetadata,
-                                                 cardsBalances,
-                                                 cardsPrice,
-                                                 allowance,
-                                                 onApprove,
-                                                 isApproving,
-                                                 transactions,
-                                                 setTransactions,
-                                                 promo,
-                                             }) => {
-    const [delayApprove, setDelayApprove] = useState(false)
-    const [imageModal, setImageModal] = useState(null);
-    const { onRedeemCard, isRedeemingCard } = useRedeemCard(getPepemonPromoStoreContract(pepemon));
-    const isAllowedSpending = () => {
-        return new BigNumber(100000000000000000000).comparedTo(allowance) === -1;
+  pepemon,
+  promoBalance,
+  cardsMetadata,
+  cardsBalances,
+  cardsPrice,
+  allowance,
+  onApprove,
+  isApproving,
+  transactions,
+  setTransactions,
+  promo,
+}) => {
+  const [delayApprove, setDelayApprove] = useState(false);
+  const [imageModal, setImageModal] = useState(null);
+  const { onRedeemCard, isRedeemingCard } = useRedeemCard(
+    getPepemonPromoStoreContract(pepemon)
+  );
+  const isAllowedSpending = () => {
+    return new BigNumber(100000000000000000000).comparedTo(allowance) === -1;
+  };
+
+  const ref = useRef();
+  useOutsideClick(ref, () => {
+    if (imageModal !== null) {
+      setImageModal(null);
     }
+  });
 
-    const ref = useRef();
-    useOutsideClick(ref, () => {
-        if (imageModal !== null) {
-            setImageModal(null);
-        }
-    })
-
-    return (
-        <StyledCardWrapper>
-            <Card>
-                <StyledCardHead>
-                    <StyledTitle size="l">Promotional Editions</StyledTitle>
-                    <div style={{fontSize: '24px'}}>Your balance: <b>{getDisplayBalance(promoBalance, promo.decimals)}</b> ${promo.token}</div>
-                </StyledCardHead>
-                <StyledCardContent>
-                    {(!isAllowedSpending() && !delayApprove) &&
-                    <StyledOverlay>
-                      <StyledOverlayTitle>Approve {promo.token} spending in shop</StyledOverlayTitle>
-                      <Spacer size="md"/>
-                      <StyleOverlayButtonContainer>
-                        <Button styling="purple" disabled={isApproving} onClick={() => onApprove().then(() => setDelayApprove(true))}>{isApproving ? 'Approving...' : 'Approve now'}</Button>
-                        <Spacer size="lg"/>
-                        <Button styling="white" disabled={isApproving} onClick={() => setDelayApprove(true)}>Just look around</Button>
-                      </StyleOverlayButtonContainer>
-                    </StyledOverlay>
-                    }
-                    { imageModal !== null &&
-                    <StyledOverlay>
-                      <img alt="placeholder" ref={ref} height="600" src={imageModal}/>
-                    </StyledOverlay>
-                    }
-                    <StyledTitle size="m">{promo.name}</StyledTitle>
-                    <StyledPepemonCardsWrapper>
-                        {
-                            cardsMetadata
-                                .filter((metaData) => promo.cards.includes(metaData.tokenId))
-                                .map((cardMetadata, index) => {
-                                    const cardPrice = cardsPrice.find((price) => price.tokenId === cardMetadata.tokenId);
-                                    return (
-                                        <PepemonCard
-                                            pepemon={pepemon}
-                                            ppdexBalance={promoBalance}
-                                            key={cardMetadata.tokenId}
-                                            tokenId={cardMetadata.tokenId}
-                                            metadata={cardMetadata}
-                                            balances={cardsBalances.find(balance => balance.tokenId === cardMetadata.tokenId)}
-                                            price={(cardPrice && cardPrice.price) || new BigNumber(0)}
-                                            allowance={allowance}
-                                            transactions={transactions}
-                                            setTransactions={setTransactions}
-                                            setDelayApprove={setDelayApprove}
-                                            setImageModal={setImageModal}
-                                            onRedeemCard={onRedeemCard}
-                                            isRedeemingCard={isRedeemingCard}
-                                            token={{name: promo.token, decimals: promo.decimals}}
-                                        />
-                                    );
-                                })
-                        }
-                    </StyledPepemonCardsWrapper>
-                </StyledCardContent>
-            </Card>
-        </StyledCardWrapper>
-    );
-}
+  return (
+    <StyledCardWrapper>
+      <Card>
+        <StyledCardHead>
+          <StyledTitle size="l">Promotional Editions</StyledTitle>
+          <div style={{ fontSize: "24px" }}>
+            Your balance:{" "}
+            <b>{getDisplayBalance(promoBalance, promo.decimals)}</b> $
+            {promo.token}
+          </div>
+        </StyledCardHead>
+        <StyledCardContent>
+          {!isAllowedSpending() && !delayApprove && (
+            <StyledOverlay>
+              <StyledOverlayTitle>
+                Approve {promo.token} spending in shop
+              </StyledOverlayTitle>
+              <Spacer size="md" />
+              <StyleOverlayButtonContainer>
+                <Button
+                  styling="purple"
+                  disabled={isApproving}
+                  onClick={() => onApprove().then(() => setDelayApprove(true))}
+                >
+                  {isApproving ? "Approving..." : "Approve now"}
+                </Button>
+                <Spacer size="lg" />
+                <Button
+                  styling="white"
+                  disabled={isApproving}
+                  onClick={() => setDelayApprove(true)}
+                >
+                  Just look around
+                </Button>
+              </StyleOverlayButtonContainer>
+            </StyledOverlay>
+          )}
+          {imageModal !== null && (
+            <StyledOverlay>
+              <img alt="placeholder" ref={ref} height="600" src={imageModal} />
+            </StyledOverlay>
+          )}
+          <StyledTitle size="m">{promo.name}</StyledTitle>
+          <StyledPepemonCardsWrapper>
+            {cardsMetadata
+              .filter((metaData) => promo.cards.includes(metaData.tokenId))
+              .map((cardMetadata, index) => {
+                const cardPrice = cardsPrice.find(
+                  (price) => price.tokenId === cardMetadata.tokenId
+                );
+                return (
+                  <PepemonCard
+                    pepemon={pepemon}
+                    ppdexBalance={promoBalance}
+                    key={cardMetadata.tokenId}
+                    tokenId={cardMetadata.tokenId}
+                    metadata={cardMetadata}
+                    balances={cardsBalances.find(
+                      (balance) => balance.tokenId === cardMetadata.tokenId
+                    )}
+                    price={(cardPrice && cardPrice.price) || new BigNumber(0)}
+                    allowance={allowance}
+                    transactions={transactions}
+                    setTransactions={setTransactions}
+                    setDelayApprove={setDelayApprove}
+                    setImageModal={setImageModal}
+                    onRedeemCard={onRedeemCard}
+                    isRedeemingCard={isRedeemingCard}
+                    token={{ name: promo.token, decimals: promo.decimals }}
+                  />
+                );
+              })}
+          </StyledPepemonCardsWrapper>
+        </StyledCardContent>
+      </Card>
+    </StyledCardWrapper>
+  );
+};
 
 interface StyledTitleProps {
-    size: 'm' | 'l';
+  size: "m" | "l";
 }
 
 const StyledCardHead = styled.div`
-    background-color: ${(props) => props.theme.color[3]};
-    padding: 1.5rem 3rem;
-    border-top-left-radius: 10px;
-    border-top-right-radius: 10px;
+  background-color: ${(props) => props.theme.color[3]};
+  padding: 1.5rem 3rem;
+  border-top-left-radius: 10px;
+  border-top-right-radius: 10px;
 
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 
-    @media (max-width: 450px) {
-        flex-direction: column;
-    }
-`
+  @media (max-width: 450px) {
+    flex-direction: column;
+  }
+`;
 
 const StyledCardWrapper = styled.div`
   width: 940px;
@@ -141,40 +169,39 @@ const StyledCardWrapper = styled.div`
     padding: 0 2rem;
     flex-direction: column;
   }
-`
+`;
 
 const StyledCardContent = styled.div`
-    position: relative;
-    padding: 1.5rem 3rem 0 3rem;
-    background-color: #f1f1f1;
-`
+  position: relative;
+  padding: 1.5rem 3rem 0 3rem;
+  background-color: #f1f1f1;
+`;
 
 const StyledOverlay = styled.div`
-    position: absolute;
-    background-color: rgba(240, 233, 231, 0.9);
-    width: 100%;
-    top: 1.7rem;
-    bottom: 2rem;
-    margin: -1.5rem -3rem;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    padding-top: 10rem;
-    z-index: 100;
-`
+  position: absolute;
+  background-color: rgba(240, 233, 231, 0.9);
+  width: 100%;
+  top: 1.7rem;
+  bottom: 2rem;
+  margin: -1.5rem -3rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-top: 10rem;
+  z-index: 100;
+`;
 
 const StyledOverlayTitle = styled.div`
-
-    font-size: 60px;
-    font-weight: 799;
-    padding: 0 10rem;
-    text-align: center;
-    letter-spacing: 4px;
-`
+  font-size: 60px;
+  font-weight: 799;
+  padding: 0 10rem;
+  text-align: center;
+  letter-spacing: 4px;
+`;
 
 const StyleOverlayButtonContainer = styled.div`
-    display: flex;
-`
+  display: flex;
+`;
 
 const StyledPepemonCardsWrapper = styled.div`
   display: flex;
@@ -188,17 +215,16 @@ const StyledPepemonCardsWrapper = styled.div`
   @media (max-width: 450px) {
     justify-content: center;
   }
-`
+`;
 
 const StyledTitle = styled.h4<StyledTitleProps>`
-
-  font-size: ${(props) => props.size === 'l' ? 36 : 30}px;
+  font-size: ${(props) => (props.size === "l" ? 36 : 30)}px;
   font-weight: 700;
   margin: 0;
   letter-spacing: 3px;
   @media (max-width: 880px) {
     text-align: center;
   }
-`
+`;
 
-export default PromoStoreCard
+export default PromoStoreCard;

--- a/packages/app/src/views/Store/components/StoreAside.tsx
+++ b/packages/app/src/views/Store/components/StoreAside.tsx
@@ -1,50 +1,63 @@
-import React from 'react';
-import styled from 'styled-components';
-import { Title } from '../../../components';
-import { ActionClose } from '../../../assets';
-import { theme } from '../../../theme';
-import { StyledStoreWrapper, StyledStoreHeader } from '../components';
+import React from "react";
+import styled from "styled-components";
+import { Title } from "../../../components";
+import { ActionClose } from "../../../assets";
+import { theme } from "../../../theme";
+import { StyledStoreWrapper, StyledStoreHeader } from "../components";
 
-const StoreAside = ({children, close, title}) => {
-	return (
-		<StyledStoreWrapper width="34%">
-			<StyledStoreAsideInner>
-				<StyledStoreHeader>
-					<div style={{display: 'flex', justifyContent: 'space-between', width: '100%'}}>
-						<Title as="h2" color={theme.color.white} font={theme.font.neometric} weight={900} size='s'>
-							{title}
-						</Title>
-						<ActionClose onClick={close}/>
-					</div>
-				</StyledStoreHeader>
-				{children}
-			</StyledStoreAsideInner>
-		</StyledStoreWrapper>
-	)
-}
+const StoreAside = ({ children, close, title }) => {
+  return (
+    <StyledStoreWrapper width="34%">
+      <StyledStoreAsideInner>
+        <StyledStoreHeader>
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              width: "100%",
+            }}
+          >
+            <Title
+              as="h2"
+              color={theme.color.white}
+              font={theme.font.neometric}
+              weight={900}
+              size="s"
+            >
+              {title}
+            </Title>
+            <ActionClose onClick={close} />
+          </div>
+        </StyledStoreHeader>
+        {children}
+      </StyledStoreAsideInner>
+    </StyledStoreWrapper>
+  );
+};
 
 const StyledStoreAsideInner = styled.div`
-	@media (min-width: ${theme.breakpoints.mobileS}) and (max-width: ${theme.breakpoints.tabletL}) {
-		padding-top: 1em;
-	}
+  @media (min-width: ${theme.breakpoints.mobileS}) and (max-width: ${theme
+      .breakpoints.tabletL}) {
+    padding-top: 1em;
+  }
 
-	@media (max-width: ${theme.breakpoints.tabletL}) {
-		padding-bottom: 1em;
-	}
+  @media (max-width: ${theme.breakpoints.tabletL}) {
+    padding-bottom: 1em;
+  }
 
-	@media (min-width: ${theme.breakpoints.tabletL}) {
-		position: sticky;
-		top: calc(${theme.topBarSize}px + 1em);
-		display: flex;
-		flex-direction: column;
-		max-height: calc(100vh - ${theme.topBarSize}px - 2em);
-		overflow: hidden;
-	}
+  @media (min-width: ${theme.breakpoints.tabletL}) {
+    position: sticky;
+    top: calc(${theme.topBarSize}px + 1em);
+    display: flex;
+    flex-direction: column;
+    max-height: calc(100vh - ${theme.topBarSize}px - 2em);
+    overflow: hidden;
+  }
 
-	@media (min-width: ${theme.breakpoints.desktop}) {
-		top: 1em;
-		max-height: calc(100vh - 2em);
-	}
-`
+  @media (min-width: ${theme.breakpoints.desktop}) {
+    top: 1em;
+    max-height: calc(100vh - 2em);
+  }
+`;
 
 export default StoreAside;

--- a/packages/app/src/views/Store/components/StoreCard.tsx
+++ b/packages/app/src/views/Store/components/StoreCard.tsx
@@ -1,51 +1,78 @@
-import React, { useState } from 'react';
+import React, { useState } from "react";
 import { Link, Redirect, useParams } from "react-router-dom";
-import { Badge, StyledLinkTitle } from '../../../components';
-import { StyledStoreWrapper, StyledStoreHeader, StyledStoreBody, StoreCardsCollection, StoreCardsAside, StorePacksAside, StorePacksCollection } from '../components';
+import { Badge, StyledLinkTitle } from "../../../components";
+import {
+  StyledStoreWrapper,
+  StyledStoreHeader,
+  StyledStoreBody,
+  StoreCardsCollection,
+  StoreCardsAside,
+  StorePacksAside,
+  StorePacksCollection,
+} from "../components";
 
-const StoreCard : React.FC<any> = () => {
-	const [selectedCard, setSelectedCard] = useState(null);
-	const [selectedPack, setSelectedPack] = useState(null);
+const StoreCard: React.FC<any> = () => {
+  const [selectedCard, setSelectedCard] = useState(null);
+  const [selectedPack, setSelectedPack] = useState(null);
 
-	const routerParams : any = useParams();
+  const routerParams: any = useParams();
 
-	if (!routerParams.storeState) return <Redirect to="/store/boosterpacks"/>
+  if (!routerParams.storeState) return <Redirect to="/store/boosterpacks" />;
 
-	const itemSelected = (selectedCard && routerParams.storeState === "cards") ||
-	(selectedPack && routerParams.storeState === "boosterpacks");
+  const itemSelected =
+    (selectedCard && routerParams.storeState === "cards") ||
+    (selectedPack && routerParams.storeState === "boosterpacks");
 
-	const storeWidth = () =>{
-		if (itemSelected) return "calc(60% + .5em)";
-		return "100%";
-	}
+  const storeWidth = () => {
+    if (itemSelected) return "calc(60% + .5em)";
+    return "100%";
+  };
 
-	return (
-		<div style={{display: 'flex', position: 'relative'}}>
-			<StyledStoreWrapper width={storeWidth()} itemSelected={itemSelected}>
-				<StyledStoreHeader>
-					<div style={{display: 'flex'}}>
-						<StyledLinkTitle isInactive={routerParams.storeState !== "cards"}>
-							<Link to={`/store/cards`}>Cards</Link>
-						</StyledLinkTitle>
-						<StyledLinkTitle isInactive={routerParams.storeState !== "boosterpacks"}>
-							<Link to={`/store/boosterpacks`}>Boosterpacks</Link>
-							<Badge text='soon'/>
-						</StyledLinkTitle>
-					</div>
-				</StyledStoreHeader>
-				<StyledStoreBody>
-					{routerParams.storeState === "cards" &&
-						<StoreCardsCollection setSelectedCard={setSelectedCard} selectedCard={selectedCard}/>
-					}
-					{routerParams.storeState === "boosterpacks" &&
-						<StorePacksCollection setSelectedPack={setSelectedPack} selectedPack={selectedPack}/>
-					}
-				</StyledStoreBody>
-			</StyledStoreWrapper>
-			{ (selectedCard && routerParams.storeState === "cards") && <StoreCardsAside setSelectedCard={setSelectedCard} selectedCard={selectedCard}/> }
-			{ (selectedPack && routerParams.storeState === "boosterpacks") && <StorePacksAside setSelectedPack={setSelectedPack} selectedPack={selectedPack}/> }
-		</div>
-	)
-}
+  return (
+    <div style={{ display: "flex", position: "relative" }}>
+      <StyledStoreWrapper width={storeWidth()} itemSelected={itemSelected}>
+        <StyledStoreHeader>
+          <div style={{ display: "flex" }}>
+            <StyledLinkTitle isInactive={routerParams.storeState !== "cards"}>
+              <Link to={`/store/cards`}>Cards</Link>
+            </StyledLinkTitle>
+            <StyledLinkTitle
+              isInactive={routerParams.storeState !== "boosterpacks"}
+            >
+              <Link to={`/store/boosterpacks`}>Boosterpacks</Link>
+              <Badge text="soon" />
+            </StyledLinkTitle>
+          </div>
+        </StyledStoreHeader>
+        <StyledStoreBody>
+          {routerParams.storeState === "cards" && (
+            <StoreCardsCollection
+              setSelectedCard={setSelectedCard}
+              selectedCard={selectedCard}
+            />
+          )}
+          {routerParams.storeState === "boosterpacks" && (
+            <StorePacksCollection
+              setSelectedPack={setSelectedPack}
+              selectedPack={selectedPack}
+            />
+          )}
+        </StyledStoreBody>
+      </StyledStoreWrapper>
+      {selectedCard && routerParams.storeState === "cards" && (
+        <StoreCardsAside
+          setSelectedCard={setSelectedCard}
+          selectedCard={selectedCard}
+        />
+      )}
+      {selectedPack && routerParams.storeState === "boosterpacks" && (
+        <StorePacksAside
+          setSelectedPack={setSelectedPack}
+          selectedPack={selectedPack}
+        />
+      )}
+    </div>
+  );
+};
 
 export default StoreCard;

--- a/packages/app/src/views/Store/components/StoreCardsAside.tsx
+++ b/packages/app/src/views/Store/components/StoreCardsAside.tsx
@@ -1,161 +1,274 @@
 import React, { useState, useContext } from "react";
-import { StoreAside, StyledStoreBody, StyledPepemonCardMeta, StyledPepemonCardPrice } from './index';
-import { Button, ExternalLink, Title, Text, Spacer, StyledSpacer } from '../../../components';
-import { PepemonProviderContext } from '../../../contexts';
+import {
+  StoreAside,
+  StyledStoreBody,
+  StyledPepemonCardMeta,
+  StyledPepemonCardPrice,
+} from "./index";
+import {
+  Button,
+  ExternalLink,
+  Title,
+  Text,
+  Spacer,
+  StyledSpacer,
+} from "../../../components";
+import { PepemonProviderContext } from "../../../contexts";
 import { getDisplayBalance } from "../../../utils";
-import { cardback_normal, coin } from '../../../assets';
-import { useModal, useAllowance, useTokenBalance, useRedeemCard, useApprove, useWeb3Modal } from "../../../hooks";
-import { theme } from '../../../theme';
+import { cardback_normal, coin } from "../../../assets";
+import {
+  useModal,
+  useAllowance,
+  useTokenBalance,
+  useRedeemCard,
+  useApprove,
+  useWeb3Modal,
+} from "../../../hooks";
+import { theme } from "../../../theme";
 
-const StoreCardsAside: React.FC<any> = ({setSelectedCard, selectedCard: { cardId, cardPrice, cardMeta = null, cardBalance = null }}) => {
-	const [transactions, setTransactions] = useState(0);
-	const [pepemon] = useContext(PepemonProviderContext);
-	const { chainId, contracts, account } = pepemon;
-	const [, loadWeb3Modal] = useWeb3Modal();
-	const { onRedeemCard, isRedeemingCard } = useRedeemCard(contracts.pepemonStore);
-	const { onApprove, isApproving } = useApprove(contracts.pepemonStore, contracts.ppdex);
-	const allowance = useAllowance(contracts.pepemonStore);
-	const ppdexBalance = useTokenBalance(contracts?.ppdex?.address);
+const StoreCardsAside: React.FC<any> = ({
+  setSelectedCard,
+  selectedCard: { cardId, cardPrice, cardMeta = null, cardBalance = null },
+}) => {
+  const [transactions, setTransactions] = useState(0);
+  const [pepemon] = useContext(PepemonProviderContext);
+  const { chainId, contracts, account } = pepemon;
+  const [, loadWeb3Modal] = useWeb3Modal();
+  const { onRedeemCard, isRedeemingCard } = useRedeemCard(
+    contracts.pepemonStore
+  );
+  const { onApprove, isApproving } = useApprove(
+    contracts.pepemonStore,
+    contracts.ppdex
+  );
+  const allowance = useAllowance(contracts.pepemonStore);
+  const ppdexBalance = useTokenBalance(contracts?.ppdex?.address);
 
-	const isItemCard = (tokenId: number) => {
-        return [17, 18, 19].includes(tokenId);
+  const isItemCard = (tokenId: number) => {
+    return [17, 18, 19].includes(tokenId);
+  };
+
+  const daysForSale = () => {
+    if (isItemCard(cardId)) {
+      return 1000000;
     }
+    return cardId > 5 ? (cardId > 12 ? 28 : 21) : 14;
+  };
 
-    const daysForSale = () => {
-        if (isItemCard(cardId)) {
-            return 1000000
-        }
-        return cardId > 5 ? (cardId > 12 ? 28 : 21) : 14;
+  const isAllowedSpending = () => {
+    // No allowance needed for native BNB payments
+    if (chainId === 56) {
+      return true;
     }
+    return cardPrice?.comparedTo(allowance) === -1;
+  };
 
-	const isAllowedSpending = () => {
-        // No allowance needed for native BNB payments
-        if (chainId === 56) { return true; }
-		return cardPrice?.comparedTo(allowance) === -1;
+  const isMintable = () => {
+    return (
+      cardBalance &&
+      parseFloat(cardBalance.totalSupply) < parseFloat(cardBalance.maxSupply)
+    );
+  };
+
+  const isAffordable = () => {
+    if (cardPrice?.isEqualTo(ppdexBalance)) {
+      return true;
     }
+    return cardPrice?.comparedTo(ppdexBalance) === -1;
+  };
 
-	const isMintable = () => {
-        return cardBalance && (parseFloat(cardBalance.totalSupply) < parseFloat(cardBalance.maxSupply));
+  const [handlePresent] = useModal({
+    title: "Claim this card",
+    modalActions: [
+      {
+        text: isRedeemingCard ? "Claiming..." : "Claim card",
+        buttonProps: {
+          disabled: isRedeemingCard,
+          styling: "purple",
+          onClick: () =>
+            onRedeemCard(
+              cardId,
+              chainId === 56 ? priceOfCard.toString() : null
+            ).then(() => setTransactions(transactions + 1)),
+        },
+      },
+    ],
+  });
+
+  if (cardMeta.status === "failed") {
+    setSelectedCard(null);
+    return <></>;
+  } // bail out early if card infos couldn't be loaded
+
+  const isReleasingSoon = () => {
+    const birthdayMetaData = cardMeta.attributes.find(
+      (attribute) => attribute.trait_type === "birthday"
+    );
+    if (parseFloat(birthdayMetaData.value) === 0) return true;
+    return parseFloat(birthdayMetaData.value) > Date.now() / 1000;
+  };
+
+  const isForSale = () => {
+    const birthdayMetaData = cardMeta.attributes.find(
+      (attribute) => attribute.trait_type === "birthday"
+    );
+    if (parseFloat(birthdayMetaData.value) === 0) return false;
+    return (
+      parseFloat(birthdayMetaData.value) + daysForSale() * 24 * 60 * 60 >
+      Date.now() / 1000
+    );
+  };
+
+  const isNoLongerForSale = () => {
+    return !isForSale() && !isReleasingSoon();
+  };
+
+  const isSoldOut = () => {
+    return (!isMintable() && !isReleasingSoon()) || isNoLongerForSale();
+  };
+
+  const priceOfCard =
+    cardPrice && parseFloat(getDisplayBalance(cardPrice, 18)).toFixed(2);
+
+  const buttonProps = () => {
+    if (!account) {
+      return {
+        disabled: false,
+        onClick: loadWeb3Modal,
+        text: "Connect wallet",
+      };
     }
-
-	const isAffordable = () => {
-        if (cardPrice?.isEqualTo(ppdexBalance)) { return true; }
-        return cardPrice?.comparedTo(ppdexBalance) === -1;
+    if (isSoldOut() || isNoLongerForSale()) {
+      return { disabled: true, onClick: () => null, text: "Not available" };
+    } else if (isAllowedSpending()) {
+      if (isReleasingSoon()) {
+        return { disabled: true, onClick: () => null, text: "Available soon" };
+      } else if (!isAffordable()) {
+        return {
+          disabled: true,
+          onClick: handlePresent,
+          text: "Not enough balance",
+        };
+      } else {
+        return {
+          disabled: isRedeemingCard ? true : false,
+          onClick: handlePresent,
+          text: isRedeemingCard ? "Claiming..." : "Claim card",
+        };
+      }
+    } else {
+      return {
+        disabled: false,
+        onClick: () => !isApproving && onApprove(),
+        text: isApproving ? "Enabling..." : "Enable",
+      };
     }
+  };
 
-	const [handlePresent] = useModal({
-		title: 'Claim this card',
-		modalActions: [
-			{
-				text: isRedeemingCard ? 'Claiming...' : 'Claim card',
-				buttonProps: {
-					disabled: isRedeemingCard,
-					styling: "purple",
-					onClick: () => onRedeemCard(cardId, chainId === 56 ? priceOfCard.toString() : null).then(() => setTransactions(transactions + 1))
-				}
-			}
-		]
-	});
-
-	if (cardMeta.status === "failed") { setSelectedCard(null); return <></> } // bail out early if card infos couldn't be loaded
-
-	const isReleasingSoon = () => {
-        const birthdayMetaData = cardMeta.attributes.find(attribute => attribute.trait_type === 'birthday');
-		if (parseFloat(birthdayMetaData.value) === 0) return true;
-        return parseFloat(birthdayMetaData.value) > (Date.now() / 1000);
-    }
-
-	const isForSale = () => {
-        const birthdayMetaData = cardMeta.attributes.find(attribute => attribute.trait_type === 'birthday');
-		if (parseFloat(birthdayMetaData.value) === 0) return false;
-		return (parseFloat(birthdayMetaData.value) + (daysForSale() * 24 * 60 * 60)) > (Date.now() / 1000)
-    }
-
-	const isNoLongerForSale = () => {
-		return !isForSale() && !isReleasingSoon();
-	}
-
-	const isSoldOut = () => {
-        return (!isMintable() && !isReleasingSoon()) || (isNoLongerForSale());
-    }
-
-	const priceOfCard = cardPrice && parseFloat(getDisplayBalance(cardPrice, 18)).toFixed(2);
-
-	const buttonProps = () => {
-		if (!account) {
-			return { disabled: false, onClick: loadWeb3Modal, text: 'Connect wallet' }
-		}
-		if (isSoldOut() || isNoLongerForSale()) {
-			return { disabled: true, onClick: () => null, text: 'Not available' }
-		} else if (isAllowedSpending()) {
-			if (isReleasingSoon()) {
-				return { disabled: true, onClick: () => null, text: 'Available soon' }
-			} else if (!isAffordable()) {
-				return { disabled: true, onClick: handlePresent, text: 'Not enough balance' };
-			} else {
-				return { disabled: isRedeemingCard ? true : false, onClick: handlePresent, text: isRedeemingCard ? 'Claiming...' : 'Claim card' }
-			}
-		} else {
-			return { disabled: false, onClick: () => !isApproving && onApprove(), text: isApproving ? 'Enabling...' : 'Enable' }
-		}
-	}
-
-	return (
-		<StoreAside close={() => setSelectedCard("")} title="Selected Card">
-			<StyledStoreBody>
-				<Title as="h2" font={theme.font.neometric} size='m'>{cardMeta ? cardMeta.name : 'Loading card'}</Title>
-				<Spacer size="sm"/>
-				<Text as="p" font={theme.font.inter} size='s' lineHeight={1.3} color={theme.color.gray[600]}>{cardMeta && cardMeta.description}</Text>
-				<Spacer size="sm"/>
-				<img loading="lazy" src={cardMeta ? cardMeta.image : cardback_normal} alt={cardMeta ? cardMeta.name : 'Loading card'} style={{width: "100%"}}/>
-				<Spacer size='md'/>
-				<StyledPepemonCardMeta>
-					<dt>Rarity:</dt>
-					<dd>{cardMeta && cardMeta.attributes.find((trait) => trait.trait_type === 'Rarity').value}</dd>
-				</StyledPepemonCardMeta>
-				<Spacer size='sm'/>
-				<StyledSpacer bg={theme.color.gray[100]} size={2}/>
-				<StyledPepemonCardMeta>
-					<dt>Type:</dt>
-					<dd>{cardMeta && cardMeta.attributes.find((trait) => trait.trait_type === 'Type').value}</dd>
-				</StyledPepemonCardMeta>
-				<Spacer size='sm'/>
-				<StyledSpacer bg={theme.color.gray[100]} size={2}/>
-				<StyledPepemonCardMeta>
-					<dt>Set:</dt>
-					<dd>{cardMeta && cardMeta.attributes.find((trait) => trait.trait_type === 'Set').value}</dd>
-				</StyledPepemonCardMeta>
-				<Spacer size='sm'/>
-				<StyledSpacer bg={theme.color.gray[100]} size={2}/>
-				<StyledPepemonCardMeta>
-					<dt>Artist:</dt>
-					<dd>{cardMeta && cardMeta.attributes.find((trait) => trait.trait_type === 'Artist').value}</dd>
-				</StyledPepemonCardMeta>
-				<Spacer size='sm'/>
-				<StyledSpacer bg={theme.color.gray[100]} size={2}/>
-				<StyledPepemonCardMeta>
-					<dt>Price:</dt>
-					<dd>
-						<StyledPepemonCardPrice styling="alt">
-							<img loading="lazy" src={coin} alt="coin"/>
-							{cardPrice ? `${priceOfCard} ${chainId === 56 ? 'BNB' : 'PPDEX'}` : 'loading'}
-						</StyledPepemonCardPrice>
-					</dd>
-				</StyledPepemonCardMeta>
-				<Spacer size='md'/>
-				<ExternalLink style={{ width: '100%' }} href={chainId === 137 ? `https://quickswap.exchange/#/swap?outputCurrency=${contracts?.ppdex?.address || ''}` :
-				chainId === 56 ? 'https://www.binance.com/en/trade/BNB_ETH' : `https://app.uniswap.org/#/swap?outputCurrency=${contracts?.ppdex?.address || ''}`}>
-					Buy {chainId === 56 ? 'BNB' : 'PPDEX'}
-				</ExternalLink>
-				<Spacer size='md'/>
-				<Button width="100%" styling="purple"
-					disabled={buttonProps().disabled}
-					onClick={buttonProps().onClick}>
-						{buttonProps().text}
-				</Button>
-			</StyledStoreBody>
-		</StoreAside>
-	)
-}
+  return (
+    <StoreAside close={() => setSelectedCard("")} title="Selected Card">
+      <StyledStoreBody>
+        <Title as="h2" font={theme.font.neometric} size="m">
+          {cardMeta ? cardMeta.name : "Loading card"}
+        </Title>
+        <Spacer size="sm" />
+        <Text
+          as="p"
+          font={theme.font.inter}
+          size="s"
+          lineHeight={1.3}
+          color={theme.color.gray[600]}
+        >
+          {cardMeta && cardMeta.description}
+        </Text>
+        <Spacer size="sm" />
+        <img
+          loading="lazy"
+          src={cardMeta ? cardMeta.image : cardback_normal}
+          alt={cardMeta ? cardMeta.name : "Loading card"}
+          style={{ width: "100%" }}
+        />
+        <Spacer size="md" />
+        <StyledPepemonCardMeta>
+          <dt>Rarity:</dt>
+          <dd>
+            {cardMeta &&
+              cardMeta.attributes.find((trait) => trait.trait_type === "Rarity")
+                .value}
+          </dd>
+        </StyledPepemonCardMeta>
+        <Spacer size="sm" />
+        <StyledSpacer bg={theme.color.gray[100]} size={2} />
+        <StyledPepemonCardMeta>
+          <dt>Type:</dt>
+          <dd>
+            {cardMeta &&
+              cardMeta.attributes.find((trait) => trait.trait_type === "Type")
+                .value}
+          </dd>
+        </StyledPepemonCardMeta>
+        <Spacer size="sm" />
+        <StyledSpacer bg={theme.color.gray[100]} size={2} />
+        <StyledPepemonCardMeta>
+          <dt>Set:</dt>
+          <dd>
+            {cardMeta &&
+              cardMeta.attributes.find((trait) => trait.trait_type === "Set")
+                .value}
+          </dd>
+        </StyledPepemonCardMeta>
+        <Spacer size="sm" />
+        <StyledSpacer bg={theme.color.gray[100]} size={2} />
+        <StyledPepemonCardMeta>
+          <dt>Artist:</dt>
+          <dd>
+            {cardMeta &&
+              cardMeta.attributes.find((trait) => trait.trait_type === "Artist")
+                .value}
+          </dd>
+        </StyledPepemonCardMeta>
+        <Spacer size="sm" />
+        <StyledSpacer bg={theme.color.gray[100]} size={2} />
+        <StyledPepemonCardMeta>
+          <dt>Price:</dt>
+          <dd>
+            <StyledPepemonCardPrice styling="alt">
+              <img loading="lazy" src={coin} alt="coin" />
+              {cardPrice
+                ? `${priceOfCard} ${chainId === 56 ? "BNB" : "PPDEX"}`
+                : "loading"}
+            </StyledPepemonCardPrice>
+          </dd>
+        </StyledPepemonCardMeta>
+        <Spacer size="md" />
+        <ExternalLink
+          style={{ width: "100%" }}
+          href={
+            chainId === 137
+              ? `https://quickswap.exchange/#/swap?outputCurrency=${
+                  contracts?.ppdex?.address || ""
+                }`
+              : chainId === 56
+              ? "https://www.binance.com/en/trade/BNB_ETH"
+              : `https://app.uniswap.org/#/swap?outputCurrency=${
+                  contracts?.ppdex?.address || ""
+                }`
+          }
+        >
+          Buy {chainId === 56 ? "BNB" : "PPDEX"}
+        </ExternalLink>
+        <Spacer size="md" />
+        <Button
+          width="100%"
+          styling="purple"
+          disabled={buttonProps().disabled}
+          onClick={buttonProps().onClick}
+        >
+          {buttonProps().text}
+        </Button>
+      </StyledStoreBody>
+    </StoreAside>
+  );
+};
 
 export default StoreCardsAside;

--- a/packages/app/src/views/Store/components/StoreCardsCollection.tsx
+++ b/packages/app/src/views/Store/components/StoreCardsCollection.tsx
@@ -1,73 +1,106 @@
-import React, { useEffect, useState, useContext } from 'react';
-import { Title, Spacer, DropdownMenu,
-	// Button
-} from '../../../components';
-import { PepemonProviderContext } from '../../../contexts';
-import { cards } from '../../../constants';
-import { theme } from '../../../theme';
-import { CardSingle, StyledStoreCardsWrapper, StyledStoreCardsInner, StoreSelectionWrapper } from '../components';
+import React, { useEffect, useState, useContext } from "react";
+import {
+  Title,
+  Spacer,
+  DropdownMenu,
+  // Button
+} from "../../../components";
+import { PepemonProviderContext } from "../../../contexts";
+import { cards } from "../../../constants";
+import { theme } from "../../../theme";
+import {
+  CardSingle,
+  StyledStoreCardsWrapper,
+  StyledStoreCardsInner,
+  StoreSelectionWrapper,
+} from "../components";
 
-const StoreCardsCollection : React.FC<any> = ({selectedCard, setSelectedCard}) => {
-	const [pepemon] = useContext(PepemonProviderContext);
-	const { chainId } = pepemon;
-	const effectiveChainId = chainId || 1;
-	const [options, setOptions] = useState(null);
-	const [activeSeries, setActiveSeries] = useState<any>(cards.get(effectiveChainId)?.find(series => {
-																if (effectiveChainId === 56) {
-																	return series.title_formatted === 'CARTOONIZED_SERIES'
-																}
-																return series.title_formatted === 'EVENT_ITEM_CARDS'
-															}));
+const StoreCardsCollection: React.FC<any> = ({
+  selectedCard,
+  setSelectedCard,
+}) => {
+  const [pepemon] = useContext(PepemonProviderContext);
+  const { chainId } = pepemon;
+  const effectiveChainId = chainId || 1;
+  const [options, setOptions] = useState(null);
+  const [activeSeries, setActiveSeries] = useState<any>(
+    cards.get(effectiveChainId)?.find((series) => {
+      if (effectiveChainId === 56) {
+        return series.title_formatted === "CARTOONIZED_SERIES";
+      }
+      return series.title_formatted === "EVENT_ITEM_CARDS";
+    })
+  );
 
-	useEffect(() => {
-		const cid = chainId || 1;
-		setActiveSeries(cards.get(cid)?.find(series => {
-			if (cid === 56) {
-				return series.title_formatted === 'CARTOONIZED_SERIES'
-			}
-			return series.title_formatted === 'EVENT_ITEM_CARDS'
-		}))
-	},[setActiveSeries, chainId])
+  useEffect(() => {
+    const cid = chainId || 1;
+    setActiveSeries(
+      cards.get(cid)?.find((series) => {
+        if (cid === 56) {
+          return series.title_formatted === "CARTOONIZED_SERIES";
+        }
+        return series.title_formatted === "EVENT_ITEM_CARDS";
+      })
+    );
+  }, [setActiveSeries, chainId]);
 
-	useEffect(() => {
-		setSelectedCard(null);
-	},[setSelectedCard, chainId])
+  useEffect(() => {
+    setSelectedCard(null);
+  }, [setSelectedCard, chainId]);
 
-	useEffect(() => {
-		const cid = chainId || 1;
-		setOptions(cards.get(cid)?.map((series) => {
-			return {
-				title: series.title,
-				onClick: () => setActiveSeries(series)
-			}
-		}))
-	}, [setActiveSeries, chainId]);
+  useEffect(() => {
+    const cid = chainId || 1;
+    setOptions(
+      cards.get(cid)?.map((series) => {
+        return {
+          title: series.title,
+          onClick: () => setActiveSeries(series),
+        };
+      })
+    );
+  }, [setActiveSeries, chainId]);
 
-	return (
-		<div>
-			<StoreSelectionWrapper>
-				{/*<Button styling="link" style={{padding: 0}} onClick={selectAllSeries}>show series</Button>*/}
-				{(activeSeries && options) && <DropdownMenu title="0 Selected" options={options} activeOptions={activeSeries} setActiveSeries={setActiveSeries}/>}
-			</StoreSelectionWrapper>
-			{/*{seriesToMap.map((activeSerie, key) => {
+  return (
+    <div>
+      <StoreSelectionWrapper>
+        {/*<Button styling="link" style={{padding: 0}} onClick={selectAllSeries}>show series</Button>*/}
+        {activeSeries && options && (
+          <DropdownMenu
+            title="0 Selected"
+            options={options}
+            activeOptions={activeSeries}
+            setActiveSeries={setActiveSeries}
+          />
+        )}
+      </StoreSelectionWrapper>
+      {/*{seriesToMap.map((activeSerie, key) => {
 				return (
 					<div key={key}>*/}
-					{ activeSeries &&
-						<StyledStoreCardsWrapper>
-							<Title as="h3" size='m' font={theme.font.spaceMace}>{activeSeries.title}</Title>
-							<Spacer size="md"/>
-							<StyledStoreCardsInner gridCols={selectedCard ? 3 : 5}>
-								{activeSeries.cards.map(cardId => {
-									return <CardSingle key={cardId} cardId={cardId} selectedCard={selectedCard} selectCard={setSelectedCard}/>
-								})}
-							</StyledStoreCardsInner>
-							<Spacer size="md"/>
-						</StyledStoreCardsWrapper>
-					}
-				{/*)
+      {activeSeries && (
+        <StyledStoreCardsWrapper>
+          <Title as="h3" size="m" font={theme.font.spaceMace}>
+            {activeSeries.title}
+          </Title>
+          <Spacer size="md" />
+          <StyledStoreCardsInner gridCols={selectedCard ? 3 : 5}>
+            {activeSeries.cards.map((cardId) => {
+              return (
+                <CardSingle
+                  key={cardId}
+                  cardId={cardId}
+                  selectedCard={selectedCard}
+                  selectCard={setSelectedCard}
+                />
+              );
+            })}
+          </StyledStoreCardsInner>
+          <Spacer size="md" />
+        </StyledStoreCardsWrapper>
+      )}
+      {/*)
 			})}*/}
-		</div>
-	)
-}
+    </div>
+  );
+};
 
 export default StoreCardsCollection;

--- a/packages/app/src/views/Store/components/StorePacksAside.tsx
+++ b/packages/app/src/views/Store/components/StorePacksAside.tsx
@@ -1,13 +1,13 @@
 import React, { useContext, useRef, useEffect, useState } from "react";
 import styled, { keyframes } from "styled-components";
-import { StyledStoreBody } from './index';
-import { Button, Title, Text, Spacer } from '../../../components';
-import { PepemonProviderContext } from '../../../contexts';
-import { StoreAside } from '../components';
-import { theme } from '../../../theme';
-import { useClaimBoosterPack, useWeb3Modal } from '../../../hooks';
-import type { ReceivedCard } from '../../../hooks/useClaimBoosterPack';
-import chains from '../../../constants/chains';
+import { StyledStoreBody } from "./index";
+import { Button, Title, Text, Spacer } from "../../../components";
+import { PepemonProviderContext } from "../../../contexts";
+import { StoreAside } from "../components";
+import { theme } from "../../../theme";
+import { useClaimBoosterPack, useWeb3Modal } from "../../../hooks";
+import type { ReceivedCard } from "../../../hooks/useClaimBoosterPack";
+import chains from "../../../constants/chains";
 
 const BASE_SEPOLIA_CHAIN_ID = 84532;
 
@@ -59,10 +59,10 @@ const CardOverlayLayer = styled.div<{ visible: boolean }>`
   background: rgba(0, 0, 0, 0.55);
   border-radius: 20px;
   backdrop-filter: blur(8px);
-  opacity: ${p => (p.visible ? 1 : 0)};
-  transform: ${p => (p.visible ? 'scale(1)' : 'scale(0.95)')};
+  opacity: ${(p) => (p.visible ? 1 : 0)};
+  transform: ${(p) => (p.visible ? "scale(1)" : "scale(0.95)")};
   transition: opacity 0.5s ease, transform 0.5s ease;
-  pointer-events: ${p => (p.visible ? 'auto' : 'none')};
+  pointer-events: ${(p) => (p.visible ? "auto" : "none")};
 `;
 
 const CardRow = styled.div`
@@ -74,8 +74,9 @@ const CardRow = styled.div`
 
 const CardSlot = styled.div<{ visible: boolean }>`
   width: 110px;
-  opacity: ${p => (p.visible ? 1 : 0)};
-  animation: ${p => (p.visible ? popIn : 'none')} 0.55s cubic-bezier(0.34,1.56,0.64,1) both;
+  opacity: ${(p) => (p.visible ? 1 : 0)};
+  animation: ${(p) => (p.visible ? popIn : "none")} 0.55s
+    cubic-bezier(0.34, 1.56, 0.64, 1) both;
 `;
 
 const CardImg = styled.img`
@@ -99,7 +100,7 @@ const RevealTitle = styled.h2`
   font-size: 20px;
   font-weight: 800;
   text-align: center;
-  text-shadow: 0 0 18px rgba(168,85,247,0.9);
+  text-shadow: 0 0 18px rgba(168, 85, 247, 0.9);
   margin: 0;
 `;
 
@@ -123,12 +124,12 @@ const ScrollableContent = styled.div`
   }
 `;
 
-const StickyBottom = styled.div`
+const StickyTop = styled.div`
   @media (min-width: ${theme.breakpoints.tabletL}) {
     flex-shrink: 0;
     background: #fff;
-    padding-top: 12px;
-    border-top: 1px solid ${theme.color.gray[100]};
+    padding-bottom: 12px;
+    border-bottom: 1px solid ${theme.color.gray[100]};
   }
 `;
 
@@ -142,40 +143,48 @@ const QtyBtn = styled.button<{ active: boolean }>`
   flex: 1;
   padding: 6px 0;
   border-radius: 8px;
-  border: 2px solid ${p => (p.active ? theme.color.purple[600] : theme.color.gray[200])};
-  background: ${p => (p.active ? theme.color.purple[600] : 'transparent')};
-  color: ${p => (p.active ? '#fff' : theme.color.gray[600])};
+  border: 2px solid
+    ${(p) => (p.active ? theme.color.purple[600] : theme.color.gray[200])};
+  background: ${(p) => (p.active ? theme.color.purple[600] : "transparent")};
+  color: ${(p) => (p.active ? "#fff" : theme.color.gray[600])};
   font-size: 13px;
   font-weight: 700;
   cursor: pointer;
   transition: all 0.15s;
-  &:hover { border-color: ${theme.color.purple[600]}; }
+  &:hover {
+    border-color: ${theme.color.purple[600]};
+  }
 `;
 
 // ─── Card metadata ────────────────────────────────────────────────────────────
 
-interface CardMeta { image: string; name: string; }
+interface CardMeta {
+  image: string;
+  name: string;
+}
 
 function useCardMeta(ids: number[]): Record<number, CardMeta> {
   const [meta, setMeta] = useState<Record<number, CardMeta>>({});
-  const key = ids.join(',');
+  const key = ids.join(",");
   useEffect(() => {
     if (!ids.length) return;
     const unique = Array.from(new Set(ids));
     Promise.all(
-      unique.map(id =>
+      unique.map((id) =>
         fetch(`/metadata/cards/${id}`)
-          .then(r => r.json())
-          .then(d => ({
+          .then((r) => r.json())
+          .then((d) => ({
             id,
-            image: (d.image || '').replace('https://pepemon.world/', '/'),
+            image: (d.image || "").replace("https://pepemon.world/", "/"),
             name: d.name || `Card #${id}`,
           }))
-          .catch(() => ({ id, image: '', name: `Card #${id}` }))
+          .catch(() => ({ id, image: "", name: `Card #${id}` }))
       )
-    ).then(results => {
+    ).then((results) => {
       const m: Record<number, CardMeta> = {};
-      results.forEach(r => { m[r.id] = { image: r.image, name: r.name }; });
+      results.forEach((r) => {
+        m[r.id] = { image: r.image, name: r.name };
+      });
       setMeta(m);
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -186,24 +195,28 @@ function useCardMeta(ids: number[]): Record<number, CardMeta> {
 // ─── Reveal overlay ───────────────────────────────────────────────────────────
 
 interface RevealOverlayProps {
-  phase: 'idle' | 'wallet-pending' | 'video-playing' | 'revealing';
+  phase: "idle" | "wallet-pending" | "video-playing" | "revealing";
   receivedCards: ReceivedCard[];
   onDismiss: () => void;
 }
 
-const RevealOverlay: React.FC<RevealOverlayProps> = ({ phase, receivedCards, onDismiss }) => {
-  const videoRef      = useRef<HTMLVideoElement>(null);
-  const [videoEnded,  setVideoEnded]  = useState(false);
+const RevealOverlay: React.FC<RevealOverlayProps> = ({
+  phase,
+  receivedCards,
+  onDismiss,
+}) => {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const [videoEnded, setVideoEnded] = useState(false);
   const [revealedCount, setRevealedCount] = useState(0);
 
-  const showOverlay = phase === 'video-playing' || phase === 'revealing';
+  const showOverlay = phase === "video-playing" || phase === "revealing";
   // Show cards when BOTH: tx confirmed AND video has played to the end
-  const showCards   = phase === 'revealing' && videoEnded;
+  const showCards = phase === "revealing" && videoEnded;
 
   // Expand receivedCards to individual card slots (2× card 2 → [2, 2])
-  const cardList = receivedCards.flatMap(c => Array(c.amount).fill(c.id));
-  const cardIds  = cardList.filter((v, i, a) => a.indexOf(v) === i);
-  const meta     = useCardMeta(showCards ? cardIds : []);
+  const cardList = receivedCards.flatMap((c) => Array(c.amount).fill(c.id));
+  const cardIds = cardList.filter((v, i, a) => a.indexOf(v) === i);
+  const meta = useCardMeta(showCards ? cardIds : []);
 
   // Play video when overlay opens; it will stop at the end (no loop)
   useEffect(() => {
@@ -231,7 +244,7 @@ const RevealOverlay: React.FC<RevealOverlayProps> = ({ phase, receivedCards, onD
     if (!showCards || cardList.length === 0) return;
     setRevealedCount(0);
     cardList.forEach((_, i) => {
-      setTimeout(() => setRevealedCount(n => n + 1), 300 + i * 750);
+      setTimeout(() => setRevealedCount((n) => n + 1), 300 + i * 750);
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [showCards]);
@@ -260,17 +273,32 @@ const RevealOverlay: React.FC<RevealOverlayProps> = ({ phase, receivedCards, onD
 
       <CardOverlayLayer visible={showCards}>
         <RevealTitle>
-          You pulled {cardList.length} {cardList.length === 1 ? 'card' : 'cards'}!
+          You pulled {cardList.length}{" "}
+          {cardList.length === 1 ? "card" : "cards"}!
         </RevealTitle>
         <CardRow>
           {cardList.map((id, i) => {
             const revealed = i < revealedCount;
             return (
               <CardSlot key={i} visible={revealed}>
-                {meta[id]?.image
-                  ? <CardImg src={meta[id].image} alt={meta[id]?.name} />
-                  : <div style={{ width: '100%', aspectRatio: '2/3', borderRadius: 10, background: 'linear-gradient(135deg,#4f46e5,#7c3aed)', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 28 }}>✦</div>
-                }
+                {meta[id]?.image ? (
+                  <CardImg src={meta[id].image} alt={meta[id]?.name} />
+                ) : (
+                  <div
+                    style={{
+                      width: "100%",
+                      aspectRatio: "2/3",
+                      borderRadius: 10,
+                      background: "linear-gradient(135deg,#4f46e5,#7c3aed)",
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      fontSize: 28,
+                    }}
+                  >
+                    ✦
+                  </div>
+                )}
                 <CardName>{meta[id]?.name || `#${id}`}</CardName>
               </CardSlot>
             );
@@ -295,78 +323,114 @@ const StorePacksAside: React.FC<any> = ({ setSelectedPack, selectedPack }) => {
   const { chainId, account } = pepemon;
   const [quantity, setQuantity] = useState(1);
 
-  const onchainConfig  = selectedPack?.onchainConfig ?? null;
-  const isLivePack     = onchainConfig !== null;
+  const onchainConfig = selectedPack?.onchainConfig ?? null;
+  const isLivePack = onchainConfig !== null;
   const isOnRightChain = isLivePack && chainId === onchainConfig.chainId;
 
-  const { onClaim, phase, receivedCards, claimError, onDismiss } = useClaimBoosterPack(
-    onchainConfig ?? { chainId: 0, faucetAddress: '', factoryAddress: '', packId: 0, cardIds: [] }
-  );
+  const { onClaim, phase, receivedCards, claimError, onDismiss } =
+    useClaimBoosterPack(
+      onchainConfig ?? {
+        chainId: 0,
+        faucetAddress: "",
+        factoryAddress: "",
+        packId: 0,
+        cardIds: [],
+      }
+    );
 
   const [, loadWeb3Modal] = useWeb3Modal() as any;
 
   const switchToBaseSepolia = async () => {
-    const chain = chains.find(c => parseInt(c.chainId, 16) === BASE_SEPOLIA_CHAIN_ID);
+    const chain = chains.find(
+      (c) => parseInt(c.chainId, 16) === BASE_SEPOLIA_CHAIN_ID
+    );
     if (!chain || !window.ethereum) return;
     try {
       await (window.ethereum as any).request({
-        method: 'wallet_switchEthereumChain',
+        method: "wallet_switchEthereumChain",
         params: [{ chainId: chain.chainId }],
       });
     } catch (err: any) {
       if (err.code === 4902) {
         await (window.ethereum as any).request({
-          method: 'wallet_addEthereumChain',
-          params: [{
-            chainId: chain.chainId,
-            chainName: chain.chainName,
-            nativeCurrency: chain.nativeCurrency,
-            rpcUrls: chain.rpcUrls,
-            blockExplorerUrls: chain.blockExplorerUrls,
-          }],
+          method: "wallet_addEthereumChain",
+          params: [
+            {
+              chainId: chain.chainId,
+              chainName: chain.chainName,
+              nativeCurrency: chain.nativeCurrency,
+              rpcUrls: chain.rpcUrls,
+              blockExplorerUrls: chain.blockExplorerUrls,
+            },
+          ],
         });
       }
     }
   };
 
-  const isClaiming = phase === 'wallet-pending' || phase === 'video-playing' || phase === 'revealing';
+  const isClaiming =
+    phase === "wallet-pending" ||
+    phase === "video-playing" ||
+    phase === "revealing";
 
   const handleOpen = async () => {
-    if (!account)      { await loadWeb3Modal(); return; }
-    if (!isOnRightChain) { await switchToBaseSepolia(); return; }
+    if (!account) {
+      await loadWeb3Modal();
+      return;
+    }
+    if (!isOnRightChain) {
+      await switchToBaseSepolia();
+      return;
+    }
     onClaim(quantity);
   };
 
-  const buttonLabel = phase === 'wallet-pending'
-    ? `Confirm in wallet… (${quantity > 1 ? `sign ${quantity}×` : 'signing'})`
-    : isClaiming
-    ? 'Opening pack…'
-    : quantity > 1
-    ? `Open ${quantity} Boosterpacks`
-    : 'Open Boosterpack';
+  const buttonLabel =
+    phase === "wallet-pending"
+      ? `Confirm in wallet… (${quantity > 1 ? `sign ${quantity}×` : "signing"})`
+      : isClaiming
+      ? "Opening pack…"
+      : quantity > 1
+      ? `Open ${quantity} Boosterpacks`
+      : "Open Boosterpack";
 
   const renderClaimArea = () => {
     if (!isLivePack) {
-      return <Button disabled styling="purple" width="100%">Not available (yet)</Button>;
+      return (
+        <Button disabled styling="purple" width="100%">
+          Not available (yet)
+        </Button>
+      );
     }
     return (
       <>
         {!isClaiming && (
           <QuantityRow>
-            {QUANTITIES.map(q => (
-              <QtyBtn key={q} active={quantity === q} onClick={() => setQuantity(q)}>
+            {QUANTITIES.map((q) => (
+              <QtyBtn
+                key={q}
+                active={quantity === q}
+                onClick={() => setQuantity(q)}
+              >
                 {q}×
               </QtyBtn>
             ))}
           </QuantityRow>
         )}
-        <Button styling="purple" width="100%" disabled={isClaiming} onClick={handleOpen}>
+        <Button
+          styling="purple"
+          width="100%"
+          disabled={isClaiming}
+          onClick={handleOpen}
+        >
           {buttonLabel}
         </Button>
         {claimError && (
           <>
-            <Spacer size="sm"/>
-            <Text as="p" font={theme.font.inter} size='xs' color="red">{claimError}</Text>
+            <Spacer size="sm" />
+            <Text as="p" font={theme.font.inter} size="xs" color="red">
+              {claimError}
+            </Text>
           </>
         )}
       </>
@@ -375,22 +439,47 @@ const StorePacksAside: React.FC<any> = ({ setSelectedPack, selectedPack }) => {
 
   return (
     <>
-      <RevealOverlay phase={phase} receivedCards={receivedCards} onDismiss={onDismiss} />
+      <RevealOverlay
+        phase={phase}
+        receivedCards={receivedCards}
+        onDismiss={onDismiss}
+      />
       <StoreAside close={() => setSelectedPack(null)} title="Selected Pack">
-        <StyledStoreBody style={{ padding: 0, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+        <StyledStoreBody
+          style={{
+            padding: 0,
+            overflow: "hidden",
+            display: "flex",
+            flexDirection: "column",
+          }}
+        >
           <AsideContent>
-            <ScrollableContent style={{ padding: '1.1em' }}>
-              <Title as="h2" font={theme.font.neometric} size='m'>{selectedPack.name}</Title>
-              <Spacer size="sm"/>
-              <Text as="p" font={theme.font.inter} size='s' lineHeight={1.3} color={theme.color.gray[600]}>
-                When claiming this booster pack you will receive {selectedPack.cardsPerPack} random cards.
+            <StickyTop style={{ padding: "1.1em 1.1em 0.6em" }}>
+              <Title as="h2" font={theme.font.neometric} size="m">
+                {selectedPack.name}
+              </Title>
+              <Spacer size="sm" />
+              <Text
+                as="p"
+                font={theme.font.inter}
+                size="s"
+                lineHeight={1.3}
+                color={theme.color.gray[600]}
+              >
+                When claiming this booster pack you will receive{" "}
+                {selectedPack.cardsPerPack} random cards.
               </Text>
-              <Spacer size="sm"/>
-              <img loading="lazy" src={selectedPack.url} alt={selectedPack.name} style={{ width: '100%', display: 'block' }}/>
-            </ScrollableContent>
-            <StickyBottom style={{ padding: '0 1.1em 1.1em' }}>
+              <Spacer size="sm" />
               {renderClaimArea()}
-            </StickyBottom>
+            </StickyTop>
+            <ScrollableContent style={{ padding: "1.1em" }}>
+              <img
+                loading="lazy"
+                src={selectedPack.url}
+                alt={selectedPack.name}
+                style={{ width: "100%", display: "block" }}
+              />
+            </ScrollableContent>
           </AsideContent>
         </StyledStoreBody>
       </StoreAside>

--- a/packages/app/src/views/Store/components/StorePacksCollection.tsx
+++ b/packages/app/src/views/Store/components/StorePacksCollection.tsx
@@ -1,43 +1,54 @@
-import React, { useEffect, useState, useContext } from 'react';
-import { Title, Spacer } from '../../../components';
-import { PepemonProviderContext } from '../../../contexts';
-import { packs } from '../../../constants';
-import { theme } from '../../../theme';
+import React, { useEffect, useState, useContext } from "react";
+import { Title, Spacer } from "../../../components";
+import { PepemonProviderContext } from "../../../contexts";
+import { packs } from "../../../constants";
+import { theme } from "../../../theme";
 // import { useCardsMetadata, useCardsFactoryData, useCardsStorePrices, useApprove, useAllowance, useTokenBalance } from '../../../hooks';
-import { PackSingle, StyledStoreCardsInner } from '../components';
+import { PackSingle, StyledStoreCardsInner } from "../components";
 
-const StorePacksCollection : React.FC<any> = ({selectedPack, setSelectedPack}) => {
-	const [pepemon] = useContext(PepemonProviderContext);
-	const { chainId } = pepemon;
-	const [activeSeries, setActiveSeries] = useState([]);
+const StorePacksCollection: React.FC<any> = ({
+  selectedPack,
+  setSelectedPack,
+}) => {
+  const [pepemon] = useContext(PepemonProviderContext);
+  const { chainId } = pepemon;
+  const [activeSeries, setActiveSeries] = useState([]);
 
-	useEffect(() => {
-		const effectiveChainId = chainId || 1;
-		setActiveSeries(packs.get(effectiveChainId) || []);
-		// TODO: Handle url to switch actice cards to boosterpacks
-	},[chainId])
+  useEffect(() => {
+    const effectiveChainId = chainId || 1;
+    setActiveSeries(packs.get(effectiveChainId) || []);
+    // TODO: Handle url to switch actice cards to boosterpacks
+  }, [chainId]);
 
-	return (
-		<>{activeSeries.map((activeSerie, key) => {
-			return (
-				<div key={key}>
-					<Title as="h3" size='m' font={theme.font.spaceMace}>{activeSerie.title}</Title>
-					<Spacer size="md"/>
-					<StyledStoreCardsInner gridCols={selectedPack ? 3 : 5}>
-						{activeSerie.packs.map((pack, key) => {
-							return <PackSingle key={key}
-										packId={`${activeSerie.title_formatted}_${key}`}
-										selectedPack={selectedPack}
-										selectPack={setSelectedPack}
-										chainId={chainId}
-										packMeta={pack}/>
-						})}
-					</StyledStoreCardsInner>
-					<Spacer size="md"/>
-				</div>
-			)
-		})}</>
-	)
-}
+  return (
+    <>
+      {activeSeries.map((activeSerie, key) => {
+        return (
+          <div key={key}>
+            <Title as="h3" size="m" font={theme.font.spaceMace}>
+              {activeSerie.title}
+            </Title>
+            <Spacer size="md" />
+            <StyledStoreCardsInner gridCols={selectedPack ? 3 : 5}>
+              {activeSerie.packs.map((pack, key) => {
+                return (
+                  <PackSingle
+                    key={key}
+                    packId={`${activeSerie.title_formatted}_${key}`}
+                    selectedPack={selectedPack}
+                    selectPack={setSelectedPack}
+                    chainId={chainId}
+                    packMeta={pack}
+                  />
+                );
+              })}
+            </StyledStoreCardsInner>
+            <Spacer size="md" />
+          </div>
+        );
+      })}
+    </>
+  );
+};
 
 export default StorePacksCollection;

--- a/packages/app/src/views/Store/components/StoreSelection.tsx
+++ b/packages/app/src/views/Store/components/StoreSelection.tsx
@@ -1,29 +1,25 @@
 import React from "react";
-import styled from 'styled-components';
+import styled from "styled-components";
 
-const StoreSelectionWrapper: React.FC<any> = ({children}) => {
-	return (
-		<StyledStoreSelectionWrapper>
-			{children}
-		</StyledStoreSelectionWrapper>
-	)
-}
+const StoreSelectionWrapper: React.FC<any> = ({ children }) => {
+  return <StyledStoreSelectionWrapper>{children}</StyledStoreSelectionWrapper>;
+};
 
 const StyledStoreSelectionWrapper = styled.div`
-	display: flex;
-	color: ${props => props.theme.color.purple[600]};
-	position: absolute;
-	font-family: ${props => props.theme.font.inter};
-	top: 1.1em;
-	right: 1.1em;
-	font-size: .9rem;
-	align-items: center;
+  display: flex;
+  color: ${(props) => props.theme.color.purple[600]};
+  position: absolute;
+  font-family: ${(props) => props.theme.font.inter};
+  top: 1.1em;
+  right: 1.1em;
+  font-size: 0.9rem;
+  align-items: center;
 
-	> button {
-		margin-right: 1.2em;
-		font-size: 0.625rem;
-		text-decoration: none;
-	}
+  > button {
+    margin-right: 1.2em;
+    font-size: 0.625rem;
+    text-decoration: none;
+  }
 `;
 
 export default StoreSelectionWrapper;

--- a/packages/app/src/views/Store/components/StyledStoreComponents.tsx
+++ b/packages/app/src/views/Store/components/StyledStoreComponents.tsx
@@ -1,18 +1,23 @@
-import styled from 'styled-components';
-import { theme } from '../../../theme';
+import styled from "styled-components";
+import { theme } from "../../../theme";
 
-export const StyledStoreWrapper = styled.div<{width?: string, itemSelected?: any}>`
-    color: ${props => props.theme.color.black};
+export const StyledStoreWrapper = styled.div<{
+  width?: string;
+  itemSelected?: any;
+}>`
+  color: ${(props) => props.theme.color.black};
 
-	@media (min-width: ${theme.breakpoints.tabletL}) {
-		max-width: ${props => props.width && props.width};
-	}
+  @media (min-width: ${theme.breakpoints.tabletL}) {
+    max-width: ${(props) => props.width && props.width};
+  }
 
-	@media (min-width: 575px) and (max-width: ${theme.breakpoints.tabletL}) {
-		min-height: 1000px;
-	}
+  @media (min-width: 575px) and (max-width: ${theme.breakpoints.tabletL}) {
+    min-height: 1000px;
+  }
 
-	${props => props.itemSelected && `
+  ${(props) =>
+    props.itemSelected &&
+    `
 		&:first-child::after {
 			@media (max-width: ${theme.breakpoints.tabletL}) {
 				background-color: ${theme.color.layoutOverlay};
@@ -29,69 +34,69 @@ export const StyledStoreWrapper = styled.div<{width?: string, itemSelected?: any
 		}
 	`}
 
-    &:last-child:not(:first-child) {
-		position: absolute;
-		z-index: 2;
+  &:last-child:not(:first-child) {
+    position: absolute;
+    z-index: 2;
 
-		@media (min-width: ${theme.breakpoints.mobileS}) {
-			left: 50%;
-			max-width: 100%;
-			transform: translateX(-50%);
-			width: ${theme.breakpoints.mobileS};
-		}
-
-		@media (min-width: ${theme.breakpoints.tabletL}) {
-			left: 0;
-			margin-left: 1em;
-			position: relative;
-			transform: translateX(0);
-		}
+    @media (min-width: ${theme.breakpoints.mobileS}) {
+      left: 50%;
+      max-width: 100%;
+      transform: translateX(-50%);
+      width: ${theme.breakpoints.mobileS};
     }
-`
-
-export const StyledStoreHeader = styled.div`
-    background-color: ${(props) => props.theme.color.purple[800]};
-    color:  ${(props) => props.theme.color.white};
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 1.1em;
-    border-top-left-radius: 16px;
-    border-top-right-radius: 16px;
-`
-
-export const StyledStoreBody = styled.div`
-    position: relative;
-    background-color: ${props => props.theme.color.white};
-    padding: 1.1em;
-    border-bottom-left-radius: ${theme.borderRadius}px;;
-    border-bottom-right-radius: ${theme.borderRadius}px;
 
     @media (min-width: ${theme.breakpoints.tabletL}) {
-        flex: 1;
-        min-height: 0;
-        overflow-y: auto;
+      left: 0;
+      margin-left: 1em;
+      position: relative;
+      transform: translateX(0);
     }
-`
+  }
+`;
+
+export const StyledStoreHeader = styled.div`
+  background-color: ${(props) => props.theme.color.purple[800]};
+  color: ${(props) => props.theme.color.white};
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.1em;
+  border-top-left-radius: 16px;
+  border-top-right-radius: 16px;
+`;
+
+export const StyledStoreBody = styled.div`
+  position: relative;
+  background-color: ${(props) => props.theme.color.white};
+  padding: 1.1em;
+  border-bottom-left-radius: ${theme.borderRadius}px;
+  border-bottom-right-radius: ${theme.borderRadius}px;
+
+  @media (min-width: ${theme.breakpoints.tabletL}) {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+  }
+`;
 
 export const StyledStoreCardsWrapper = styled.div`
-	@media (max-width: ${theme.breakpoints.mobile}) {
-		margin-top: 3em;
-	}
-`
+  @media (max-width: ${theme.breakpoints.mobile}) {
+    margin-top: 3em;
+  }
+`;
 
-export const StyledStoreCardsInner = styled.div<{gridCols: number}>`
-	display: grid;
-	grid-column-gap: 1rem;
-	grid-row-gap: 2rem;
-	grid-template-columns: repeat(2, 1fr);
-	overflow: visible;
+export const StyledStoreCardsInner = styled.div<{ gridCols: number }>`
+  display: grid;
+  grid-column-gap: 1rem;
+  grid-row-gap: 2rem;
+  grid-template-columns: repeat(2, 1fr);
+  overflow: visible;
 
-	@media (min-width: ${theme.breakpoints.mobile}) {
-		grid-template-columns: repeat(3, 1fr);
-	}
+  @media (min-width: ${theme.breakpoints.mobile}) {
+    grid-template-columns: repeat(3, 1fr);
+  }
 
-	@media (min-width: ${theme.breakpoints.tabletL}) {
-		grid-template-columns: repeat(${props => props.gridCols}, 1fr);
-	}
-`
+  @media (min-width: ${theme.breakpoints.tabletL}) {
+    grid-template-columns: repeat(${(props) => props.gridCols}, 1fr);
+  }
+`;

--- a/packages/app/src/views/Store/components/index.ts
+++ b/packages/app/src/views/Store/components/index.ts
@@ -1,10 +1,20 @@
-export { default as CardSingle, StyledPepemonCardMeta, StyledPepemonCardPrice } from './CardSingle';
-export { default as PackSingle } from './PackSingle';
-export { default as StoreAside } from './StoreAside';
-export { default as StoreCard } from './StoreCard';
-export { default as StoreCardsAside } from './StoreCardsAside';
-export { default as StoreCardsCollection } from './StoreCardsCollection';
-export { default as StorePacksAside } from './StorePacksAside';
-export { default as StorePacksCollection } from './StorePacksCollection';
-export { default as StoreSelectionWrapper } from './StoreSelection';
-export { StyledStoreWrapper, StyledStoreHeader, StyledStoreBody, StyledStoreCardsWrapper, StyledStoreCardsInner } from './StyledStoreComponents';
+export {
+  default as CardSingle,
+  StyledPepemonCardMeta,
+  StyledPepemonCardPrice,
+} from "./CardSingle";
+export { default as PackSingle } from "./PackSingle";
+export { default as StoreAside } from "./StoreAside";
+export { default as StoreCard } from "./StoreCard";
+export { default as StoreCardsAside } from "./StoreCardsAside";
+export { default as StoreCardsCollection } from "./StoreCardsCollection";
+export { default as StorePacksAside } from "./StorePacksAside";
+export { default as StorePacksCollection } from "./StorePacksCollection";
+export { default as StoreSelectionWrapper } from "./StoreSelection";
+export {
+  StyledStoreWrapper,
+  StyledStoreHeader,
+  StyledStoreBody,
+  StyledStoreCardsWrapper,
+  StyledStoreCardsInner,
+} from "./StyledStoreComponents";

--- a/packages/app/src/views/Store/index.ts
+++ b/packages/app/src/views/Store/index.ts
@@ -1,1 +1,1 @@
-export { default, storeMeta } from './Store'
+export { default, storeMeta } from "./Store";

--- a/packages/app/src/views/Subscription/Subscription.tsx
+++ b/packages/app/src/views/Subscription/Subscription.tsx
@@ -1,18 +1,19 @@
-import React from 'react'
-import { DefaultPage } from '../../components';
-import SubscriptionCard from './components/SubscriptionCard';
+import React from "react";
+import { DefaultPage } from "../../components";
+import SubscriptionCard from "./components/SubscriptionCard";
 
 export const subscriptionMeta = {
-	title:'Pepemon! NFT Subscription',
-	description: "Pepemon One NFT subscription is the best way not to miss out on any exclusive Collector's Edition NFTs and secure NFT drops every month."
-}
+  title: "Pepemon! NFT Subscription",
+  description:
+    "Pepemon One NFT subscription is the best way not to miss out on any exclusive Collector's Edition NFTs and secure NFT drops every month.",
+};
 
 const Subscription: React.FC<any> = () => {
-	return (
-		<DefaultPage title='Subscription'>
-			<SubscriptionCard/>
-		</DefaultPage>
-	)
-}
+  return (
+    <DefaultPage title="Subscription">
+      <SubscriptionCard />
+    </DefaultPage>
+  );
+};
 
 export default Subscription;

--- a/packages/app/src/views/Subscription/components/SubscriptionCard.tsx
+++ b/packages/app/src/views/Subscription/components/SubscriptionCard.tsx
@@ -1,14 +1,17 @@
-import React from 'react'
+import React from "react";
 import { AccordionGroup } from "../../../components";
-import { PepemonOneSubscription, PepemonOneAnniversarySet } from "../subscriptions";
+import {
+  PepemonOneSubscription,
+  PepemonOneAnniversarySet,
+} from "../subscriptions";
 
 const SubscriptionCard: React.FC<any> = () => {
-    return (
-		<AccordionGroup>
-			<PepemonOneAnniversarySet/>
-			<PepemonOneSubscription/>
-		</AccordionGroup>
-    )
-}
+  return (
+    <AccordionGroup>
+      <PepemonOneAnniversarySet />
+      <PepemonOneSubscription />
+    </AccordionGroup>
+  );
+};
 
-export default SubscriptionCard
+export default SubscriptionCard;

--- a/packages/app/src/views/Subscription/index.ts
+++ b/packages/app/src/views/Subscription/index.ts
@@ -1,1 +1,1 @@
-export { default, subscriptionMeta } from './Subscription'
+export { default, subscriptionMeta } from "./Subscription";

--- a/packages/app/src/views/Subscription/subscriptions/PepemonOneAnniversarySet/CardToClaim/CardToClaim.tsx
+++ b/packages/app/src/views/Subscription/subscriptions/PepemonOneAnniversarySet/CardToClaim/CardToClaim.tsx
@@ -1,73 +1,111 @@
 import React, { useContext } from "react";
 import styled from "styled-components";
-import { Button, Spacer, Title, Text } from '../../../../../components';
-import { theme } from '../../../../../theme';
-import { PepemonProviderContext } from '../../../../../contexts';
-import { usePepemonApi, useIsClaimedMerkle, useClaimMerkle } from '../../../../../hooks';
+import { Button, Spacer, Title, Text } from "../../../../../components";
+import { theme } from "../../../../../theme";
+import { PepemonProviderContext } from "../../../../../contexts";
+import {
+  usePepemonApi,
+  useIsClaimedMerkle,
+  useClaimMerkle,
+} from "../../../../../hooks";
 
 interface CardToClaimProps {
-	title: string,
-	text: string,
-	img: {
-		url: string,
-		title: string
-	}
-	tokenId: number
+  title: string;
+  text: string;
+  img: {
+    url: string;
+    title: string;
+  };
+  tokenId: number;
 }
 
-const CardToClaim: React.FC<CardToClaimProps> = ({title, text, tokenId, img}) => {
-	const merkleType = 'distributor';
-	const [pepemon] = useContext(PepemonProviderContext);
-	const { account } = pepemon;
-	const { response, isFetching } = usePepemonApi(`/merkle/${tokenId}/${account}`);
-	const canClaim = response && response.index;
+const CardToClaim: React.FC<CardToClaimProps> = ({
+  title,
+  text,
+  tokenId,
+  img,
+}) => {
+  const merkleType = "distributor";
+  const [pepemon] = useContext(PepemonProviderContext);
+  const { account } = pepemon;
+  const { response, isFetching } = usePepemonApi(
+    `/merkle/${tokenId}/${account}`
+  );
+  const canClaim = response && response.index;
 
-	// @dev for more info: https://etherscan.io/address/0x78a285dcd2AD742d8D4ACC33C3a279f44d842e13#readContract
-	const isClaimed = useIsClaimedMerkle( (response && response.index) &&
-		response.index,
-		merkleType,
-		tokenId,
-	);
+  // @dev for more info: https://etherscan.io/address/0x78a285dcd2AD742d8D4ACC33C3a279f44d842e13#readContract
+  const isClaimed = useIsClaimedMerkle(
+    response && response.index && response.index,
+    merkleType,
+    tokenId
+  );
 
-	// @dev for more info: https://etherscan.io/address/0x78a285dcd2AD742d8D4ACC33C3a279f44d842e13#writeContract
-	const { onClaimMerkle, isClaiming } = useClaimMerkle( response && response.index ? {
-		account,
-		index: response.index,
-		amount: parseInt(response.amount),
-		proof: response.proof,
-	} : null, merkleType, tokenId);
+  // @dev for more info: https://etherscan.io/address/0x78a285dcd2AD742d8D4ACC33C3a279f44d842e13#writeContract
+  const { onClaimMerkle, isClaiming } = useClaimMerkle(
+    response && response.index
+      ? {
+          account,
+          index: response.index,
+          amount: parseInt(response.amount),
+          proof: response.proof,
+        }
+      : null,
+    merkleType,
+    tokenId
+  );
 
-	const isDisabled = !account || isFetching || !canClaim || isClaiming;
+  const isDisabled = !account || isFetching || !canClaim || isClaiming;
 
-	return (
-		<CardToClaimWrapper>
-			<Title as="h3" size='xxs' weight={900} font={theme.font.neometric}>{title}</Title>
-			<Spacer size="sm"/>
-			<StyledFigure>
-			  <img loading='lazy' src={img.url} alt={img.title} title={img.title}/>
-			  <figcaption><Text as="p" size='s' lineHeight={1.125} align="center" color={theme.color.gray[300]}>{text}</Text></figcaption>
-			</StyledFigure>
-			<Spacer size="sm"/>
-			<Button width="100%" styling="purple" style={{marginTop: "auto"}}
-			onClick={onClaimMerkle} disabled={isDisabled || isClaimed}
-			>{
-				isFetching ? 'Checking...'
-				: isClaimed ? 'Already claimed'
-				: isClaiming ? 'Claiming...'
-				: canClaim ? 'Claim' : "Can't claim"
-			}</Button>
-		</CardToClaimWrapper>
-	)
-}
+  return (
+    <CardToClaimWrapper>
+      <Title as="h3" size="xxs" weight={900} font={theme.font.neometric}>
+        {title}
+      </Title>
+      <Spacer size="sm" />
+      <StyledFigure>
+        <img loading="lazy" src={img.url} alt={img.title} title={img.title} />
+        <figcaption>
+          <Text
+            as="p"
+            size="s"
+            lineHeight={1.125}
+            align="center"
+            color={theme.color.gray[300]}
+          >
+            {text}
+          </Text>
+        </figcaption>
+      </StyledFigure>
+      <Spacer size="sm" />
+      <Button
+        width="100%"
+        styling="purple"
+        style={{ marginTop: "auto" }}
+        onClick={onClaimMerkle}
+        disabled={isDisabled || isClaimed}
+      >
+        {isFetching
+          ? "Checking..."
+          : isClaimed
+          ? "Already claimed"
+          : isClaiming
+          ? "Claiming..."
+          : canClaim
+          ? "Claim"
+          : "Can't claim"}
+      </Button>
+    </CardToClaimWrapper>
+  );
+};
 
 const CardToClaimWrapper = styled.div`
-	display: flex;
-	flex-direction: column;
-	height: 100%;
-`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+`;
 
 const StyledFigure = styled.figure`
-	margin: 0;
-`
+  margin: 0;
+`;
 
 export default CardToClaim;

--- a/packages/app/src/views/Subscription/subscriptions/PepemonOneAnniversarySet/CardToClaim/index.ts
+++ b/packages/app/src/views/Subscription/subscriptions/PepemonOneAnniversarySet/CardToClaim/index.ts
@@ -1,1 +1,1 @@
-export { default as CardToClaim } from './CardToClaim';
+export { default as CardToClaim } from "./CardToClaim";

--- a/packages/app/src/views/Subscription/subscriptions/PepemonOneAnniversarySet/index.ts
+++ b/packages/app/src/views/Subscription/subscriptions/PepemonOneAnniversarySet/index.ts
@@ -1,1 +1,1 @@
-export { default } from './PepemonOneAnniversarySet';
+export { default } from "./PepemonOneAnniversarySet";

--- a/packages/app/src/views/Subscription/subscriptions/PepemonOneSubscription/PepemonOneSubscription.tsx
+++ b/packages/app/src/views/Subscription/subscriptions/PepemonOneSubscription/PepemonOneSubscription.tsx
@@ -1,139 +1,298 @@
-import React, { useState, useContext, useEffect } from 'react'
-import BigNumber from 'bignumber.js';
-import { Accordion, AccordionBodyContent, Spacer, Button, Text, ContentColumns, ContentColumn, ExternalLink } from '../../../../components';
-import { PepemonProviderContext } from '../../../../contexts';
-import { getCardMeta, useTokenBalance, useApprove, useAllowance, useLotteryMinLPTokens, useLotteryRewardCard, useLotteryLPBalance, useLotteryIsStaking, useLotteryHasClaimed, useLotteryStakingDeadline, useLotteryStakingStartblock, useLotteryClaim, useLotteryWithdraw, useLotteryStake, useBlock, useWeb3Modal } from '../../../../hooks';
-import { getPepemonLotteryContract, getPpdexAddress, getPpdexUniV2Contract, getUniV2PpdexAddress } from '../../../../pepemon/utils';
-import { getBalanceNumber } from '../../../../utils';
-import { cardback_normal } from '../../../../assets';
-import { theme } from '../../../../theme';
+import React, { useState, useContext, useEffect } from "react";
+import BigNumber from "bignumber.js";
+import {
+  Accordion,
+  AccordionBodyContent,
+  Spacer,
+  Button,
+  Text,
+  ContentColumns,
+  ContentColumn,
+  ExternalLink,
+} from "../../../../components";
+import { PepemonProviderContext } from "../../../../contexts";
+import {
+  getCardMeta,
+  useTokenBalance,
+  useApprove,
+  useAllowance,
+  useLotteryMinLPTokens,
+  useLotteryRewardCard,
+  useLotteryLPBalance,
+  useLotteryIsStaking,
+  useLotteryHasClaimed,
+  useLotteryStakingDeadline,
+  useLotteryStakingStartblock,
+  useLotteryClaim,
+  useLotteryWithdraw,
+  useLotteryStake,
+  useBlock,
+  useWeb3Modal,
+} from "../../../../hooks";
+import {
+  getPepemonLotteryContract,
+  getPpdexAddress,
+  getPpdexUniV2Contract,
+  getUniV2PpdexAddress,
+} from "../../../../pepemon/utils";
+import { getBalanceNumber } from "../../../../utils";
+import { cardback_normal } from "../../../../assets";
+import { theme } from "../../../../theme";
 
 const PepemonOneSubscription: React.FC<any> = () => {
-	const [pepemon] = useContext(PepemonProviderContext);
-	const { account } = pepemon;
-	const [, loadWeb3Modal] = useWeb3Modal();
-    const ppdexUniV2Balance = useTokenBalance(getUniV2PpdexAddress(pepemon));
-    const [transaction, setTransaction] = useState(0);
-    const { onApprove, isApproving } = useApprove(getPepemonLotteryContract(pepemon), getPpdexUniV2Contract(pepemon));
-    const { onLotteryStake, isJoining } = useLotteryStake();
-    const { onLotteryWithdraw, isWithdrawing } = useLotteryWithdraw();
-    const { onLotteryClaim, isClaiming } = useLotteryClaim();
-    const blockNumber = useBlock();
-    const lockedPeriod = 208000;
-    const allowance = useAllowance(getPepemonLotteryContract(pepemon), getPpdexUniV2Contract(pepemon));
-    const minLPTokens: BigNumber = useLotteryMinLPTokens();
-    const isStaking = useLotteryIsStaking(transaction);
-    const stakedBalance = useLotteryLPBalance(transaction);
-    const rewardCard = useLotteryRewardCard();
-	const [cardMeta, setCardMeta] = useState(null)
-	useEffect(() => {(async () => {
-			setCardMeta(await getCardMeta(parseFloat(rewardCard || 0 ), pepemon))
-		})()
-	}, [rewardCard, pepemon]);
-    const stakingDeadline = useLotteryStakingDeadline();
-    const stakingStart = useLotteryStakingStartblock(transaction);
-    const hasClaimed = useLotteryHasClaimed(rewardCard, transaction);
-    const lockedBlocks = (parseFloat(stakingStart) + lockedPeriod) - blockNumber;
-    const canClaimCurrentCard = () => {
-        return stakingDeadline > stakingStart;
-    }
+  const [pepemon] = useContext(PepemonProviderContext);
+  const { account } = pepemon;
+  const [, loadWeb3Modal] = useWeb3Modal();
+  const ppdexUniV2Balance = useTokenBalance(getUniV2PpdexAddress(pepemon));
+  const [transaction, setTransaction] = useState(0);
+  const { onApprove, isApproving } = useApprove(
+    getPepemonLotteryContract(pepemon),
+    getPpdexUniV2Contract(pepemon)
+  );
+  const { onLotteryStake, isJoining } = useLotteryStake();
+  const { onLotteryWithdraw, isWithdrawing } = useLotteryWithdraw();
+  const { onLotteryClaim, isClaiming } = useLotteryClaim();
+  const blockNumber = useBlock();
+  const lockedPeriod = 208000;
+  const allowance = useAllowance(
+    getPepemonLotteryContract(pepemon),
+    getPpdexUniV2Contract(pepemon)
+  );
+  const minLPTokens: BigNumber = useLotteryMinLPTokens();
+  const isStaking = useLotteryIsStaking(transaction);
+  const stakedBalance = useLotteryLPBalance(transaction);
+  const rewardCard = useLotteryRewardCard();
+  const [cardMeta, setCardMeta] = useState(null);
+  useEffect(() => {
+    (async () => {
+      setCardMeta(await getCardMeta(parseFloat(rewardCard || 0), pepemon));
+    })();
+  }, [rewardCard, pepemon]);
+  const stakingDeadline = useLotteryStakingDeadline();
+  const stakingStart = useLotteryStakingStartblock(transaction);
+  const hasClaimed = useLotteryHasClaimed(rewardCard, transaction);
+  const lockedBlocks = parseFloat(stakingStart) + lockedPeriod - blockNumber;
+  const canClaimCurrentCard = () => {
+    return stakingDeadline > stakingStart;
+  };
 
-	return (
-		<Accordion title='Pepemon One Subscription' isActive={isStaking}>
-			<AccordionBodyContent side="left">
-				<Text as="p" size='s' lineHeight={1.125}>
-					Get Exclusive NFTs! Provide 100 PPDEX (+ETH) on Uniswap LP, stake these LP tokens and recieve a unique NFT every month. Your LP tokens will be locked for a minimum 32 days.
-				</Text>
-				<Spacer size="lg"/>
-				<ContentColumns>
-					<ContentColumn width="50%">
-						<Text as="p" lineHeight={1}>PPDEX-ETH LP balance</Text>
-						<Spacer size="sm"/>
-						<Text as="p" size='xxl' weight={900} lineHeight={1} font={theme.font.neometric}>
-							{parseFloat(getBalanceNumber(ppdexUniV2Balance).toString()).toFixed(2)}
-						</Text>
-						<Spacer size="md"/>
-						<Text as="p" lineHeight={1}>PPDEX-ETH LP staked</Text>
-						<Spacer size="sm"/>
-						<Text as="p" size='xxl' weight={900} lineHeight={1} font={theme.font.neometric}>
-							{parseFloat(getBalanceNumber(stakedBalance).toString()).toFixed(2)}
-						</Text>
-					</ContentColumn>
-					<ContentColumn width="50%">
-						<ExternalLink href={`https://app.uniswap.org/#/add/v2/ETH/${getPpdexAddress(pepemon)}`}>Provide PPDEX-ETH LP liquidity</ExternalLink>
-					</ContentColumn>
-				</ContentColumns>
-				<Spacer size="md"/>
-				{ isStaking &&
-					<>
-						<Text as="p" size='xxl' lineHeight={1.1} color={theme.color.purple[600]} weight={900} font={theme.font.neometric}>
-							You have an active <wbr/>subscription!
-						</Text>
-						<Spacer size="md"/>
-					</>
-				}
-					<div style={{ display: "inline-flex", flexDirection: "column" }}>
-						{ !isStaking &&
-							<>
-								<Text as="p" size='s'>
-									{ minLPTokens ?
-										`${parseFloat(parseFloat((getBalanceNumber(minLPTokens) + 0.01).toString()).toPrecision(3))} PPDEX-ETH LP needed to subscribe` :
-										'loading...'
-									}
-								</Text>
-								<Spacer size="sm"/>
-							</>
-						}
-						{allowance.comparedTo(minLPTokens) === -1 ?
-							<Button disabled={!account ? false : isApproving} size="sm" styling="purple" onClick={!account ? loadWeb3Modal : onApprove}>
-								{!account ? 'Connect wallet' : isApproving ? 'Approving...' : 'Approve LP'}
-							</Button>
-						: isStaking ?
-							<Button disabled={isWithdrawing || (lockedBlocks > 0)} size="sm" styling="purple" onClick={() => onLotteryWithdraw().then(() => setTransaction(transaction + 1))}>
-								{(lockedBlocks > 0) ? 'Locked' : isWithdrawing ? 'Unsubscribing...' : 'Unsubscribe'}
-							</Button>
-						:
-							<Button disabled={!account ? false : (minLPTokens && ppdexUniV2Balance.comparedTo(minLPTokens) === -1) || isJoining || isStaking} size="sm" styling="purple" onClick={!account ? loadWeb3Modal : () => onLotteryStake().then(() => setTransaction(transaction + 1))}>
-								{!account ? 'Connect wallet' : isStaking ? 'Active' : (minLPTokens && ppdexUniV2Balance.comparedTo(minLPTokens) === -1) ? 'Insufficient LP' : isJoining ? 'Staking...' : 'Subscribe & Stake LP'}
-							</Button>
-						}
-					</div>
-				<Spacer size="md"/>
-			</AccordionBodyContent>
+  return (
+    <Accordion title="Pepemon One Subscription" isActive={isStaking}>
+      <AccordionBodyContent side="left">
+        <Text as="p" size="s" lineHeight={1.125}>
+          Get Exclusive NFTs! Provide 100 PPDEX (+ETH) on Uniswap LP, stake
+          these LP tokens and recieve a unique NFT every month. Your LP tokens
+          will be locked for a minimum 32 days.
+        </Text>
+        <Spacer size="lg" />
+        <ContentColumns>
+          <ContentColumn width="50%">
+            <Text as="p" lineHeight={1}>
+              PPDEX-ETH LP balance
+            </Text>
+            <Spacer size="sm" />
+            <Text
+              as="p"
+              size="xxl"
+              weight={900}
+              lineHeight={1}
+              font={theme.font.neometric}
+            >
+              {parseFloat(
+                getBalanceNumber(ppdexUniV2Balance).toString()
+              ).toFixed(2)}
+            </Text>
+            <Spacer size="md" />
+            <Text as="p" lineHeight={1}>
+              PPDEX-ETH LP staked
+            </Text>
+            <Spacer size="sm" />
+            <Text
+              as="p"
+              size="xxl"
+              weight={900}
+              lineHeight={1}
+              font={theme.font.neometric}
+            >
+              {parseFloat(getBalanceNumber(stakedBalance).toString()).toFixed(
+                2
+              )}
+            </Text>
+          </ContentColumn>
+          <ContentColumn width="50%">
+            <ExternalLink
+              href={`https://app.uniswap.org/#/add/v2/ETH/${getPpdexAddress(
+                pepemon
+              )}`}
+            >
+              Provide PPDEX-ETH LP liquidity
+            </ExternalLink>
+          </ContentColumn>
+        </ContentColumns>
+        <Spacer size="md" />
+        {isStaking && (
+          <>
+            <Text
+              as="p"
+              size="xxl"
+              lineHeight={1.1}
+              color={theme.color.purple[600]}
+              weight={900}
+              font={theme.font.neometric}
+            >
+              You have an active <wbr />
+              subscription!
+            </Text>
+            <Spacer size="md" />
+          </>
+        )}
+        <div style={{ display: "inline-flex", flexDirection: "column" }}>
+          {!isStaking && (
+            <>
+              <Text as="p" size="s">
+                {minLPTokens
+                  ? `${parseFloat(
+                      parseFloat(
+                        (getBalanceNumber(minLPTokens) + 0.01).toString()
+                      ).toPrecision(3)
+                    )} PPDEX-ETH LP needed to subscribe`
+                  : "loading..."}
+              </Text>
+              <Spacer size="sm" />
+            </>
+          )}
+          {allowance.comparedTo(minLPTokens) === -1 ? (
+            <Button
+              disabled={!account ? false : isApproving}
+              size="sm"
+              styling="purple"
+              onClick={!account ? loadWeb3Modal : onApprove}
+            >
+              {!account
+                ? "Connect wallet"
+                : isApproving
+                ? "Approving..."
+                : "Approve LP"}
+            </Button>
+          ) : isStaking ? (
+            <Button
+              disabled={isWithdrawing || lockedBlocks > 0}
+              size="sm"
+              styling="purple"
+              onClick={() =>
+                onLotteryWithdraw().then(() => setTransaction(transaction + 1))
+              }
+            >
+              {lockedBlocks > 0
+                ? "Locked"
+                : isWithdrawing
+                ? "Unsubscribing..."
+                : "Unsubscribe"}
+            </Button>
+          ) : (
+            <Button
+              disabled={
+                !account
+                  ? false
+                  : (minLPTokens &&
+                      ppdexUniV2Balance.comparedTo(minLPTokens) === -1) ||
+                    isJoining ||
+                    isStaking
+              }
+              size="sm"
+              styling="purple"
+              onClick={
+                !account
+                  ? loadWeb3Modal
+                  : () =>
+                      onLotteryStake().then(() =>
+                        setTransaction(transaction + 1)
+                      )
+              }
+            >
+              {!account
+                ? "Connect wallet"
+                : isStaking
+                ? "Active"
+                : minLPTokens &&
+                  ppdexUniV2Balance.comparedTo(minLPTokens) === -1
+                ? "Insufficient LP"
+                : isJoining
+                ? "Staking..."
+                : "Subscribe & Stake LP"}
+            </Button>
+          )}
+        </div>
+        <Spacer size="md" />
+      </AccordionBodyContent>
 
-			<AccordionBodyContent side="right">
-				<div>
-					<Text as="p" size='xs' color={theme.color.gray[400]} txtTransform="uppercase">This months card:</Text>
-					<Spacer size="md"/>
-					<Text as="p" size='l' color={theme.color.headers} weight={900} font={theme.font.neometric}>{cardMeta ? cardMeta.name : 'Loading card title...'}</Text>
-					<Spacer size="sm"/>
-					<Text as="p" size='s' color={theme.color.headers}>
-						{cardMeta ? cardMeta.description : 'Loading card description...'}
-					</Text>
-					<Spacer size="sm"/>
-					<img src={cardMeta ? cardMeta.image : cardback_normal} alt={cardMeta ? cardMeta.name : 'Loading card...'}/>
-					<Spacer size="md"/>
-					{ isStaking ?
-						<>
-							{ canClaimCurrentCard() ?
-								<Button disabled={hasClaimed || isClaiming} styling="purple" width="100%" onClick={() => onLotteryClaim().then(() => setTransaction(transaction + 1))}>
-									{hasClaimed ? 'Already claimed' : (isClaiming ? 'Claiming...' : 'Claim card')}
-								</Button>
-								:
-								<Button disabled styling="white_borderless" width="100%">
-									Not eligible
-								</Button>
-							}
-						</>
-						:
-						<Button disabled={!account ? false : true} styling={!account ? "purple" : "white_borderless"} width="100%" onClick={!account ? loadWeb3Modal : undefined}>
-							{!account ? 'Connect wallet' : 'Subscribe to claim'}
-						</Button>
-					}
-				</div>
-			</AccordionBodyContent>
-		</Accordion>
-	)
-}
+      <AccordionBodyContent side="right">
+        <div>
+          <Text
+            as="p"
+            size="xs"
+            color={theme.color.gray[400]}
+            txtTransform="uppercase"
+          >
+            This months card:
+          </Text>
+          <Spacer size="md" />
+          <Text
+            as="p"
+            size="l"
+            color={theme.color.headers}
+            weight={900}
+            font={theme.font.neometric}
+          >
+            {cardMeta ? cardMeta.name : "Loading card title..."}
+          </Text>
+          <Spacer size="sm" />
+          <Text as="p" size="s" color={theme.color.headers}>
+            {cardMeta ? cardMeta.description : "Loading card description..."}
+          </Text>
+          <Spacer size="sm" />
+          <img
+            src={cardMeta ? cardMeta.image : cardback_normal}
+            alt={cardMeta ? cardMeta.name : "Loading card..."}
+          />
+          <Spacer size="md" />
+          {isStaking ? (
+            <>
+              {canClaimCurrentCard() ? (
+                <Button
+                  disabled={hasClaimed || isClaiming}
+                  styling="purple"
+                  width="100%"
+                  onClick={() =>
+                    onLotteryClaim().then(() => setTransaction(transaction + 1))
+                  }
+                >
+                  {hasClaimed
+                    ? "Already claimed"
+                    : isClaiming
+                    ? "Claiming..."
+                    : "Claim card"}
+                </Button>
+              ) : (
+                <Button disabled styling="white_borderless" width="100%">
+                  Not eligible
+                </Button>
+              )}
+            </>
+          ) : (
+            <Button
+              disabled={!account ? false : true}
+              styling={!account ? "purple" : "white_borderless"}
+              width="100%"
+              onClick={!account ? loadWeb3Modal : undefined}
+            >
+              {!account ? "Connect wallet" : "Subscribe to claim"}
+            </Button>
+          )}
+        </div>
+      </AccordionBodyContent>
+    </Accordion>
+  );
+};
 
 export default PepemonOneSubscription;

--- a/packages/app/src/views/Subscription/subscriptions/PepemonOneSubscription/index.ts
+++ b/packages/app/src/views/Subscription/subscriptions/PepemonOneSubscription/index.ts
@@ -1,1 +1,1 @@
-export { default } from './PepemonOneSubscription';
+export { default } from "./PepemonOneSubscription";

--- a/packages/app/src/views/Subscription/subscriptions/index.ts
+++ b/packages/app/src/views/Subscription/subscriptions/index.ts
@@ -1,2 +1,2 @@
-export { default as PepemonOneAnniversarySet } from './PepemonOneAnniversarySet';
-export { default as PepemonOneSubscription } from './PepemonOneSubscription';
+export { default as PepemonOneAnniversarySet } from "./PepemonOneAnniversarySet";
+export { default as PepemonOneSubscription } from "./PepemonOneSubscription";

--- a/packages/app/src/views/TermsOfService/TermsOfService.tsx
+++ b/packages/app/src/views/TermsOfService/TermsOfService.tsx
@@ -1,98 +1,311 @@
-import React from 'react'
-import { Link } from 'react-router-dom';
-import { ExternalLink, Head, PlainText, DefaultPage } from '../../components';
+import React from "react";
+import { Link } from "react-router-dom";
+import { ExternalLink, Head, PlainText, DefaultPage } from "../../components";
 
 const TermsOfService: React.FC<any> = () => {
-	return (
-		<DefaultPage title='Terms and Conditions'>
-			<Head title='Pepemon - Terms and Conditions'
-				description="Please read these terms and conditions carefully before using Our Service."
-				index={false} follow={false}/>
-			<PlainText>
-				<p>Last updated: October 24, 2021</p>
-				<p>Please read these terms and conditions carefully before using Our Service.</p>
-				<h1>Interpretation and Definitions</h1>
-				<h2>Interpretation</h2>
-				<p>The words of which the initial letter is capitalized have meanings defined under the following conditions. The following definitions shall have the same meaning regardless of whether they appear in singular or in plural.</p>
-				<h2>Definitions</h2>
-				<p>For the purposes of these Terms and Conditions:</p>
-				<ul>
-				<li>
-				<p><strong>Affiliate</strong> means an entity that controls, is controlled by or is under common control with a party, where &quot;control&quot; means ownership of 50% or more of the shares, equity interest or other securities entitled to vote for election of directors or other managing authority.</p>
-				</li>
-				<li>
-				<p><strong>Country</strong> refers to: British Virgin Islands (BVI)</p>
-				</li>
-				<li>
-				<p><strong>Company</strong> (referred to as either &quot;the Company&quot;, &quot;We&quot;, &quot;Us&quot; or &quot;Our&quot; in this Agreement) refers to Pepemonic Arts, 0x .</p>
-				</li>
-				<li>
-				<p><strong>Device</strong> means any device that can access the Service such as a computer, a cellphone or a digital tablet.</p>
-				</li>
-				<li>
-				<p><strong>Service</strong> refers to the Website.</p>
-				</li>
-				<li>
-				<p><strong>Terms and Conditions</strong> (also referred as &quot;Terms&quot;) mean these Terms and Conditions that form the entire agreement between You and the Company regarding the use of the Service. This Terms and Conditions agreement has been created with the help of the <ExternalLink href="https://www.termsfeed.com/terms-conditions-generator/" target="_blank">Terms and Conditions Generator</ExternalLink>.</p>
-				</li>
-				<li>
-				<p><strong>Third-party Social Media Service</strong> means any services or content (including data, information, products or services) provided by a third-party that may be displayed, included or made available by the Service.</p>
-				</li>
-				<li>
-				<p><strong>Website</strong> refers to Pepemon World, accessible from <Link to="/" rel="external nofollow noopener" target="_blank">https://pepemon.finance</Link></p>
-				</li>
-				<li>
-				<p><strong>You</strong> means the individual accessing or using the Service, or the company, or other legal entity on behalf of which such individual is accessing or using the Service, as applicable.</p>
-				</li>
-				</ul>
-				<h1>Acknowledgment</h1>
-				<p>These are the Terms and Conditions governing the use of this Service and the agreement that operates between You and the Company. These Terms and Conditions set out the rights and obligations of all users regarding the use of the Service.</p>
-				<p>Your access to and use of the Service is conditioned on Your acceptance of and compliance with these Terms and Conditions. These Terms and Conditions apply to all visitors, users and others who access or use the Service.</p>
-				<p>By accessing or using the Service You agree to be bound by these Terms and Conditions. If You disagree with any part of these Terms and Conditions then You may not access the Service.</p>
-				<p>You represent that you are over the age of 18. The Company does not permit those under 18 to use the Service.</p>
-				<p>Your access to and use of the Service is also conditioned on Your acceptance of and compliance with the Privacy Policy of the Company. Our Privacy Policy describes Our policies and procedures on the collection, use and disclosure of Your personal information when You use the Application or the Website and tells You about Your privacy rights and how the law protects You. Please read Our Privacy Policy carefully before using Our Service.</p>
-				<h1>Links to Other Websites</h1>
-				<p>Our Service may contain links to third-party web sites or services that are not owned or controlled by the Company.</p>
-				<p>The Company has no control over, and assumes no responsibility for, the content, privacy policies, or practices of any third party web sites or services. You further acknowledge and agree that the Company shall not be responsible or liable, directly or indirectly, for any damage or loss caused or alleged to be caused by or in connection with the use of or reliance on any such content, goods or services available on or through any such web sites or services.</p>
-				<p>We strongly advise You to read the terms and conditions and privacy policies of any third-party web sites or services that You visit.</p>
-				<h1>Termination</h1>
-				<p>We may terminate or suspend Your access immediately, without prior notice or liability, for any reason whatsoever, including without limitation if You breach these Terms and Conditions.</p>
-				<p>Upon termination, Your right to use the Service will cease immediately.</p>
-				<h1>Limitation of Liability</h1>
-				<p>Notwithstanding any damages that You might incur, the entire liability of the Company and any of its suppliers under any provision of this Terms and Your exclusive remedy for all of the foregoing shall be limited to the amount actually paid by You through the Service or 100 USD if You haven't purchased anything through the Service.</p>
-				<p>To the maximum extent permitted by applicable law, in no event shall the Company or its suppliers be liable for any special, incidental, indirect, or consequential damages whatsoever (including, but not limited to, damages for loss of profits, loss of data or other information, for business interruption, for personal injury, loss of privacy arising out of or in any way related to the use of or inability to use the Service, third-party software and/or third-party hardware used with the Service, or otherwise in connection with any provision of this Terms), even if the Company or any supplier has been advised of the possibility of such damages and even if the remedy fails of its essential purpose.</p>
-				<p>Some states do not allow the exclusion of implied warranties or limitation of liability for incidental or consequential damages, which means that some of the above limitations may not apply. In these states, each party's liability will be limited to the greatest extent permitted by law.</p>
-				<h1>&quot;AS IS&quot; and &quot;AS AVAILABLE&quot; Disclaimer</h1>
-				<p>The Service is provided to You &quot;AS IS&quot; and &quot;AS AVAILABLE&quot; and with all faults and defects without warranty of any kind. To the maximum extent permitted under applicable law, the Company, on its own behalf and on behalf of its Affiliates and its and their respective licensors and service providers, expressly disclaims all warranties, whether express, implied, statutory or otherwise, with respect to the Service, including all implied warranties of merchantability, fitness for a particular purpose, title and non-infringement, and warranties that may arise out of course of dealing, course of performance, usage or trade practice. Without limitation to the foregoing, the Company provides no warranty or undertaking, and makes no representation of any kind that the Service will meet Your requirements, achieve any intended results, be compatible or work with any other software, applications, systems or services, operate without interruption, meet any performance or reliability standards or be error free or that any errors or defects can or will be corrected.</p>
-				<p>Without limiting the foregoing, neither the Company nor any of the company's provider makes any representation or warranty of any kind, express or implied: (i) as to the operation or availability of the Service, or the information, content, and materials or products included thereon; (ii) that the Service will be uninterrupted or error-free; (iii) as to the accuracy, reliability, or currency of any information or content provided through the Service; or (iv) that the Service, its servers, the content, or e-mails sent from or on behalf of the Company are free of viruses, scripts, trojan horses, worms, malware, timebombs or other harmful components.</p>
-				<p>Some jurisdictions do not allow the exclusion of certain types of warranties or limitations on applicable statutory rights of a consumer, so some or all of the above exclusions and limitations may not apply to You. But in such a case the exclusions and limitations set forth in this section shall be applied to the greatest extent enforceable under applicable law.</p>
-				<h1>Governing Law</h1>
-				<p>The laws of the Country, excluding its conflicts of law rules, shall govern this Terms and Your use of the Service. Your use of the Application may also be subject to other local, state, national, or international laws.</p>
-				<h1>Disputes Resolution</h1>
-				<p>If You have any concern or dispute about the Service, You agree to first try to resolve the dispute informally by contacting the Company.</p>
-				<h1>For European Union (EU) Users</h1>
-				<p>If You are a European Union consumer, you will benefit from any mandatory provisions of the law of the country in which you are resident in.</p>
-				<h1>United States Legal Compliance</h1>
-				<p>You represent and warrant that (i) You are not located in a country that is subject to the United States government embargo, or that has been designated by the United States government as a &quot;terrorist supporting&quot; country, and (ii) You are not listed on any United States government list of prohibited or restricted parties.</p>
-				<h1>Severability and Waiver</h1>
-				<h2>Severability</h2>
-				<p>If any provision of these Terms is held to be unenforceable or invalid, such provision will be changed and interpreted to accomplish the objectives of such provision to the greatest extent possible under applicable law and the remaining provisions will continue in full force and effect.</p>
-				<h2>Waiver</h2>
-				<p>Except as provided herein, the failure to exercise a right or to require performance of an obligation under this Terms shall not effect a party's ability to exercise such right or require such performance at any time thereafter nor shall be the waiver of a breach constitute a waiver of any subsequent breach.</p>
-				<h1>Translation Interpretation</h1>
-				<p>These Terms and Conditions may have been translated if We have made them available to You on our Service.
-				You agree that the original English text shall prevail in the case of a dispute.</p>
-				<h1>Changes to These Terms and Conditions</h1>
-				<p>We reserve the right, at Our sole discretion, to modify or replace these Terms at any time. If a revision is material We will make reasonable efforts to provide at least 30 days' notice prior to any new terms taking effect. What constitutes a material change will be determined at Our sole discretion.</p>
-				<p>By continuing to access or use Our Service after those revisions become effective, You agree to be bound by the revised terms. If You do not agree to the new terms, in whole or in part, please stop using the website and the Service.</p>
-				<h1>Contact Us</h1>
-				<p>If you have any questions about these Terms and Conditions, You can contact us:</p>
-				<ul>
-				<li>By email: <ExternalLink href="mailto:pepemonfinance@gmail.com">pepemonfinance@gmail.com</ExternalLink></li>
-				</ul>
-			</PlainText>
-		</DefaultPage>
-	)
-}
+  return (
+    <DefaultPage title="Terms and Conditions">
+      <Head
+        title="Pepemon - Terms and Conditions"
+        description="Please read these terms and conditions carefully before using Our Service."
+        index={false}
+        follow={false}
+      />
+      <PlainText>
+        <p>Last updated: October 24, 2021</p>
+        <p>
+          Please read these terms and conditions carefully before using Our
+          Service.
+        </p>
+        <h1>Interpretation and Definitions</h1>
+        <h2>Interpretation</h2>
+        <p>
+          The words of which the initial letter is capitalized have meanings
+          defined under the following conditions. The following definitions
+          shall have the same meaning regardless of whether they appear in
+          singular or in plural.
+        </p>
+        <h2>Definitions</h2>
+        <p>For the purposes of these Terms and Conditions:</p>
+        <ul>
+          <li>
+            <p>
+              <strong>Affiliate</strong> means an entity that controls, is
+              controlled by or is under common control with a party, where
+              &quot;control&quot; means ownership of 50% or more of the shares,
+              equity interest or other securities entitled to vote for election
+              of directors or other managing authority.
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>Country</strong> refers to: British Virgin Islands (BVI)
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>Company</strong> (referred to as either &quot;the
+              Company&quot;, &quot;We&quot;, &quot;Us&quot; or &quot;Our&quot;
+              in this Agreement) refers to Pepemonic Arts, 0x .
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>Device</strong> means any device that can access the
+              Service such as a computer, a cellphone or a digital tablet.
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>Service</strong> refers to the Website.
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>Terms and Conditions</strong> (also referred as
+              &quot;Terms&quot;) mean these Terms and Conditions that form the
+              entire agreement between You and the Company regarding the use of
+              the Service. This Terms and Conditions agreement has been created
+              with the help of the{" "}
+              <ExternalLink
+                href="https://www.termsfeed.com/terms-conditions-generator/"
+                target="_blank"
+              >
+                Terms and Conditions Generator
+              </ExternalLink>
+              .
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>Third-party Social Media Service</strong> means any
+              services or content (including data, information, products or
+              services) provided by a third-party that may be displayed,
+              included or made available by the Service.
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>Website</strong> refers to Pepemon World, accessible from{" "}
+              <Link to="/" rel="external nofollow noopener" target="_blank">
+                https://pepemon.finance
+              </Link>
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>You</strong> means the individual accessing or using the
+              Service, or the company, or other legal entity on behalf of which
+              such individual is accessing or using the Service, as applicable.
+            </p>
+          </li>
+        </ul>
+        <h1>Acknowledgment</h1>
+        <p>
+          These are the Terms and Conditions governing the use of this Service
+          and the agreement that operates between You and the Company. These
+          Terms and Conditions set out the rights and obligations of all users
+          regarding the use of the Service.
+        </p>
+        <p>
+          Your access to and use of the Service is conditioned on Your
+          acceptance of and compliance with these Terms and Conditions. These
+          Terms and Conditions apply to all visitors, users and others who
+          access or use the Service.
+        </p>
+        <p>
+          By accessing or using the Service You agree to be bound by these Terms
+          and Conditions. If You disagree with any part of these Terms and
+          Conditions then You may not access the Service.
+        </p>
+        <p>
+          You represent that you are over the age of 18. The Company does not
+          permit those under 18 to use the Service.
+        </p>
+        <p>
+          Your access to and use of the Service is also conditioned on Your
+          acceptance of and compliance with the Privacy Policy of the Company.
+          Our Privacy Policy describes Our policies and procedures on the
+          collection, use and disclosure of Your personal information when You
+          use the Application or the Website and tells You about Your privacy
+          rights and how the law protects You. Please read Our Privacy Policy
+          carefully before using Our Service.
+        </p>
+        <h1>Links to Other Websites</h1>
+        <p>
+          Our Service may contain links to third-party web sites or services
+          that are not owned or controlled by the Company.
+        </p>
+        <p>
+          The Company has no control over, and assumes no responsibility for,
+          the content, privacy policies, or practices of any third party web
+          sites or services. You further acknowledge and agree that the Company
+          shall not be responsible or liable, directly or indirectly, for any
+          damage or loss caused or alleged to be caused by or in connection with
+          the use of or reliance on any such content, goods or services
+          available on or through any such web sites or services.
+        </p>
+        <p>
+          We strongly advise You to read the terms and conditions and privacy
+          policies of any third-party web sites or services that You visit.
+        </p>
+        <h1>Termination</h1>
+        <p>
+          We may terminate or suspend Your access immediately, without prior
+          notice or liability, for any reason whatsoever, including without
+          limitation if You breach these Terms and Conditions.
+        </p>
+        <p>
+          Upon termination, Your right to use the Service will cease
+          immediately.
+        </p>
+        <h1>Limitation of Liability</h1>
+        <p>
+          Notwithstanding any damages that You might incur, the entire liability
+          of the Company and any of its suppliers under any provision of this
+          Terms and Your exclusive remedy for all of the foregoing shall be
+          limited to the amount actually paid by You through the Service or 100
+          USD if You haven't purchased anything through the Service.
+        </p>
+        <p>
+          To the maximum extent permitted by applicable law, in no event shall
+          the Company or its suppliers be liable for any special, incidental,
+          indirect, or consequential damages whatsoever (including, but not
+          limited to, damages for loss of profits, loss of data or other
+          information, for business interruption, for personal injury, loss of
+          privacy arising out of or in any way related to the use of or
+          inability to use the Service, third-party software and/or third-party
+          hardware used with the Service, or otherwise in connection with any
+          provision of this Terms), even if the Company or any supplier has been
+          advised of the possibility of such damages and even if the remedy
+          fails of its essential purpose.
+        </p>
+        <p>
+          Some states do not allow the exclusion of implied warranties or
+          limitation of liability for incidental or consequential damages, which
+          means that some of the above limitations may not apply. In these
+          states, each party's liability will be limited to the greatest extent
+          permitted by law.
+        </p>
+        <h1>&quot;AS IS&quot; and &quot;AS AVAILABLE&quot; Disclaimer</h1>
+        <p>
+          The Service is provided to You &quot;AS IS&quot; and &quot;AS
+          AVAILABLE&quot; and with all faults and defects without warranty of
+          any kind. To the maximum extent permitted under applicable law, the
+          Company, on its own behalf and on behalf of its Affiliates and its and
+          their respective licensors and service providers, expressly disclaims
+          all warranties, whether express, implied, statutory or otherwise, with
+          respect to the Service, including all implied warranties of
+          merchantability, fitness for a particular purpose, title and
+          non-infringement, and warranties that may arise out of course of
+          dealing, course of performance, usage or trade practice. Without
+          limitation to the foregoing, the Company provides no warranty or
+          undertaking, and makes no representation of any kind that the Service
+          will meet Your requirements, achieve any intended results, be
+          compatible or work with any other software, applications, systems or
+          services, operate without interruption, meet any performance or
+          reliability standards or be error free or that any errors or defects
+          can or will be corrected.
+        </p>
+        <p>
+          Without limiting the foregoing, neither the Company nor any of the
+          company's provider makes any representation or warranty of any kind,
+          express or implied: (i) as to the operation or availability of the
+          Service, or the information, content, and materials or products
+          included thereon; (ii) that the Service will be uninterrupted or
+          error-free; (iii) as to the accuracy, reliability, or currency of any
+          information or content provided through the Service; or (iv) that the
+          Service, its servers, the content, or e-mails sent from or on behalf
+          of the Company are free of viruses, scripts, trojan horses, worms,
+          malware, timebombs or other harmful components.
+        </p>
+        <p>
+          Some jurisdictions do not allow the exclusion of certain types of
+          warranties or limitations on applicable statutory rights of a
+          consumer, so some or all of the above exclusions and limitations may
+          not apply to You. But in such a case the exclusions and limitations
+          set forth in this section shall be applied to the greatest extent
+          enforceable under applicable law.
+        </p>
+        <h1>Governing Law</h1>
+        <p>
+          The laws of the Country, excluding its conflicts of law rules, shall
+          govern this Terms and Your use of the Service. Your use of the
+          Application may also be subject to other local, state, national, or
+          international laws.
+        </p>
+        <h1>Disputes Resolution</h1>
+        <p>
+          If You have any concern or dispute about the Service, You agree to
+          first try to resolve the dispute informally by contacting the Company.
+        </p>
+        <h1>For European Union (EU) Users</h1>
+        <p>
+          If You are a European Union consumer, you will benefit from any
+          mandatory provisions of the law of the country in which you are
+          resident in.
+        </p>
+        <h1>United States Legal Compliance</h1>
+        <p>
+          You represent and warrant that (i) You are not located in a country
+          that is subject to the United States government embargo, or that has
+          been designated by the United States government as a &quot;terrorist
+          supporting&quot; country, and (ii) You are not listed on any United
+          States government list of prohibited or restricted parties.
+        </p>
+        <h1>Severability and Waiver</h1>
+        <h2>Severability</h2>
+        <p>
+          If any provision of these Terms is held to be unenforceable or
+          invalid, such provision will be changed and interpreted to accomplish
+          the objectives of such provision to the greatest extent possible under
+          applicable law and the remaining provisions will continue in full
+          force and effect.
+        </p>
+        <h2>Waiver</h2>
+        <p>
+          Except as provided herein, the failure to exercise a right or to
+          require performance of an obligation under this Terms shall not effect
+          a party's ability to exercise such right or require such performance
+          at any time thereafter nor shall be the waiver of a breach constitute
+          a waiver of any subsequent breach.
+        </p>
+        <h1>Translation Interpretation</h1>
+        <p>
+          These Terms and Conditions may have been translated if We have made
+          them available to You on our Service. You agree that the original
+          English text shall prevail in the case of a dispute.
+        </p>
+        <h1>Changes to These Terms and Conditions</h1>
+        <p>
+          We reserve the right, at Our sole discretion, to modify or replace
+          these Terms at any time. If a revision is material We will make
+          reasonable efforts to provide at least 30 days' notice prior to any
+          new terms taking effect. What constitutes a material change will be
+          determined at Our sole discretion.
+        </p>
+        <p>
+          By continuing to access or use Our Service after those revisions
+          become effective, You agree to be bound by the revised terms. If You
+          do not agree to the new terms, in whole or in part, please stop using
+          the website and the Service.
+        </p>
+        <h1>Contact Us</h1>
+        <p>
+          If you have any questions about these Terms and Conditions, You can
+          contact us:
+        </p>
+        <ul>
+          <li>
+            By email:{" "}
+            <ExternalLink href="mailto:pepemonfinance@gmail.com">
+              pepemonfinance@gmail.com
+            </ExternalLink>
+          </li>
+        </ul>
+      </PlainText>
+    </DefaultPage>
+  );
+};
 
 export default TermsOfService;

--- a/packages/app/src/views/TermsOfService/index.ts
+++ b/packages/app/src/views/TermsOfService/index.ts
@@ -1,1 +1,1 @@
-export { default } from './TermsOfService';
+export { default } from "./TermsOfService";

--- a/packages/app/src/views/index.ts
+++ b/packages/app/src/views/index.ts
@@ -1,11 +1,11 @@
-import { stakingMeta } from './Staking';
-import { storeMeta } from './Store';
-import { subscriptionMeta } from './Subscription';
+import { stakingMeta } from "./Staking";
+import { storeMeta } from "./Store";
+import { subscriptionMeta } from "./Subscription";
 
 export const metas = {
-	stakingMeta,
-	storeMeta,
-	subscriptionMeta,
-}
+  stakingMeta,
+  storeMeta,
+  subscriptionMeta,
+};
 
-export { default as LoadingPage } from './LoadingPage';
+export { default as LoadingPage } from "./LoadingPage";


### PR DESCRIPTION
## Summary

- Moves the 1×/3×/5× quantity selector and OPEN BOOSTERPACK button to appear **below the title/description** rather than pinned at the bottom of the Selected Pack right column
- Pack image now sits in the scrollable region below the action buttons
- `StickyBottom` renamed to `StickyTop` with border/padding flipped accordingly

## Also included

- Fix pre-existing CI build failures: widespread prettier violations and lint errors (`@ts-ignore` → `@ts-expect-error`, `prefer-const`, `no-empty-function`, `no-inferrable-types`) that were already broken on upstream main

## Test plan

- [ ] Navigate to `/store/boosterpacks`, select a pack
- [ ] Confirm order top-to-bottom: title → description → 1×/3×/5× → OPEN BOOSTERPACK → pack image
- [ ] Verify claim/reveal flow still works
- [ ] Check mobile layout stacks correctly on mobile